### PR TITLE
Reexport MappedPageTable on non-x86_64 platforms too

### DIFF
--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -4,9 +4,11 @@
 
 pub use self::frame::PhysFrame;
 pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
+#[doc(no_inline)]
+pub use self::mapper::MappedPageTable;
 #[cfg(target_arch = "x86_64")]
 #[doc(no_inline)]
-pub use self::mapper::{MappedPageTable, RecursivePageTable};
+pub use self::mapper::RecursivePageTable;
 pub use self::mapper::{Mapper, MapperAllSizes};
 pub use self::page::{Page, PageSize, Size1GiB, Size2MiB, Size4KiB};
 pub use self::page_table::{PageTable, PageTableFlags};


### PR DESCRIPTION
Just a small oversight. The `MappedPageTable` type is platform independent, so we can reexport it on all platforms.