### PR TITLE
Add bochs magic breakpoint, read instruction pointer, inline instructions

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -10,6 +10,7 @@ pub fn are_enabled() -> bool {
 /// Enable interrupts.
 ///
 /// This is a wrapper around the `sti` instruction.
+#[inline]
 pub fn enable() {
     unsafe {
         asm!("sti" :::: "volatile");
@@ -19,6 +20,7 @@ pub fn enable() {
 /// Disable interrupts.
 ///
 /// This is a wrapper around the `cli` instruction.
+#[inline]
 pub fn disable() {
     unsafe {
         asm!("cli" :::: "volatile");
@@ -70,6 +72,7 @@ where
 }
 
 /// Cause a breakpoint exception by invoking the `int3` instruction.
+#[inline]
 pub fn int3() {
     unsafe {
         asm!("int3" :::: "volatile");

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -10,9 +10,34 @@ pub mod tables;
 pub mod tlb;
 
 /// Halts the CPU until the next interrupt arrives.
-#[inline(always)]
+#[inline]
 pub fn hlt() {
     unsafe {
         asm!("hlt" :::: "volatile");
     }
+}
+
+/// Emits a 'magic breakpoint' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
+/// emulator. Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
+#[inline]
+pub fn bochs_breakpoint() {
+    unsafe {
+        asm!("xchgw %bx, %bx" :::: "volatile");
+    }
+}
+
+/// Gets the current instruction pointer. Note that this is only approximate as it requires a few
+/// instructions to execute.
+#[inline]
+pub fn read_rip() -> u64 {
+    let rip: u64;
+    unsafe {
+        asm!(
+            "call .next
+            .next:
+            pop $0"
+            : "=r"(rip) ::: "volatile"
+        );
+    }
+    rip
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -17,27 +17,11 @@ pub fn hlt() {
     }
 }
 
-/// Emits a 'magic breakpoint' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
+/// Emits a '[magic breakpoint](https://wiki.osdev.org/Bochs#Magic_Breakpoint)' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
 /// emulator. Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
 #[inline]
 pub fn bochs_breakpoint() {
     unsafe {
         asm!("xchgw %bx, %bx" :::: "volatile");
     }
-}
-
-/// Gets the current instruction pointer. Note that this is only approximate as it requires a few
-/// instructions to execute.
-#[inline]
-pub fn read_rip() -> u64 {
-    let rip: u64;
-    unsafe {
-        asm!(
-            "call .next
-            .next:
-            pop $0"
-            : "=r"(rip) ::: "volatile"
-        );
-    }
-    rip
 }

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -22,26 +22,31 @@ pub unsafe fn set_cs(sel: SegmentSelector) {
 }
 
 /// Reload stack segment register.
+#[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
     asm!("movw $0, %ss " :: "r" (sel.0) : "memory");
 }
 
 /// Reload data segment register.
+#[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
     asm!("movw $0, %ds " :: "r" (sel.0) : "memory");
 }
 
 /// Reload es segment register.
+#[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
     asm!("movw $0, %es " :: "r" (sel.0) : "memory");
 }
 
 /// Reload fs segment register.
+#[inline]
 pub unsafe fn load_fs(sel: SegmentSelector) {
     asm!("movw $0, %fs " :: "r" (sel.0) : "memory");
 }
 
 /// Reload gs segment register.
+#[inline]
 pub unsafe fn load_gs(sel: SegmentSelector) {
     asm!("movw $0, %gs " :: "r" (sel.0) : "memory");
 }

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -20,9 +20,7 @@ pub unsafe fn lidt(idt: &DescriptorTablePointer) {
     asm!("lidt ($0)" :: "r" (idt) : "memory");
 }
 
-/// Load the task state register using the `ltr` instruction. Use the
-/// [`GlobalDescriptorTable`](crate::structures::gdt::GlobalDescriptorTable) struct for a
-/// high-level interface to loading a TSS.
+/// Load the task state register using the `ltr` instruction.
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     asm!("ltr $0" :: "r" (sel.0));

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -4,17 +4,26 @@ use crate::structures::gdt::SegmentSelector;
 
 pub use crate::structures::DescriptorTablePointer;
 
-/// Load GDT table.
+/// Load a GDT. Use the
+/// [`GlobalDescriptorTable`](crate::structures::gdt::GlobalDescriptorTable) struct for a high-level
+/// interface to loading a GDT.
+#[inline]
 pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
     asm!("lgdt ($0)" :: "r" (gdt) : "memory");
 }
 
-/// Load IDT table.
+/// Load an IDT. Use the
+/// [`InterruptDescriptorTable`](crate::structures::idt::InterruptDescriptorTable) struct for a high-level
+/// interface to loading an IDT.
+#[inline]
 pub unsafe fn lidt(idt: &DescriptorTablePointer) {
     asm!("lidt ($0)" :: "r" (idt) : "memory");
 }
 
-/// Load the task state register using the `ltr` instruction.
+/// Load the task state register using the `ltr` instruction. Use the
+/// [`GlobalDescriptorTable`](crate::structures::gdt::GlobalDescriptorTable) struct for a
+/// high-level interface to loading a TSS.
+#[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     asm!("ltr $0" :: "r" (sel.0));
 }

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -3,11 +3,13 @@
 use crate::VirtAddr;
 
 /// Invalidate the given address in the TLB using the `invlpg` instruction.
+#[inline]
 pub fn flush(addr: VirtAddr) {
     unsafe { asm!("invlpg ($0)" :: "r" (addr.as_u64()) : "memory") };
 }
 
 /// Invalidate the TLB completely by reloading the CR3 register.
+#[inline]
 pub fn flush_all() {
     use crate::registers::control::Cr3;
     let (frame, flags) = Cr3::read();

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -3,3 +3,17 @@
 pub mod control;
 pub mod model_specific;
 pub mod rflags;
+
+/// Gets the current instruction pointer. Note that this is only approximate as it requires a few
+/// instructions to execute.
+#[inline(always)]
+pub fn read_rip() -> u64 {
+    let rip: u64;
+    unsafe {
+        asm!(
+            "lea (%rip), $0"
+            : "=r"(rip) ::: "volatile"
+        );
+    }
+    rip
+}


### PR DESCRIPTION
* Added functions for a bochs magic breakpoint and reading the instruction pointer
* Marked small single-instruction functions as `#[inline]`
* Improved the docs for the segmentation functions