### PR TITLE
Make FrameAllocator an unsafe trait

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- **Breaking**: Make the `FrameAllocator` unsafe to implement. This way, we can force the implementer to guarantee that all frame allocators are valid. See [#69](https://github.com/rust-osdev/x86_64/issues/69) for more information.
+
 # 0.5.5
 
 - Use [`cast`](https://docs.rs/cast/0.2.2/cast/) crate instead of less general `usize_conversions` crate.

--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -3,7 +3,10 @@
 use crate::structures::paging::{PageSize, PhysFrame};
 
 /// A trait for types that can allocate a frame of memory.
-pub trait FrameAllocator<S: PageSize> {
+///
+/// This trait is unsafe to implement because the implementer must guarantee that
+/// the `allocate_frame` method returns only unique unused frames.
+pub unsafe trait FrameAllocator<S: PageSize> {
     /// Allocate a frame of the appropriate size and return it if possible.
     fn allocate_frame(&mut self) -> Option<PhysFrame<S>>;
 }

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -81,10 +81,8 @@ pub trait Mapper<S: PageSize> {
     /// This function might need additional physical frames to create new page tables. These
     /// frames are allocated from the `allocator` argument. At most three frames are required.
     ///
-    /// This function is unsafe because the caller must guarantee the following:
-    ///
-    /// - The passed `frame` must be unused, i.e. not used for any other mappings.
-    /// - The passed `frame_allocator` must only yield unused frames.
+    /// This function is unsafe because the caller must guarantee that passed `frame` is
+    /// unused, i.e. not used for any other mappings.
     unsafe fn map_to<A>(
         &mut self,
         page: Page<S>,
@@ -115,10 +113,8 @@ pub trait Mapper<S: PageSize> {
 
     /// Maps the given frame to the virtual page with the same address.
     ///
-    /// This function is unsafe because the caller must guarantee the following:
-    ///
-    /// - The passed `frame` must be unused, i.e. not used for any other mappings.
-    /// - The passed `frame_allocator` must only yield unused frames.
+    /// This function is unsafe because the caller must guarantee that the passed `frame` is
+    /// unused, i.e. not used for any other mappings.
     unsafe fn identity_map<A>(
         &mut self,
         frame: PhysFrame<S>,


### PR DESCRIPTION
This is a breaking change.

Fixes #69 