### PR TITLE
Use conditional compilation for platform specific functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ cache:
   - $TRAVIS_BUILD_DIR/testing/target
 
 before_script:
+  - rustup target add i686-unknown-linux-gnu
+  - rustup target add thumbv7em-none-eabihf
   - rustup component add rust-src
   - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
   - (test -x $HOME/.cargo/bin/cargo-xbuild || cargo install cargo-xbuild)
@@ -16,6 +18,8 @@ script:
   - cargo test
   - cargo build --features deny-warnings
   - bootimage test --manifest-path testing/Cargo.toml
+  - cargo build --target i686-unknown-linux-gnu
+  - cargo build --target thumbv7em-none-eabihf
 
 addons:
   apt:

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -1,7 +1,6 @@
 //! Enabling and disabling interrupts
 
 /// Returns whether interrupts are enabled.
-#[cfg(target_pointer_width = "64")]
 pub fn are_enabled() -> bool {
     use registers::rflags::{self, RFlags};
 
@@ -46,7 +45,6 @@ pub fn disable() {
 /// });
 /// // interrupts are enabled again
 /// ```
-#[cfg(target_pointer_width = "64")]
 pub fn without_interrupts<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "x86_64")]
+
 //! Special x86_64 instructions.
 
 pub mod interrupts;

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -2,23 +2,7 @@
 
 use core::marker::PhantomData;
 
-/// A helper trait that implements the actual port operations.
-///
-/// On x86, I/O ports operate on either `u8` (via `inb`/`outb`), `u16` (via `inw`/`outw`),
-/// or `u32` (via `inl`/`outl`). Therefore this trait is implemented for exactly these types.
-pub trait PortReadWrite {
-    /// Reads a `Self` value from the given port.
-    ///
-    /// This function is unsafe because the I/O port could have side effects that violate memory
-    /// safety.
-    unsafe fn read_from_port(port: u16) -> Self;
-
-    /// Writes a `Self` value to the given port.
-    ///
-    /// This function is unsafe because the I/O port could have side effects that violate memory
-    /// safety.
-    unsafe fn write_to_port(port: u16, value: Self);
-}
+pub use structures::port::PortReadWrite;
 
 impl PortReadWrite for u8 {
     #[inline]

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -9,16 +9,6 @@ use structures::gdt::SegmentSelector;
 /// and return value on the stack and use lretq
 /// to reload cs and continue at 1:.
 pub unsafe fn set_cs(sel: SegmentSelector) {
-    #[cfg(target_arch = "x86")]
-    #[inline(always)]
-    unsafe fn inner(sel: SegmentSelector) {
-        asm!("pushl $0; \
-              pushl $$1f; \
-              lretl; \
-              1:" :: "ri" (u64::from(sel.0)) : "rax" "memory");
-    }
-
-    #[cfg(target_arch = "x86_64")]
     #[inline(always)]
     unsafe fn inner(sel: SegmentSelector) {
         asm!("pushq $0; \

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -2,16 +2,7 @@
 
 use structures::gdt::SegmentSelector;
 
-/// A struct describing a pointer to a descriptor table (GDT / IDT).
-/// This is in a format suitable for giving to 'lgdt' or 'lidt'.
-#[derive(Debug, Clone, Copy)]
-#[repr(C, packed)]
-pub struct DescriptorTablePointer {
-    /// Size of the DT.
-    pub limit: u16,
-    /// Pointer to the memory region containing the DT.
-    pub base: u64,
-}
+pub use structures::DescriptorTablePointer;
 
 /// Load GDT table.
 pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -9,20 +9,6 @@ impl Msr {
     pub const fn new(reg: u32) -> Msr {
         Msr(reg)
     }
-
-    /// Read 64 bits msr register.
-    pub unsafe fn read(&self) -> u64 {
-        let (high, low): (u32, u32);
-        asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (self.0) : "memory" : "volatile");
-        ((high as u64) << 32) | (low as u64)
-    }
-
-    /// Write 64 bits to msr register.
-    pub unsafe fn write(&mut self, value: u64) {
-        let low = value as u32;
-        let high = (value >> 32) as u32;
-        asm!("wrmsr" :: "{ecx}" (self.0), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
-    }
 }
 
 /// The Extended Feature Enable Register.
@@ -32,49 +18,6 @@ pub struct Efer;
 impl Efer {
     /// The underlying model specific register.
     pub const MSR: Msr = Msr(0xC0000080);
-
-    /// Read the current EFER flags.
-    pub fn read() -> EferFlags {
-        EferFlags::from_bits_truncate(Self::read_raw())
-    }
-
-    /// Read the current raw EFER flags.
-    pub fn read_raw() -> u64 {
-        unsafe { Self::MSR.read() }
-    }
-
-    /// Write the EFER flags, preserving reserved values.
-    ///
-    /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
-    /// safety, e.g. by disabling long mode.
-    pub unsafe fn write(flags: EferFlags) {
-        let old_value = Self::read_raw();
-        let reserved = old_value & !(EferFlags::all().bits());
-        let new_value = reserved | flags.bits();
-
-        Self::write_raw(new_value);
-    }
-
-    /// Write the EFER flags.
-    ///
-    /// Does not preserve any bits, including reserved fields. Unsafe because it's possible to
-    /// break memory safety, e.g. by disabling long mode.
-    pub unsafe fn write_raw(flags: u64) {
-        Self::MSR.write(flags);
-    }
-
-    /// Update EFER flags.
-    ///
-    /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
-    /// safety, e.g. by disabling long mode.
-    pub unsafe fn update<F>(f: F)
-    where
-        F: FnOnce(&mut EferFlags),
-    {
-        let mut flags = Self::read();
-        f(&mut flags);
-        Self::write(flags);
-    }
 }
 
 bitflags! {
@@ -96,5 +39,71 @@ bitflags! {
         const FAST_FXSAVE_FXRSTOR = 1 << 14;
         /// Changes how the `invlpg` instruction operates on TLB entries of upper-level entries.
         const TRANSLATION_CACHE_EXTENSION = 1 << 15;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+mod x86_64 {
+    use super::*;
+
+    impl Msr {
+        /// Read 64 bits msr register.
+        pub unsafe fn read(&self) -> u64 {
+            let (high, low): (u32, u32);
+            asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (self.0) : "memory" : "volatile");
+            ((high as u64) << 32) | (low as u64)
+        }
+
+        /// Write 64 bits to msr register.
+        pub unsafe fn write(&mut self, value: u64) {
+            let low = value as u32;
+            let high = (value >> 32) as u32;
+            asm!("wrmsr" :: "{ecx}" (self.0), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
+        }
+    }
+
+    impl Efer {
+        /// Read the current EFER flags.
+        pub fn read() -> EferFlags {
+            EferFlags::from_bits_truncate(Self::read_raw())
+        }
+
+        /// Read the current raw EFER flags.
+        pub fn read_raw() -> u64 {
+            unsafe { Self::MSR.read() }
+        }
+
+        /// Write the EFER flags, preserving reserved values.
+        ///
+        /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
+        /// safety, e.g. by disabling long mode.
+        pub unsafe fn write(flags: EferFlags) {
+            let old_value = Self::read_raw();
+            let reserved = old_value & !(EferFlags::all().bits());
+            let new_value = reserved | flags.bits();
+
+            Self::write_raw(new_value);
+        }
+
+        /// Write the EFER flags.
+        ///
+        /// Does not preserve any bits, including reserved fields. Unsafe because it's possible to
+        /// break memory safety, e.g. by disabling long mode.
+        pub unsafe fn write_raw(flags: u64) {
+            Self::MSR.write(flags);
+        }
+
+        /// Update EFER flags.
+        ///
+        /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
+        /// safety, e.g. by disabling long mode.
+        pub unsafe fn update<F>(f: F)
+        where
+            F: FnOnce(&mut EferFlags),
+        {
+            let mut flags = Self::read();
+            f(&mut flags);
+            Self::write(flags);
+        }
     }
 }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -81,6 +81,7 @@ impl GlobalDescriptorTable {
     }
 
     /// Loads the GDT in the CPU using the `lgdt` instruction.
+    #[cfg(target_arch = "x86_64")]
     pub fn load(&'static self) {
         use core::mem::size_of;
         use instructions::tables::{lgdt, DescriptorTablePointer};

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -429,6 +429,7 @@ impl InterruptDescriptorTable {
     }
 
     /// Loads the IDT in the CPU using the `lidt` command.
+    #[cfg(target_arch = "x86_64")]
     pub fn load(&'static self) {
         use core::mem::size_of;
         use instructions::tables::{lidt, DescriptorTablePointer};
@@ -550,6 +551,7 @@ impl<F> Entry<F> {
     ///
     /// The function returns a mutable reference to the entry's options that allows
     /// further customization.
+    #[cfg(target_arch = "x86_64")]
     fn set_handler_addr(&mut self, addr: u64) -> &mut EntryOptions {
         use instructions::segmentation;
 
@@ -566,6 +568,7 @@ impl<F> Entry<F> {
 
 macro_rules! impl_set_handler_fn {
     ($h:ty) => {
+        #[cfg(target_arch = "x86_64")]
         impl Entry<$h> {
             /// Set the handler function for the IDT entry and sets the present bit.
             ///

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -3,4 +3,16 @@
 pub mod gdt;
 pub mod idt;
 pub mod paging;
+pub mod port;
 pub mod tss;
+
+/// A struct describing a pointer to a descriptor table (GDT / IDT).
+/// This is in a format suitable for giving to 'lgdt' or 'lidt'.
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct DescriptorTablePointer {
+    /// Size of the DT.
+    pub limit: u16,
+    /// Pointer to the memory region containing the DT.
+    pub base: u64,
+}

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -4,7 +4,7 @@
 
 pub use self::frame_alloc::*;
 pub use self::page_table::*;
-#[cfg(target_pointer_width = "64")]
+#[cfg(target_arch = "x86_64")]
 pub use self::recursive::*;
 
 use core::fmt;

--- a/src/structures/paging/recursive.rs
+++ b/src/structures/paging/recursive.rs
@@ -1,4 +1,4 @@
-#![cfg(target_pointer_width = "64")]
+#![cfg(target_arch = "x86_64")]
 
 use instructions::tlb;
 use registers::control::Cr3;

--- a/src/structures/port.rs
+++ b/src/structures/port.rs
@@ -1,0 +1,19 @@
+//! A trait for accessing I/O ports.
+
+/// A helper trait that implements the actual port operations.
+///
+/// On x86, I/O ports operate on either `u8` (via `inb`/`outb`), `u16` (via `inw`/`outw`),
+/// or `u32` (via `inl`/`outl`). Therefore this trait is implemented for exactly these types.
+pub trait PortReadWrite {
+    /// Reads a `Self` value from the given port.
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
+    unsafe fn read_from_port(port: u16) -> Self;
+
+    /// Writes a `Self` value to the given port.
+    ///
+    /// This function is unsafe because the I/O port could have side effects that violate memory
+    /// safety.
+    unsafe fn write_to_port(port: u16, value: Self);
+}


### PR DESCRIPTION
This ensures that the crate is buildable on all platforms. If building on non-x86_64, not all functions will be present.