### PR TITLE
Add #![feature(try_from)] to avoid "error[E0658]"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_fn)]
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
+#![feature(try_from)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]


### PR DESCRIPTION
The use of TryFrom traits generates a compilation error `error[E0658]: use of unstable library feature 'try_from' (see issue #33417)` while compiling the sources with `rustc 1.34.0-nightly`.
Adding the recommended `#![feature(try_from)]` in lib.rs fixes it.

Log: 
```
$ cargo build                                                          
   Compiling semver-parser v0.7.0
   Compiling cc v1.0.30
   Compiling bitflags v1.0.4
   Compiling nodrop v0.1.13
   Compiling ux v0.1.3
   Compiling bit_field v0.9.0
   Compiling usize_conversions v0.2.0
   Compiling array-init v0.0.4
   Compiling semver v0.9.0
   Compiling rustc_version v0.2.3
   Compiling raw-cpuid v6.1.0
   Compiling x86_64 v0.5.1 (/home/xxx/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.5.1)
error[E0658]: use of unstable library feature 'try_from' (see issue #33417)
 --> src/addr.rs:1:27
  |
1 | use core::convert::{Into, TryInto};
  |                           ^^^^^^^
  |
  = help: add #![feature(try_from)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'try_from' (see issue #33417)
   --> src/addr.rs:144:35
    |
144 |         u12::new((self.0 & 0xfff).try_into().unwrap())
    |                                   ^^^^^^^^
//! This crate provides x86_64 specific functions and data structures,
    |
    = help: add #![feature(try_from)] to the crate attributes to enableerror[E0658]: use of unstable library feature 'try_from' (see issue #33417)
   --> src/addr.rs:149:42
    |
149 |         u9::new(((self.0 >> 12) & 0o777).try_into().unwrap())
    |                                          ^^^^^^^^
    |
    = help: add #![feature(try_from)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'try_from' (see issue #33417)
   --> src/addr.rs:154:47
    |
154 |         u9::new(((self.0 >> 12 >> 9) & 0o777).try_into().unwrap())
    |                                               ^^^^^^^^
    |
    = help: add #![feature(try_from)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'try_from' (see issue #33417)
   --> src/addr.rs:159:52
    |
159 |         u9::new(((self.0 >> 12 >> 9 >> 9) & 0o777).try_into().unwrap())
    |                                                    ^^^^^^^^
    |
    = help: add #![feature(try_from)] to the crate attributes to enable

error[E0658]: use of unstable library feature 'try_from' (see issue #33417)
   --> src/addr.rs:164:57
    |
164 |         u9::new(((self.0 >> 12 >> 9 >> 9 >> 9) & 0o777).try_into().unwrap())
    |                                                         ^^^^^^^^
    |
    = help: add #![feature(try_from)] to the crate attributes to enable

error: aborting due to 6 previous errors

For more information about this error, try `rustc --explain E0658`.
error: Could not compile `x86_64`.

To learn more, run the command again with --verbose.
```