### PR TITLE
Random

### DIFF
--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -41,7 +41,8 @@ impl RdRand {
         res
     }
 
-    /// Uniformly sampled u64, u32, or u16
+    /// Uniformly sampled T.
+    /// T must be one of u16, u32, or u64.
     #[inline]
     pub fn rand<T: RdRandPrimitive>(&self) -> Option<T> {
         let res: T;

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -4,12 +4,15 @@
 /// Used to obtain random numbers using x86_64's RDRAND opcode
 pub struct RdRand(());
 
-/// Trait for types that can be returned by the RDRAND instruction
-pub trait RdRandPrimitive: Sized {}
-impl RdRandPrimitive for u16 {}
-impl RdRandPrimitive for u32 {}
-#[cfg(target_arch = "x86_64")]
-impl RdRandPrimitive for u64 {}
+mod private {
+    /// Trait for types that can be returned by the RDRAND instruction
+    pub trait RdRandPrimitive: Sized {}
+    impl RdRandPrimitive for u16 {}
+    impl RdRandPrimitive for u32 {}
+    #[cfg(target_arch = "x86_64")]
+    impl RdRandPrimitive for u64 {}
+}
+use private::RdRandPrimitive;
 
 impl RdRand {
     /// Creates Some(RdRand) if RDRAND is supported, None otherwise

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -1,12 +1,19 @@
 //! Support for build-in RNGs
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 /// Used to obtain random numbers using x86_64's RDRAND opcode
 pub struct RdRand(());
 
+/// Trait for types that can be returned by the RDRAND instruction
+pub trait RdRandPrimitive: Sized {}
+impl RdRandPrimitive for u16 {}
+impl RdRandPrimitive for u32 {}
+#[cfg(target_arch = "x86_64")]
+impl RdRandPrimitive for u64 {}
+
 impl RdRand {
     /// Creates Some(RdRand) if RDRAND is supported, None otherwise
-    #[cfg(target_arch = "x86_64")]
+    #[cfg(target_arch = "x86_64")] // <-- raw_cpuid is only a dep for x86_64 targets
     pub fn new() -> Option<Self> {
         let cpuid = raw_cpuid::CpuId::new();
         let has_rdrand = match cpuid.get_feature_info() {
@@ -20,15 +27,35 @@ impl RdRand {
         }
     }
 
-    /// Uniformly sampled u64
+    /// Uniformly sampled u64, u32, or u16
     #[inline]
-    #[cfg(target_arch = "x86_64")]
-    pub fn get(&self) -> u64 {
-        let res: u64;
+    pub fn get<T: RdRandPrimitive>(&self) -> Option<T> {
+        let res: T;
+        let ok: u8;
         unsafe {
-            asm!("rdrand %rax" : "={rax}"(res) ::: "volatile");
+            asm!("rdrand $0; setc $1;"
+                : "=r"(res) "=r"(ok)
+                :: "flags" : "volatile");
         }
-
-        res
+        match ok {
+            1 => Some(res),
+            _ => None
+        }
+    }
+    /// Uniformly sampled u64
+    #[cfg(target_arch = "x86_64")]
+    #[inline]
+    pub fn get_u64(&self) -> Option<u64> {
+        self.get()
+    }
+    /// Uniformly sampled u32
+    #[inline]
+    pub fn get_u32(&self) -> Option<u32> {
+        self.get()
+    }
+    /// Uniformly sampled u16
+    #[inline]
+    pub fn get_u16(&self) -> Option<u16> {
+        self.get()
     }
 }


### PR DESCRIPTION
Let me know what you think of this. It should handle the case of rdrand instruction failing. It also makes the RdRand::get() method generic, so it can return a u64, u32, or u16, depending on what the caller wants.

I removed the target requirement on the 'get' method, since x86 can use the instruction for u16 and u32, just not u64. I put the x86_64 target requirement on the u64 RdRandPrimitive.

I did NOT remove the x86_64 target requirement from RdRand::new(), since it appears the raw_cpuid dependency is only used in x86_64. If the dependency can be added for other targets, then we can remove the requirement from RdRand::new() as well.

I've tested this with a release build, and confirmed that the assembly output picks the correct register size in each scenario.

I have not tested a failure scenario. I may try to do this later. I'm thinking if I run the instruction a whole bunch of times in parallel, hopefully I can get a failure to happen.

I may also play with the idea of something like `pub fn fill(&self, &mut T) -> bool` which would let rdrand write directly into the destination.