### PR TITLE
Add repr_transparent as feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
 #![feature(try_from)]
+#![feature(repr_transparent)]
 #![no_std]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]


### PR DESCRIPTION
In the latest nightly (1.27.0-nightly) this will not compile due to the `#[repr(transparent)]` attribute being experimental, this adds it as a feature.

<details><summary>Compilation Error Message</summary>
<p>

```
   Compiling x86_64 v0.2.6
error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
  --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/structures/gdt.rs:14:1
   |
14 | #[repr(transparent)]
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(repr_transparent)] to the crate attributes to enable

error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
   --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/structures/idt.rs:586:1
    |
586 | #[repr(transparent)]
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(repr_transparent)] to the crate attributes to enable

error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
  --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/structures/paging/page_table.rs:22:1
   |
22 | #[repr(transparent)]
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(repr_transparent)] to the crate attributes to enable

error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
   --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/structures/paging/page_table.rs:165:1
    |
165 | #[repr(transparent)]
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = help: add #![feature(repr_transparent)] to the crate attributes to enable

error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
  --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/addr.rs:19:1
   |
19 | #[repr(transparent)]
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(repr_transparent)] to the crate attributes to enable

error[E0658]: the `#[repr(transparent)]` attribute is experimental (see issue #43036)
  --> /Users/nicktaylor/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.2.6/src/addr.rs:31:1
   |
31 | #[repr(transparent)]
   | ^^^^^^^^^^^^^^^^^^^^
   |
   = help: add #![feature(repr_transparent)] to the crate attributes to enable

error: aborting due to 6 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `x86_64`.
```

</p></details>