### PR TITLE
Add a new `OffsetPageTable` mapper type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Add a new `OffsetPageTable` mapper type ([#83](https://github.com/rust-osdev/x86_64/pull/83))
+
 # 0.7.2
 
 - Add `instructions::bochs_breakpoint` and `registers::read_rip` functions ([#79](https://github.com/rust-osdev/x86_64/pull/79))

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -1,6 +1,6 @@
 //! Abstractions for reading and modifying the mapping of pages.
 
-pub use self::mapped_page_table::MappedPageTable;
+pub use self::mapped_page_table::{MappedPageTable, PhysToVirt};
 #[cfg(target_arch = "x86_64")]
 pub use self::recursive_page_table::RecursivePageTable;
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -2,6 +2,8 @@
 
 pub use self::mapped_page_table::{MappedPageTable, PhysToVirt};
 #[cfg(target_arch = "x86_64")]
+pub use self::offset_page_table::OffsetPageTable;
+#[cfg(target_arch = "x86_64")]
 pub use self::recursive_page_table::RecursivePageTable;
 
 use crate::structures::paging::{
@@ -11,6 +13,7 @@ use crate::structures::paging::{
 use crate::{PhysAddr, VirtAddr};
 
 mod mapped_page_table;
+mod offset_page_table;
 mod recursive_page_table;
 
 /// This trait defines page table operations that work for all page sizes of the x86_64

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -2,10 +2,7 @@
 
 pub use self::mapped_page_table::{MappedPageTable, PhysToVirt};
 #[cfg(target_arch = "x86_64")]
-pub use self::{
-    offset_page_table::OffsetPageTable,
-    recursive_page_table::RecursivePageTable,
-};
+pub use self::{offset_page_table::OffsetPageTable, recursive_page_table::RecursivePageTable};
 
 use crate::structures::paging::{
     frame_alloc::FrameAllocator, page_table::PageTableFlags, Page, PageSize, PhysFrame, Size1GiB,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -2,9 +2,10 @@
 
 pub use self::mapped_page_table::{MappedPageTable, PhysToVirt};
 #[cfg(target_arch = "x86_64")]
-pub use self::offset_page_table::OffsetPageTable;
-#[cfg(target_arch = "x86_64")]
-pub use self::recursive_page_table::RecursivePageTable;
+pub use self::{
+    offset_page_table::OffsetPageTable,
+    recursive_page_table::RecursivePageTable,
+};
 
 use crate::structures::paging::{
     frame_alloc::FrameAllocator, page_table::PageTableFlags, Page, PageSize, PhysFrame, Size1GiB,

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -1,0 +1,151 @@
+#![cfg(target_arch = "x86_64")]
+
+use crate::structures::paging::{frame::PhysFrame, mapper::*, page_table::PageTable};
+
+/// A Mapper implementation that requires that the complete physically memory is mapped at some
+/// offset in the virtual address space.
+#[derive(Debug)]
+pub struct OffsetPageTable<'a> {
+    inner: MappedPageTable<'a, PhysOffset>,
+}
+
+impl<'a> OffsetPageTable<'a> {
+    /// Creates a new `OffsetPageTable` that uses the given offset for converting virtual
+    /// to physical addresses.
+    ///
+    /// This function is unsafe because the caller must guarantee that the passed `phys_offset`
+    /// is correct. Also, the passed `level_4_table` must point to the level 4 page table
+    /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
+    /// by writing to an illegal memory location.
+    pub unsafe fn new(level_4_table: &'a mut PageTable, phys_offset: u64) -> Self {
+        let phys_offset = PhysOffset {
+            offset: phys_offset,
+        };
+        Self {
+            inner: MappedPageTable::new(level_4_table, phys_offset),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct PhysOffset {
+    offset: u64,
+}
+
+impl PhysToVirt for PhysOffset {
+    fn phys_to_virt(&self, frame: PhysFrame) -> *mut PageTable {
+        let phys = frame.start_address().as_u64();
+        let virt = VirtAddr::new(phys + self.offset);
+        virt.as_mut_ptr()
+    }
+}
+
+// delegate all trait implementations to inner
+
+impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
+    unsafe fn map_to<A>(
+        &mut self,
+        page: Page<Size1GiB>,
+        frame: PhysFrame<Size1GiB>,
+        flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size1GiB>, MapToError>
+    where
+        A: FrameAllocator<Size4KiB>,
+    {
+        self.inner.map_to(page, frame, flags, allocator)
+    }
+
+    fn unmap(
+        &mut self,
+        page: Page<Size1GiB>,
+    ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    fn update_flags(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size1GiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    fn translate_page(&self, page: Page<Size1GiB>) -> Result<PhysFrame<Size1GiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
+    unsafe fn map_to<A>(
+        &mut self,
+        page: Page<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
+        flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size2MiB>, MapToError>
+    where
+        A: FrameAllocator<Size4KiB>,
+    {
+        self.inner.map_to(page, frame, flags, allocator)
+    }
+
+    fn unmap(
+        &mut self,
+        page: Page<Size2MiB>,
+    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    fn update_flags(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size2MiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    fn translate_page(&self, page: Page<Size2MiB>) -> Result<PhysFrame<Size2MiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
+    unsafe fn map_to<A>(
+        &mut self,
+        page: Page<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
+        flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size4KiB>, MapToError>
+    where
+        A: FrameAllocator<Size4KiB>,
+    {
+        self.inner.map_to(page, frame, flags, allocator)
+    }
+
+    fn unmap(
+        &mut self,
+        page: Page<Size4KiB>,
+    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    fn update_flags(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size4KiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    fn translate_page(&self, page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> MapperAllSizes for OffsetPageTable<'a> {
+    fn translate(&self, addr: VirtAddr) -> TranslateResult {
+        self.inner.translate(addr)
+    }
+}

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -17,7 +17,7 @@ impl<'a> OffsetPageTable<'a> {
     /// is correct. Also, the passed `level_4_table` must point to the level 4 page table
     /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
     /// by writing to an illegal memory location.
-    pub unsafe fn new(level_4_table: &'a mut PageTable, phys_offset: u64) -> Self {
+    pub unsafe fn new(level_4_table: &'a mut PageTable, phys_offset: VirtAddr) -> Self {
         let phys_offset = PhysOffset {
             offset: phys_offset,
         };
@@ -29,13 +29,13 @@ impl<'a> OffsetPageTable<'a> {
 
 #[derive(Debug)]
 struct PhysOffset {
-    offset: u64,
+    offset: VirtAddr,
 }
 
 impl PhysToVirt for PhysOffset {
     fn phys_to_virt(&self, frame: PhysFrame) -> *mut PageTable {
         let phys = frame.start_address().as_u64();
-        let virt = VirtAddr::new(phys + self.offset);
+        let virt = self.offset + phys;
         virt.as_mut_ptr()
     }
 }

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -13,6 +13,12 @@ impl<'a> OffsetPageTable<'a> {
     /// Creates a new `OffsetPageTable` that uses the given offset for converting virtual
     /// to physical addresses.
     ///
+    /// The complete physical memory must be mapped in the virtual address space starting at
+    /// address `phys_offset`. This means that for example physical address `0x5000` can be
+    /// accessed through virtual address `phys_offset + 0x5000`. This mapping is required because
+    /// the mapper needs to access page tables, which are not mapped into the virtual address
+    /// space by default.
+    ///
     /// This function is unsafe because the caller must guarantee that the passed `phys_offset`
     /// is correct. Also, the passed `level_4_table` must point to the level 4 page table
     /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -8,7 +8,7 @@ pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
 pub use self::mapper::MappedPageTable;
 #[cfg(target_arch = "x86_64")]
 #[doc(no_inline)]
-pub use self::mapper::RecursivePageTable;
+pub use self::mapper::{OffsetPageTable, RecursivePageTable};
 pub use self::mapper::{Mapper, MapperAllSizes};
 pub use self::page::{Page, PageSize, Size1GiB, Size2MiB, Size4KiB};
 pub use self::page_table::{PageTable, PageTableFlags};

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -6,10 +6,10 @@ pub use self::frame::PhysFrame;
 pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
 #[doc(no_inline)]
 pub use self::mapper::MappedPageTable;
+pub use self::mapper::{Mapper, MapperAllSizes};
 #[cfg(target_arch = "x86_64")]
 #[doc(no_inline)]
 pub use self::mapper::{OffsetPageTable, RecursivePageTable};
-pub use self::mapper::{Mapper, MapperAllSizes};
 pub use self::page::{Page, PageSize, Size1GiB, Size2MiB, Size4KiB};
 pub use self::page_table::{PageTable, PageTableFlags};
 


### PR DESCRIPTION
The type wraps a `MappedPageTable` instance with a simpler interface. It uses a simple phys-to-virt offset instead of being generic over a phys-to-virt closure, which makes it easier to e.g. store the type in a `static`.

TODO:

- [x] Make `phys_offset` a `VirtAddr` instead of an `u64` 

Fixes #81 