### PR TITLE
Correct typo ("closue" instead of "closure")

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -25,7 +25,7 @@ pub fn disable() {
     }
 }
 
-/// Run a closue with disabled interrupts.
+/// Run a closure with disabled interrupts.
 ///
 /// Run the given closure, disabling interrupts before running it (if they aren't already disabled).
 /// Afterwards, interrupts are enabling again if they were enabled before.


### PR DESCRIPTION
Almost useless pull request to fix a typo in the incode documentation.
Btw thanks for your work, your crate really help me with my honours project.