### PR TITLE
Pub use frame_alloc traits

### DIFF
--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Page tables translate virtual memory “pages” to physical memory “frames”.
 
+pub use self::frame_alloc::*;
 pub use self::page_table::*;
 #[cfg(target_pointer_width = "64")]
 pub use self::recursive::*;


### PR DESCRIPTION
Fixes issue where the new `frame_alloc` traits are private and cannot be used

```
error[E0603]: module `frame_alloc` is private
 --> src/arch/x86_64/memory/area_frame_allocator.rs:3:47
  |
3 | use x86_64::structures::paging::frame_alloc::{FrameAllocator, FrameDeallocator};
  |                                               ^^^^^^^^^^^^^^

error[E0603]: module `frame_alloc` is private
 --> src/arch/x86_64/memory/area_frame_allocator.rs:3:63
  |
3 | use x86_64::structures::paging::frame_alloc::{FrameAllocator, FrameDeallocator};
  |                                                               ^^^^^^^^^^^^^^^^    
```