### PR TITLE
Add I/O Port, Segmentation Register, and Descriptor Table support.

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod tlb;
 pub mod segmentation;
-
+pub mod tables;
+pub mod port;

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -1,3 +1,5 @@
 //! Special x86_64 instructions.
 
 pub mod tlb;
+pub mod segmentation;
+

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -1,0 +1,74 @@
+//! Access to I/O ports
+
+use core::marker::PhantomData;
+
+pub trait PortReadWrite {
+    unsafe fn read(port: u16) -> Self;
+    unsafe fn write(port: u16, value: Self);
+}
+
+impl PortReadWrite for u8 {
+    #[inline]
+    unsafe fn read(port: u16) -> u8 {
+        let value: u8;
+        asm!("inb %dx, %al" : "={ax}"(value) : "{dx}"(port) :: "volatile");
+        value
+    }
+
+    #[inline]
+    unsafe fn write(port: u16, value: u8) {
+        asm!("outb %al, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
+    }
+}
+
+impl PortReadWrite for u16 {
+    #[inline]
+    unsafe fn read(port: u16) -> u16 {
+        let value: u16;
+        asm!("inw %dx, %ax" : "={ax}"(value) : "{dx}"(port) :: "volatile");
+        value
+    }
+
+    #[inline]
+    unsafe fn write(port: u16, value: u16) {
+        asm!("outw %ax, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
+    }
+}
+
+impl PortReadWrite for u32 {
+    #[inline]
+    unsafe fn read(port: u16) -> u32 {
+        let value: u32;
+        asm!("inl %dx, %eax" : "={ax}"(value) : "{dx}"(port) :: "volatile");
+        value
+    }
+
+    #[inline]
+    unsafe fn write(port: u16, value: u32) {
+        asm!("outl %eax, %dx" :: "{dx}"(port), "{al}"(value) :: "volatile");
+    }
+}
+
+pub struct Port<T: PortReadWrite> {
+    port: u16,
+    phantom: PhantomData<T>,
+}
+
+impl<T: PortReadWrite> Port<T> {
+    pub const fn new(port: u16) -> Port<T> {
+        Port {
+            port: port,
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub unsafe fn read(&self) -> T {
+        T::read(self.port)
+    }
+
+    #[inline]
+    pub unsafe fn write(&mut self, value: T) {
+        T::write(self.port, value)
+    }
+}

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -1,0 +1,64 @@
+//! Provides functions to read and write segment registers.
+
+use structures::gdt::SegmentSelector;
+
+/// Reload code segment register.
+/// Note this is special since we can not directly move
+/// to %cs. Instead we push the new segment selector
+/// and return value on the stack and use lretq
+/// to reload cs and continue at 1:.
+pub unsafe fn set_cs(sel: SegmentSelector) {
+
+    #[cfg(target_arch="x86")]
+    #[inline(always)]
+    unsafe fn inner(sel: SegmentSelector) {
+        asm!("pushl $0; \
+              pushl $$1f; \
+              lretl; \
+              1:" :: "ri" (u64::from(sel.0)) : "rax" "memory");
+    }
+
+    #[cfg(target_arch="x86_64")]
+    #[inline(always)]
+    unsafe fn inner(sel: SegmentSelector) {
+        asm!("pushq $0; \
+              leaq  1f(%rip), %rax; \
+              pushq %rax; \
+              lretq; \
+              1:" :: "ri" (u64::from(sel.0)) : "rax" "memory");
+    }
+
+    inner(sel)
+}
+
+/// Reload stack segment register.
+pub unsafe fn load_ss(sel: SegmentSelector) {
+    asm!("movw $0, %ss " :: "r" (sel.0) : "memory");
+}
+
+/// Reload data segment register.
+pub unsafe fn load_ds(sel: SegmentSelector) {
+    asm!("movw $0, %ds " :: "r" (sel.0) : "memory");
+}
+
+/// Reload es segment register.
+pub unsafe fn load_es(sel: SegmentSelector) {
+    asm!("movw $0, %es " :: "r" (sel.0) : "memory");
+}
+
+/// Reload fs segment register.
+pub unsafe fn load_fs(sel: SegmentSelector) {
+    asm!("movw $0, %fs " :: "r" (sel.0) : "memory");
+}
+
+/// Reload gs segment register.
+pub unsafe fn load_gs(sel: SegmentSelector) {
+    asm!("movw $0, %gs " :: "r" (sel.0) : "memory");
+}
+
+/// Returns the current value of the code segment register.
+pub fn cs() -> SegmentSelector {
+    let segment: u16;
+    unsafe { asm!("mov %cs, $0" : "=r" (segment) ) };
+    SegmentSelector(segment)
+}

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -1,0 +1,31 @@
+use structures::gdt::SegmentSelector;
+
+/// A struct describing a pointer to a descriptor table (GDT / IDT).
+/// This is in a format suitable for giving to 'lgdt' or 'lidt'.
+#[repr(C, packed)]
+pub struct DescriptorTablePointer {
+    /// Size of the DT.
+    pub limit: u16,
+    /// Pointer to the memory region containing the DT.
+    pub base: u64,
+}
+
+/// Load GDT table.
+pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
+    asm!("lgdt ($0)" :: "r" (gdt) : "memory");
+}
+
+/// Load LDT table.
+pub unsafe fn lldt(ldt: &DescriptorTablePointer) {
+    asm!("lldt ($0)" :: "r" (ldt) : "memory");
+}
+
+/// Load IDT table.
+pub unsafe fn lidt(idt: &DescriptorTablePointer) {
+    asm!("lidt ($0)" :: "r" (idt) : "memory");
+}
+
+/// Load the task state register using the `ltr` instruction.
+pub unsafe fn load_tss(sel: SegmentSelector) {
+    asm!("ltr $0" :: "r" (sel.0));
+}

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,6 +1,6 @@
 //! Representations of various x86 specific structures and descriptor tables.
 
 pub mod paging;
-//pub mod gdt;
-//pub mod idt;
+pub mod gdt;
+// pub mod idt;
 //pub mod tss;


### PR DESCRIPTION
This patch takes some code from the old version of the x86_64 crate and adds some for port io.