### PR TITLE
Run 'push' builds only for master branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - '*'
-      - '!staging.tmp'
+      - 'master'
     tags:
       - '*'
   schedule:


### PR DESCRIPTION
This avoids duplicated builds when opening a pull request from a branch from this repo.