### PR TITLE
Add required reexport for new UnusedPhysFrame type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+- Fix: Add required reexport for new UnusedPhysFrame type ([#110](https://github.com/rust-osdev/x86_64/pull/110))
+
 # 0.8.0
 
 - **Breaking:** Replace `ux` dependency with custom wrapper structs ([#91](https://github.com/rust-osdev/x86_64/pull/91))

--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -31,6 +31,7 @@ impl<S: PageSize> UnusedPhysFrame<S> {
         Self(frame)
     }
 
+    /// Returns the physical frame as `PhysFrame` type.
     pub fn frame(self) -> PhysFrame<S> {
         self.0
     }

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -3,7 +3,7 @@
 //! Page tables translate virtual memory “pages” to physical memory “frames”.
 
 pub use self::frame::PhysFrame;
-pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
+pub use self::frame_alloc::{FrameAllocator, FrameDeallocator, UnusedPhysFrame};
 #[doc(no_inline)]
 pub use self::mapper::MappedPageTable;
 pub use self::mapper::{Mapper, MapperAllSizes};


### PR DESCRIPTION
This fixes an issue in the recently released version 0.8.0 that made implementing the `FrameAllocator` trait impossible. The bug was introduced in #89.