### PR TITLE
Make Mapper trait object safe by adding `Self: Sized` bounds on generic functions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 - **Breaking:** Replace `ux` dependency with custom wrapper structs ([#91](https://github.com/rust-osdev/x86_64/pull/91))
 - **Breaking:** Add new UnsafePhysFrame type and use it in Mapper::map_to ([#89](https://github.com/rust-osdev/x86_64/pull/89))
+- _Possibly Breaking:_ Make Mapper trait object safe by adding `Self: Sized` bounds on generic functions ([#84](https://github.com/rust-osdev/x86_64/pull/84))
+
 
 # 0.7.7
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -90,6 +90,7 @@ pub trait Mapper<S: PageSize> {
         frame_allocator: &mut A,
     ) -> Result<MapperFlush<S>, MapToError>
     where
+        Self: Sized,
         A: FrameAllocator<Size4KiB>;
 
     /// Removes a mapping from the page table and returns the frame that used to be mapped.
@@ -118,6 +119,7 @@ pub trait Mapper<S: PageSize> {
         frame_allocator: &mut A,
     ) -> Result<MapperFlush<S>, MapToError>
     where
+        Self: Sized,
         A: FrameAllocator<Size4KiB>,
         S: PageSize,
         Self: Mapper<S>,
@@ -198,3 +200,5 @@ pub enum TranslateError {
     /// The page table entry for the given page points to an invalid physical address.
     InvalidFrameAddress(PhysAddr),
 }
+
+static _ASSERT_OBJECT_SAFE: Option<&(dyn MapperAllSizes + Sync)> = None;


### PR DESCRIPTION
See #80 for more information

I'm not quite sure whether this is a **breaking change**, but I think it is.