### PR TITLE
Switch to new panic_handler attribute

### DIFF
--- a/testing/src/bin/test-basic.rs
+++ b/testing/src/bin/test-basic.rs
@@ -1,4 +1,3 @@
-#![feature(panic_implementation)] // required for defining the panic handler
 #![feature(const_fn)]
 #![no_std] // don't link the Rust standard library
 #![cfg_attr(not(test), no_main)] // disable all Rust-level entry points
@@ -26,9 +25,8 @@ pub extern "C" fn _start() -> ! {
 
 /// This function is called on panic.
 #[cfg(not(test))]
-#[panic_implementation]
-#[no_mangle]
-pub fn panic(info: &PanicInfo) -> ! {
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
     serial_println!("failed");
 
     serial_println!("{}", info);


### PR DESCRIPTION
This should resolve the `panic_implementation` deprecation warning.