### PR TITLE
Introduce new diverging handler functions for exceptions classified as "abort"

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 - **Breaking:** Replace `ux` dependency with custom wrapper structs ([#91](https://github.com/rust-osdev/x86_64/pull/91))
 - **Breaking:** Add new UnsafePhysFrame type and use it in Mapper::map_to ([#89](https://github.com/rust-osdev/x86_64/pull/89))
 - **Breaking:** Rename divide_by_zero field of interrupt descriptor table to divide_error ([#108](https://github.com/rust-osdev/x86_64/pull/108))
+- **Breaking:** Introduce new diverging handler functions for double faults and machine check exceptions ([#109](https://github.com/rust-osdev/x86_64/pull/109))
 - _Possibly Breaking:_ Make Mapper trait object safe by adding `Self: Sized` bounds on generic functions ([#84](https://github.com/rust-osdev/x86_64/pull/84))
 
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -577,7 +577,8 @@ pub type PageFaultHandlerFunc =
 /// A handler function that must not return, e.g. for a machine check exception.
 pub type DivergingHandlerFunc = extern "x86-interrupt" fn(&mut InterruptStackFrame) -> !;
 /// A handler function with an error code that must not return, e.g. for a double fault exception.
-pub type DivergingHandlerFuncWithErrCode = extern "x86-interrupt" fn(&mut InterruptStackFrame, error_code: u64) -> !;
+pub type DivergingHandlerFuncWithErrCode =
+    extern "x86-interrupt" fn(&mut InterruptStackFrame, error_code: u64) -> !;
 
 impl<F> Entry<F> {
     /// Creates a non-present IDT entry (but sets the must-be-one bits).

--- a/testing/tests/double_fault_stack_overflow.rs
+++ b/testing/tests/double_fault_stack_overflow.rs
@@ -54,7 +54,7 @@ pub fn init_test_idt() {
 extern "x86-interrupt" fn double_fault_handler(
     _stack_frame: &mut InterruptStackFrame,
     _error_code: u64,
-) {
+) -> ! {
     serial_println!("[ok]");
     exit_qemu(QemuExitCode::Success);
     loop {}


### PR DESCRIPTION
Exceptions such as  double faults and machine check exceptions are classified as "abort", which means that the reported stack frame might be incorrect. It is not allowed to return from such exceptions because it could cause undefined behavior.

This pull request ensures at the type system level that double fault and machine check exceptions can never return. This way, we can prevent such undefined behavior.

Closes #97.

This is a **breaking change**.