### PR TITLE
Add new UnsafePhysFrame type and use it in Mapper::map_to

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,5 @@
 - **Breaking:** Replace `ux` dependency with custom wrapper structs ([#91](https://github.com/rust-osdev/x86_64/pull/91))
+- **Breaking:** Add new UnsafePhysFrame type and use it in Mapper::map_to ([#89](https://github.com/rust-osdev/x86_64/pull/89))
 
 # 0.7.7
 

--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -1,6 +1,7 @@
 //! Traits for abstracting away frame allocation and deallocation.
 
-use crate::structures::paging::{PageSize, PhysFrame};
+use crate::structures::paging::{PageSize, PhysFrame, Size4KiB};
+use core::ops::{Deref, DerefMut};
 
 /// A trait for types that can allocate a frame of memory.
 ///
@@ -8,11 +9,43 @@ use crate::structures::paging::{PageSize, PhysFrame};
 /// the `allocate_frame` method returns only unique unused frames.
 pub unsafe trait FrameAllocator<S: PageSize> {
     /// Allocate a frame of the appropriate size and return it if possible.
-    fn allocate_frame(&mut self) -> Option<PhysFrame<S>>;
+    fn allocate_frame(&mut self) -> Option<UnusedPhysFrame<S>>;
 }
 
 /// A trait for types that can deallocate a frame of memory.
 pub trait FrameDeallocator<S: PageSize> {
     /// Deallocate the given frame of memory.
-    fn deallocate_frame(&mut self, frame: PhysFrame<S>);
+    fn deallocate_frame(&mut self, frame: UnusedPhysFrame<S>);
+}
+
+/// Represents a physical frame that is not used for any mapping.
+#[derive(Debug)]
+pub struct UnusedPhysFrame<S: PageSize = Size4KiB>(PhysFrame<S>);
+
+impl<S: PageSize> UnusedPhysFrame<S> {
+    /// Creates a new UnusedPhysFrame from the given frame.
+    ///
+    /// This method is unsafe because the caller must guarantee
+    /// that the given frame is unused.
+    pub unsafe fn new(frame: PhysFrame<S>) -> Self {
+        Self(frame)
+    }
+
+    pub fn frame(self) -> PhysFrame<S> {
+        self.0
+    }
+}
+
+impl<S: PageSize> Deref for UnusedPhysFrame<S> {
+    type Target = PhysFrame<S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<S: PageSize> DerefMut for UnusedPhysFrame<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -39,7 +39,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
     fn map_to_1gib<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
+        frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError>
@@ -64,7 +64,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
     fn map_to_2mib<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
+        frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError>
@@ -92,7 +92,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
     fn map_to_4kib<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
+        frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError>
@@ -113,17 +113,17 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         if !p1[page.p1_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped);
         }
-        p1[page.p1_index()].set_frame(frame, flags);
+        p1[page.p1_index()].set_frame(frame.frame(), flags);
 
         Ok(MapperFlush::new(page))
     }
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
+        frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError>
@@ -193,10 +193,10 @@ impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
+        frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError>
@@ -274,10 +274,10 @@ impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size4KiB> for MappedPageTable<'a, P> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
+        frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError>
@@ -460,7 +460,10 @@ impl<P: PhysToVirt> PageTableWalker<P> {
 
         if entry.is_unused() {
             if let Some(frame) = allocator.allocate_frame() {
-                entry.set_frame(frame, PageTableFlags::PRESENT | PageTableFlags::WRITABLE);
+                entry.set_frame(
+                    frame.frame(),
+                    PageTableFlags::PRESENT | PageTableFlags::WRITABLE,
+                );
                 created = true;
             } else {
                 return Err(PageTableCreateError::FrameAllocationFailed);

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -49,10 +49,10 @@ impl PhysToVirt for PhysOffset {
 // delegate all trait implementations to inner
 
 impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
+        frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError>
@@ -83,10 +83,10 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
 }
 
 impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
+        frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError>
@@ -117,10 +117,10 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
 }
 
 impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
+        frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError>

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -110,7 +110,7 @@ impl<'a> RecursivePageTable<'a> {
 
             if entry.is_unused() {
                 if let Some(frame) = allocator.allocate_frame() {
-                    entry.set_frame(frame, Flags::PRESENT | Flags::WRITABLE);
+                    entry.set_frame(frame.frame(), Flags::PRESENT | Flags::WRITABLE);
                     created = true;
                 } else {
                     return Err(MapToError::FrameAllocationFailed);
@@ -138,7 +138,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_1gib<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
+        frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError>
@@ -164,7 +164,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_2mib<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
+        frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError>
@@ -193,7 +193,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_4kib<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
+        frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError>
@@ -214,17 +214,17 @@ impl<'a> RecursivePageTable<'a> {
         if !p1[page.p1_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped);
         }
-        p1[page.p1_index()].set_frame(frame, flags);
+        p1[page.p1_index()].set_frame(frame.frame(), flags);
 
         Ok(MapperFlush::new(page))
     }
 }
 
 impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
+        frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError>
@@ -306,10 +306,10 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
+        frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError>
@@ -411,10 +411,10 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
-    unsafe fn map_to<A>(
+    fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
+        frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError>


### PR DESCRIPTION
Fixes #88 

This pull request adds a new `UnsafePhysFrame` type that wraps a `PhysFrame`. The type is unsafe to construct and the caller must guarantee that the frame is not mapped already. This type allows to make the `map_to` and `identity_map` methods of the `Mapper` trait safe. This PR also adjust the `FrameAllocator` to use the new type.

This is a **breaking change**.

