### PR TITLE
Added remapping ability to RecursivePageTable

### DIFF
--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -57,7 +57,7 @@ impl PageTableEntry {
     }
 
     pub fn set_flags(&mut self, flags: PageTableFlags) {
-        self.entry |= flags.bits();
+        self.entry = self.addr().as_u64() | flags.bits();
     }
 }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -55,6 +55,10 @@ impl PageTableEntry {
         assert!(!flags.contains(PageTableFlags::HUGE_PAGE));
         self.set_addr(frame.start_address(), flags)
     }
+
+    pub fn set_flags(&mut self, flags: PageTableFlags) {
+        self.entry |= flags.bits();
+    }
 }
 
 impl fmt::Debug for PageTableEntry {

--- a/src/structures/paging/recursive.rs
+++ b/src/structures/paging/recursive.rs
@@ -37,6 +37,8 @@ pub trait Mapper<S: PageSize> {
     fn unmap<A>(&mut self, page: Page<S>, allocator: &mut A) -> Result<MapperFlush<S>, UnmapError>
     where
         A: FnMut(PhysFrame<S>);
+
+    fn remap(&mut self, page: Page<S>, flags: PageTableFlags) -> Result<MapperFlush<S>, RemapError>;
 }
 
 pub struct RecursivePageTable<'a> {
@@ -59,6 +61,11 @@ pub enum UnmapError {
     EntryWithInvalidFlagsPresent(PageTableFlags),
     PageNotMapped,
     InvalidFrameAddressInPageTable,
+}
+
+#[derive(Debug)]
+pub enum RemapError {
+    PageNotMapped,
 }
 
 impl<'a> RecursivePageTable<'a> {
@@ -177,6 +184,24 @@ impl<'a> Mapper<Size1GB> for RecursivePageTable<'a> {
         p3_entry.set_unused();
         Ok(MapperFlush::new(page))
     }
+
+    fn remap(&mut self, page: Page<Size1GB>, flags: PageTableFlags) -> Result<MapperFlush<Size1GB>, RemapError> {
+        use structures::paging::PageTableFlags as Flags;
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
+
+        if p3[page.p3_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+        p3[page.p3_index()].set_flags(flags | Flags::HUGE_PAGE);
+
+        Ok(MapperFlush::new(page))
+    }
 }
 
 impl<'a> Mapper<Size2MB> for RecursivePageTable<'a> {
@@ -246,6 +271,31 @@ impl<'a> Mapper<Size2MB> for RecursivePageTable<'a> {
             .map_err(|()| UnmapError::InvalidFrameAddressInPageTable)?;
         allocator(frame);
         p2_entry.set_unused();
+        Ok(MapperFlush::new(page))
+    }
+
+    fn remap(&mut self, page: Page<Size2MB>, flags: PageTableFlags) -> Result<MapperFlush<Size2MB>, RemapError> {
+        use structures::paging::PageTableFlags as Flags;
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
+
+        if p3[page.p3_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
+
+        if p2[page.p2_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+        
+        p2[page.p2_index()].set_flags(flags | Flags::HUGE_PAGE);
+
         Ok(MapperFlush::new(page))
     }
 }
@@ -323,6 +373,36 @@ impl<'a> Mapper<Size4KB> for RecursivePageTable<'a> {
         })?;
         allocator(frame);
         p1_entry.set_unused();
+        Ok(MapperFlush::new(page))
+    }
+
+    fn remap(&mut self, page: Page<Size4KB>, flags: PageTableFlags) -> Result<MapperFlush<Size4KB>, RemapError> {
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
+
+        if p3[page.p3_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
+
+        if p2[page.p2_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        let p1 = unsafe { &mut *(p1_ptr(page, self.recursive_index)) };
+
+        if p1[page.p1_index()].is_unused() {
+            return Err(RemapError::PageNotMapped);
+        }
+
+        p1[page.p1_index()].set_flags(flags);
+
         Ok(MapperFlush::new(page))
     }
 }


### PR DESCRIPTION
This adds a `remap` function to the `Mapper` trait and the `RecursivePageTable`.