### PR TITLE
Use cast crate instead of usize_conversions crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,11 @@ edition = "2018"
 [dependencies]
 bit_field = "0.9.0"
 bitflags = "1.0.4"
-usize_conversions = "0.2.0"
 array-init = "0.0.4"
+
+[dependencies.cast]
+version = "0.2.2"
+default-features = false
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "6.1.0"

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Use [`cast`](https://docs.rs/cast/0.2.2/cast/) crate instead of less general `usize_conversions` crate.
+
 # 0.5.4
 
 - Update dependencies to latest versions (fix [#67](https://github.com/rust-osdev/x86_64/issues/67))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,3 +102,9 @@ steps:
 
 - script: bootimage test --manifest-path testing/Cargo.toml
   displayName: 'Integration Tests'
+
+- script: rustup component add rustfmt
+  displayName: 'Install Rustfmt'
+
+- script: cargo fmt -- --check
+  displayName: 'Check Formatting'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,9 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - '*'
+    exclude:
+    - 'staging.tmp'
 
 strategy:
   matrix:

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,4 @@
+status = [
+  "rust-osdev.x86_64",
+]
+delete_merged_branches = true

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -3,7 +3,6 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 use bit_field::BitField;
-use usize_conversions::FromUsize;
 use ux::*;
 
 /// A canonical 64-bit virtual memory address.
@@ -92,15 +91,13 @@ impl VirtAddr {
 
     /// Creates a virtual address from the given pointer
     pub fn from_ptr<T>(ptr: *const T) -> Self {
-        Self::new(u64::from_usize(ptr as usize))
+        Self::new(cast::u64(ptr as usize))
     }
 
     /// Converts the address to a raw pointer.
     #[cfg(target_pointer_width = "64")]
     pub fn as_ptr<T>(self) -> *const T {
-        use usize_conversions::usize_from;
-
-        usize_from(self.as_u64()) as *const T
+        cast::usize(self.as_u64()) as *const T
     }
 
     /// Converts the address to a mutable raw pointer.
@@ -182,22 +179,18 @@ impl AddAssign<u64> for VirtAddr {
     }
 }
 
-impl Add<usize> for VirtAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl Add<usize> for VirtAddr {
     type Output = Self;
     fn add(self, rhs: usize) -> Self::Output {
-        self + u64::from_usize(rhs)
+        self + cast::u64(rhs)
     }
 }
 
-impl AddAssign<usize> for VirtAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl AddAssign<usize> for VirtAddr {
     fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(u64::from_usize(rhs))
+        self.add_assign(cast::u64(rhs))
     }
 }
 
@@ -214,22 +207,18 @@ impl SubAssign<u64> for VirtAddr {
     }
 }
 
-impl Sub<usize> for VirtAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl Sub<usize> for VirtAddr {
     type Output = Self;
     fn sub(self, rhs: usize) -> Self::Output {
-        self - u64::from_usize(rhs)
+        self - cast::u64(rhs)
     }
 }
 
-impl SubAssign<usize> for VirtAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl SubAssign<usize> for VirtAddr {
     fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(u64::from_usize(rhs))
+        self.sub_assign(cast::u64(rhs))
     }
 }
 
@@ -351,22 +340,18 @@ impl AddAssign<u64> for PhysAddr {
     }
 }
 
-impl Add<usize> for PhysAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl Add<usize> for PhysAddr {
     type Output = Self;
     fn add(self, rhs: usize) -> Self::Output {
-        self + u64::from_usize(rhs)
+        self + cast::u64(rhs)
     }
 }
 
-impl AddAssign<usize> for PhysAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl AddAssign<usize> for PhysAddr {
     fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(u64::from_usize(rhs))
+        self.add_assign(cast::u64(rhs))
     }
 }
 
@@ -383,22 +368,18 @@ impl SubAssign<u64> for PhysAddr {
     }
 }
 
-impl Sub<usize> for PhysAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl Sub<usize> for PhysAddr {
     type Output = Self;
     fn sub(self, rhs: usize) -> Self::Output {
-        self - u64::from_usize(rhs)
+        self - cast::u64(rhs)
     }
 }
 
-impl SubAssign<usize> for PhysAddr
-where
-    u64: FromUsize,
-{
+#[cfg(target_pointer_width = "64")]
+impl SubAssign<usize> for PhysAddr {
     fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(u64::from_usize(rhs))
+        self.sub_assign(cast::u64(rhs))
     }
 }
 

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-pub use crate::structures::port::{PortRead, PortWrite, PortReadWrite};
+pub use crate::structures::port::{PortRead, PortReadWrite, PortWrite};
 
 impl PortRead for u8 {
     #[inline]
@@ -52,7 +52,7 @@ impl PortWrite for u32 {
     }
 }
 
-impl PortReadWrite for u8  {}
+impl PortReadWrite for u8 {}
 impl PortReadWrite for u16 {}
 impl PortReadWrite for u32 {}
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -7,7 +7,6 @@ use super::{PageSize, PhysFrame, Size4KiB};
 use crate::addr::PhysAddr;
 
 use bitflags::bitflags;
-use usize_conversions::usize_from;
 use ux::*;
 
 /// The error returned by the `PageTableEntry::frame` method.
@@ -222,13 +221,13 @@ impl Index<u9> for PageTable {
     type Output = PageTableEntry;
 
     fn index(&self, index: u9) -> &Self::Output {
-        &self.entries[usize_from(u16::from(index))]
+        &self.entries[cast::usize(u16::from(index))]
     }
 }
 
 impl IndexMut<u9> for PageTable {
     fn index_mut(&mut self, index: u9) -> &mut Self::Output {
-        &mut self.entries[usize_from(u16::from(index))]
+        &mut self.entries[cast::usize(u16::from(index))]
     }
 }
 

--- a/src/structures/port.rs
+++ b/src/structures/port.rs
@@ -28,4 +28,4 @@ pub trait PortWrite {
 ///
 /// On x86, I/O ports operate on either `u8` (via `inb`/`outb`), `u16` (via `inw`/`outw`),
 /// or `u32` (via `inl`/`outl`). Therefore this trait is implemented for exactly these types.
-pub trait PortReadWrite: PortRead + PortWrite {}    
+pub trait PortReadWrite: PortRead + PortWrite {}


### PR DESCRIPTION
Update the code to use the more general [`cast`](https://docs.rs/cast/0.2.2/cast/) crate.

This PR also adds support for bors and a check for correct `rustfmt` formatting to CI.