### PR TITLE
use repr C to suppress not-ffi-safe when used with extern handler functions

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -655,6 +655,7 @@ pub type ExceptionStackFrame = InterruptStackFrame;
 /// This wrapper type ensures that no accidental modification of the interrupt stack frame
 /// occurs, which can cause undefined behavior (see the [`as_mut`](InterruptStackFrame::as_mut)
 /// method for more information).
+#[repr(C)]
 pub struct InterruptStackFrame {
     value: InterruptStackFrameValue,
 }


### PR DESCRIPTION
the interrupt handler functions are extern to allow for the special calling convention.
rust warns about using this struct with extern functions.
this patch suppresses the warning by fixing the struct layout.

i think in this case the warning is correctly pointing out that while the nested InterruptStackFrameValue is repr(C), the wrapper type is not. it seems incredibly unlikely that the compiler would do anything wrong here but adding repr(C) guards against it.

example warning:
```
   Compiling libkernel v0.1.0 (/Users/cmsd2/Development/ostoo/libkernel)
warning: `extern` fn uses type `x86_64::structures::idt::InterruptStackFrame`, which is not FFI-safe
  --> libkernel/src/interrupts.rs:70:18
   |
70 |     stack_frame: &mut InterruptStackFrame)
   |                  ^^^^^^^^^^^^^^^^^^^^^^^^ not FFI-safe
   |
   = note: `#[warn(improper_ctypes)]` on by default
   = help: consider adding a `#[repr(C)]` or `#[repr(transparent)]` attribute to this struct
   = note: this struct has unspecified layout
```