### PR TITLE
Add variable privilege to gdt

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -70,15 +70,15 @@ impl GlobalDescriptorTable {
     ///
     /// Panics if the GDT has no free entries left.
     pub fn add_entry(&mut self, entry: Descriptor) -> SegmentSelector {
-        let index = match entry {
-            Descriptor::UserSegment(value) => self.push(value),
+        let (index, privilege) = match entry {
+            Descriptor::UserSegment(value) => (self.push(value), (value >> 45) & 0b11),
             Descriptor::SystemSegment(value_low, value_high) => {
                 let index = self.push(value_low);
                 self.push(value_high);
-                index
+                (index, (value_low >> 45) & 0b11)
             }
         };
-        SegmentSelector::new(index as u16, PrivilegeLevel::Ring0)
+        SegmentSelector::new(index as u16, PrivilegeLevel::from_u16(privilege as u16))
     }
 
     /// Loads the GDT in the CPU using the `lgdt` instruction.

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -159,10 +159,10 @@ impl Descriptor {
         // base
         low.set_bits(16..40, ptr.get_bits(0..24));
         low.set_bits(56..64, ptr.get_bits(24..32));
-        // limit (the `-2` is needed since the bound is inclusive -- -1 from TSS size and -1 from iomap size)
+        // limit (the `-1` is needed since the bound is inclusive)
         low.set_bits(
             0..16,
-            (size_of::<TaskStateSegment>() + (tss.iomap_base + iomap_size) as usize - 2) as u64
+            (size_of::<TaskStateSegment>() + (tss.iomap_base + iomap_size) as usize - 1) as u64
         );
         // type (0b1001 = available 64-bit tss)
         low.set_bits(40..44, 0b1001);


### PR DESCRIPTION
This PR allows users to vary the privilege level in gdt entries by manually editing the descriptor entry. This has been tested for code/data segments, but not for system segments. It also allows the user to specify an IO permissions bitmap. 