### PR TITLE
Reclaim page tables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
 #![feature(try_from)]
+#![feature(repr_transparent)]
 #![no_std]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
 #![feature(try_from)]
+#![feature(step_trait)]
 #![no_std]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
 #![feature(try_from)]
-#![feature(repr_transparent)]
 #![no_std]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -455,22 +455,20 @@ mod tests {
         let start: Page = Page::containing_address(start_addr);
         let end = start.clone() + number;
 
-        let mut range = Page::range(start.clone(), end.clone());
-        for i in 0..number {
+        for (i, page) in (start..end).enumerate() {
             assert_eq!(
-                range.next(),
-                Some(Page::containing_address(start_addr + page_size * i))
+                page,
+                Page::containing_address(start_addr + page_size * i as u64)
             );
+            assert!((i as u64) < number);
         }
-        assert_eq!(range.next(), None);
 
-        let mut range_inclusive = Page::range_inclusive(start, end);
-        for i in 0..=number {
+        for (i, page) in (start..=end).enumerate() {
             assert_eq!(
-                range_inclusive.next(),
-                Some(Page::containing_address(start_addr + page_size * i))
+                page,
+                Page::containing_address(start_addr + page_size * i as u64)
             );
+            assert!((i as u64) <= number);
         }
-        assert_eq!(range_inclusive.next(), None);
     }
 }

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -9,7 +9,7 @@ pub use self::recursive::*;
 
 use core::fmt;
 use core::marker::PhantomData;
-use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Bound, RangeBounds, Sub, SubAssign};
 use os_bootinfo;
 use ux::*;
 use {PhysAddr, VirtAddr};
@@ -246,6 +246,16 @@ impl<S: PageSize> Iterator for PageRange<S> {
     }
 }
 
+impl<S: PageSize> RangeBounds<Page<S>> for PageRange<S> {
+    fn start_bound(&self) -> Bound<&Page<S>> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&Page<S>> {
+        Bound::Excluded(&self.end)
+    }
+}
+
 impl PageRange<Size2MiB> {
     /// Converts the range of 2MiB pages to a range of 4KiB pages.
     pub fn as_4kib_page_range(self) -> PageRange<Size4KiB> {
@@ -293,6 +303,16 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+}
+
+impl<S: PageSize> RangeBounds<Page<S>> for PageRangeInclusive<S> {
+    fn start_bound(&self) -> Bound<&Page<S>> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&Page<S>> {
+        Bound::Included(&self.end)
     }
 }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use core::ops::{Index, IndexMut};
+use core::slice;
 
 use super::{PageSize, PhysFrame, Size4KiB};
 use addr::PhysAddr;
@@ -173,6 +174,16 @@ impl PageTable {
         for entry in self.entries.iter_mut() {
             entry.set_unused();
         }
+    }
+
+    /// Returns an iterator over all `PageTableEntry`s in this page table.
+    pub fn iter(&self) -> slice::Iter<PageTableEntry> {
+        self.entries.iter()
+    }
+
+    /// Returns a mutable iterator over all `PageTableEntry`s in this page table.
+    pub fn iter_mut(&mut self) -> slice::IterMut<PageTableEntry> {
+        self.entries.iter_mut()
     }
 }
 

--- a/src/structures/paging/recursive.rs
+++ b/src/structures/paging/recursive.rs
@@ -312,7 +312,7 @@ impl<'a> RecursivePageTable<'a> {
         );
 
         // Free all the page tables!
-        for page in Page::range(p1_start, p1_end) {
+        for page in p1_start..p1_end {
             let p4_entry = &mut p4[page.p4_index()];
 
             match p4_entry.frame() {
@@ -374,7 +374,7 @@ impl<'a> RecursivePageTable<'a> {
         );
 
         // Free all the page tables!
-        for page in Page::range(p2_start, p2_end) {
+        for page in p2_start..p2_end {
             let p4_entry = &mut p4[page.p4_index()];
 
             match p4_entry.frame() {
@@ -421,7 +421,7 @@ impl<'a> RecursivePageTable<'a> {
             Page::from_page_table_indices(end.p4_index(), u9::new(0), u9::new(0), u9::new(0));
 
         // Free all the page tables!
-        for page in Page::range(p3_start, p3_end) {
+        for page in p3_start..p3_end {
             let p4_entry = &mut p4[page.p4_index()];
 
             let p3_frame = match p4_entry.frame() {


### PR DESCRIPTION
There are some concerns to be addressed. copy/pasting from previous thread:

> I'm not sure about the design of the reclaim_page_tables function. It seems a bit dangerous (it's possible to reclaim page tables that are still in use) 

Yes, it is a bit dangerous. In particular, it is very OS-specific to know if you can reclaim a page table. The problem is that it is impossible to know just from the page tables if a page is shared without some other source of information. If you have ideas for how to get around this, please let me know.

> and surprising (e.g. if a 1GiB range is passed the bounds are rounded so that not all page tables in the range might get freed).

Hmm... so would you propose not having `reclaim_page_tables` take an `S: PageSize` parameter? So it would always take two `Page<Size4KiB>` and free everything in between?

----

Also, there is one thing I want to do first: make the range be specified as `RangeBound` so that one can do `reclaim_page_tables(page..other_page)` and `reclaim_page_tables(page..=other_page)`.