### PR TITLE
Replace `ux` dependency with custom wrapper structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,5 @@ array-init = "0.0.4"
 version = "0.2.2"
 default-features = false
 
-[dependencies.ux]
-default-features = false
-version = "0.1.3"
-
 [features]
 deny-warnings = []

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- **Breaking:** Replace `ux` dependency with custom wrapper structs ([#91](https://github.com/rust-osdev/x86_64/pull/91))
+
 # 0.7.7
 
 - Add `slice` and `slice_mut` methods to IDT ([#95](https://github.com/rust-osdev/x86_64/pull/95))

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -2,8 +2,8 @@ use core::convert::{Into, TryInto};
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
+use crate::structures::paging::{PageOffset, PageTableIndex};
 use bit_field::BitField;
-use ux::*;
 
 /// A canonical 64-bit virtual memory address.
 ///
@@ -135,28 +135,28 @@ impl VirtAddr {
     }
 
     /// Returns the 12-bit page offset of this virtual address.
-    pub fn page_offset(&self) -> u12 {
-        u12::new((self.0 & 0xfff).try_into().unwrap())
+    pub fn page_offset(&self) -> PageOffset {
+        PageOffset::new((self.0 & 0xfff).try_into().unwrap())
     }
 
     /// Returns the 9-bit level 1 page table index.
-    pub fn p1_index(&self) -> u9 {
-        u9::new(((self.0 >> 12) & 0o777).try_into().unwrap())
+    pub fn p1_index(&self) -> PageTableIndex {
+        PageTableIndex::new(((self.0 >> 12) & 0o777).try_into().unwrap())
     }
 
     /// Returns the 9-bit level 2 page table index.
-    pub fn p2_index(&self) -> u9 {
-        u9::new(((self.0 >> 12 >> 9) & 0o777).try_into().unwrap())
+    pub fn p2_index(&self) -> PageTableIndex {
+        PageTableIndex::new(((self.0 >> 12 >> 9) & 0o777).try_into().unwrap())
     }
 
     /// Returns the 9-bit level 3 page table index.
-    pub fn p3_index(&self) -> u9 {
-        u9::new(((self.0 >> 12 >> 9 >> 9) & 0o777).try_into().unwrap())
+    pub fn p3_index(&self) -> PageTableIndex {
+        PageTableIndex::new(((self.0 >> 12 >> 9 >> 9) & 0o777).try_into().unwrap())
     }
 
     /// Returns the 9-bit level 4 page table index.
-    pub fn p4_index(&self) -> u9 {
-        u9::new(((self.0 >> 12 >> 9 >> 9 >> 9) & 0o777).try_into().unwrap())
+    pub fn p4_index(&self) -> PageTableIndex {
+        PageTableIndex::new(((self.0 >> 12 >> 9 >> 9 >> 9) & 0o777).try_into().unwrap())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,6 @@
 #![cfg_attr(not(feature = "deny-warnings"), warn(missing_docs))]
 #![deny(missing_debug_implementations)]
 
-/// Provides the non-standard-width integer types `u2`–`u63`.
-///
-/// We use these integer types in various APIs, for example `u9` for page tables indices.
-pub use ux;
-
 pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};
 
 pub mod instructions;

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -11,7 +11,7 @@ pub use self::mapper::{Mapper, MapperAllSizes};
 #[doc(no_inline)]
 pub use self::mapper::{OffsetPageTable, RecursivePageTable};
 pub use self::page::{Page, PageSize, Size1GiB, Size2MiB, Size4KiB};
-pub use self::page_table::{PageTable, PageTableFlags};
+pub use self::page_table::{PageOffset, PageTable, PageTableFlags, PageTableIndex};
 
 pub mod frame;
 mod frame_alloc;

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -1,10 +1,10 @@
 //! Abstractions for default-sized and huge virtual memory pages.
 
+use crate::structures::paging::PageTableIndex;
 use crate::VirtAddr;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
-use ux::*;
 
 /// Trait for abstracting over the three possible page sizes on x86_64, 4KiB, 2MiB, 1GiB.
 pub trait PageSize: Copy + Eq + PartialOrd + Ord {
@@ -92,12 +92,12 @@ impl<S: PageSize> Page<S> {
     }
 
     /// Returns the level 4 page table index of this page.
-    pub fn p4_index(&self) -> u9 {
+    pub fn p4_index(&self) -> PageTableIndex {
         self.start_address().p4_index()
     }
 
     /// Returns the level 3 page table index of this page.
-    pub fn p3_index(&self) -> u9 {
+    pub fn p3_index(&self) -> PageTableIndex {
         self.start_address().p3_index()
     }
 
@@ -114,14 +114,17 @@ impl<S: PageSize> Page<S> {
 
 impl<S: NotGiantPageSize> Page<S> {
     /// Returns the level 2 page table index of this page.
-    pub fn p2_index(&self) -> u9 {
+    pub fn p2_index(&self) -> PageTableIndex {
         self.start_address().p2_index()
     }
 }
 
 impl Page<Size1GiB> {
     /// Returns the 1GiB memory page with the specified page table indices.
-    pub fn from_page_table_indices_1gib(p4_index: u9, p3_index: u9) -> Self {
+    pub fn from_page_table_indices_1gib(
+        p4_index: PageTableIndex,
+        p3_index: PageTableIndex,
+    ) -> Self {
         use bit_field::BitField;
 
         let mut addr = 0;
@@ -133,7 +136,11 @@ impl Page<Size1GiB> {
 
 impl Page<Size2MiB> {
     /// Returns the 2MiB memory page with the specified page table indices.
-    pub fn from_page_table_indices_2mib(p4_index: u9, p3_index: u9, p2_index: u9) -> Self {
+    pub fn from_page_table_indices_2mib(
+        p4_index: PageTableIndex,
+        p3_index: PageTableIndex,
+        p2_index: PageTableIndex,
+    ) -> Self {
         use bit_field::BitField;
 
         let mut addr = 0;
@@ -146,7 +153,12 @@ impl Page<Size2MiB> {
 
 impl Page<Size4KiB> {
     /// Returns the 4KiB memory page with the specified page table indices.
-    pub fn from_page_table_indices(p4_index: u9, p3_index: u9, p2_index: u9, p1_index: u9) -> Self {
+    pub fn from_page_table_indices(
+        p4_index: PageTableIndex,
+        p3_index: PageTableIndex,
+        p2_index: PageTableIndex,
+        p1_index: PageTableIndex,
+    ) -> Self {
         use bit_field::BitField;
 
         let mut addr = 0;
@@ -158,7 +170,7 @@ impl Page<Size4KiB> {
     }
 
     /// Returns the level 1 page table index of this page.
-    pub fn p1_index(&self) -> u9 {
+    pub fn p1_index(&self) -> PageTableIndex {
         self.start_address().p1_index()
     }
 }

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -7,7 +7,6 @@ use super::{PageSize, PhysFrame, Size4KiB};
 use crate::addr::PhysAddr;
 
 use bitflags::bitflags;
-use ux::*;
 
 /// The error returned by the `PageTableEntry::frame` method.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -217,16 +216,16 @@ impl IndexMut<usize> for PageTable {
     }
 }
 
-impl Index<u9> for PageTable {
+impl Index<PageTableIndex> for PageTable {
     type Output = PageTableEntry;
 
-    fn index(&self, index: u9) -> &Self::Output {
+    fn index(&self, index: PageTableIndex) -> &Self::Output {
         &self.entries[cast::usize(u16::from(index))]
     }
 }
 
-impl IndexMut<u9> for PageTable {
-    fn index_mut(&mut self, index: u9) -> &mut Self::Output {
+impl IndexMut<PageTableIndex> for PageTable {
+    fn index_mut(&mut self, index: PageTableIndex) -> &mut Self::Output {
         &mut self.entries[cast::usize(u16::from(index))]
     }
 }
@@ -234,5 +233,61 @@ impl IndexMut<u9> for PageTable {
 impl fmt::Debug for PageTable {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.entries[..].fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageTableIndex(u16);
+
+impl PageTableIndex {
+    pub fn new(index: u16) -> Self {
+        assert!(usize::from(index) < ENTRY_COUNT);
+        Self(index)
+    }
+}
+
+impl From<PageTableIndex> for u16 {
+    fn from(index: PageTableIndex) -> Self {
+        index.0
+    }
+}
+
+impl From<PageTableIndex> for u32 {
+    fn from(index: PageTableIndex) -> Self {
+        u32::from(index.0)
+    }
+}
+
+impl From<PageTableIndex> for u64 {
+    fn from(index: PageTableIndex) -> Self {
+        u64::from(index.0)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PageOffset(u16);
+
+impl PageOffset {
+    pub fn new(offset: u16) -> Self {
+        assert!(offset < (1 << 12));
+        Self(offset)
+    }
+}
+
+impl From<PageOffset> for u16 {
+    fn from(offset: PageOffset) -> Self {
+        offset.0
+    }
+}
+
+impl From<PageOffset> for u32 {
+    fn from(offset: PageOffset) -> Self {
+        u32::from(offset.0)
+    }
+}
+
+impl From<PageOffset> for u64 {
+    fn from(offset: PageOffset) -> Self {
+        u64::from(offset.0)
     }
 }

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -236,10 +236,14 @@ impl fmt::Debug for PageTable {
     }
 }
 
+/// A 9-bit index into a page table.
+///
+/// Can be used to select one of the 512 entries of a page table.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageTableIndex(u16);
 
 impl PageTableIndex {
+    /// Creates a new index from the given `u16`. Panics if the given value is >=512.
     pub fn new(index: u16) -> Self {
         assert!(usize::from(index) < ENTRY_COUNT);
         Self(index)
@@ -264,10 +268,14 @@ impl From<PageTableIndex> for u64 {
     }
 }
 
+/// A 12-bit offset into a 4KiB Page.
+///
+/// This type is returned by the `VirtAddr::page_offset` method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct PageOffset(u16);
 
 impl PageOffset {
+    /// Creates a new offset from the given `u16`. Panics if the passed value is >=4096.
     pub fn new(offset: u16) -> Self {
         assert!(offset < (1 << 12));
         Self(offset)


### PR DESCRIPTION
This pull request introduces a new `PageTableIndex` type instead of `ux::u9`. Likewise, it introduces a new `PageOffset` instead of `ux::u12`. To migrate, you need to switch to the new types.

cc #90 


This is a **breaking change**.