### PR TITLE
Add support for cr4 control register (with complete documentation)

### DIFF
--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -62,32 +62,65 @@ bitflags! {
 }
 
 /// Various control flags modifying the basic operation of the CPU while in protected mode.
+///
+/// Note: The documention for the individual fields is taken from the AMD64 and Intel x86_64
+/// manuals.
 #[derive(Debug)]
 pub struct Cr4;
 
 bitflags! {
     /// Controls cache settings for the level 4 page table.
     pub struct Cr4Flags: u64 {
+        /// Enables hardware-supported performance enhancements for software running in
+        /// virtual-8086 mode.
         const VIRTUAL_8086_MODE_EXTENSIONS = 1 << 0;
+        /// Enables support for protected-mode virtual interrupts.
         const PROTECTED_MODE_VIRTUAL_INTERRUPTS = 1 << 1;
+        /// When set, only privilege-level 0 can execute the RDTSC or RDTSCP instructions.
         const TIMESTAMP_DISABLE = 1 << 2;
+        /// Enables I/O breakpoint capability and enforces treatment of DR4 and DR5 registers
+        /// as reserved.
         const DEBUGGING_EXTENSIONS = 1 << 3;
+        /// Enables the use of 4MB physical frames; ignored in long mode.
         const PAGE_SIZE_EXTENSION = 1 << 4;
+        /// Enables physical address extension and 2MB physical frames; required in long mode.
         const PHYSICAL_ADDRESS_EXTENSION = 1 << 5;
+        /// Enables the machine-check exception mechanism.
         const MACHINE_CHECK_EXCEPTION = 1 << 6;
+        /// Enables the global-page mechanism, which allows to make page translations global
+        /// to all processes.
         const PAGE_GLOBAL = 1 << 7;
+        /// Allows software running at any privilege level to use the RDPMC instruction.
         const PERFORMANCE_MONITOR_COUNTER = 1 << 8;
+        /// Enable the use of legacy SSE instructions; allows using FXSAVE/FXRSTOR for saving
+        /// processor state of 128-bit media instructions.
         const OSFXSR = 1 << 9;
+        /// Enables the SIMD floating-point exception (#XF) for handling unmasked 256-bit and
+        /// 128-bit media floating-point errors.
         const OSXMMEXCPT_ENABLE = 1 << 10;
+        /// Prevents the execution of the SGDT, SIDT, SLDT, SMSW, and STR instructions by
+        /// user-mode software.
         const USER_MODE_INSTRUCTION_PREVENTION = 1 << 11;
+        /// Enables 5-level paging on supported CPUs.
         const L5_PAGING = 1 << 12;
+        /// Enables VMX insturctions.
         const VIRTUAL_MACHINE_EXTENSIONS = 1 << 13;
+        /// Enables SMX instructions.
         const SAFER_MODE_EXTENSIONS = 1 << 14;
+        /// Enables software running in 64-bit mode at any privilege level to read and write
+        /// the FS.base and GS.base hidden segment register state.
         const FSGSBASE = 1 << 16;
+        /// Enables process-context identifiers (PCIDs).
         const PCID = 1 << 17;
+        /// Enables extendet processor state management instructions, including XGETBV and XSAVE.
         const OSXSAVE = 1 << 18;
+        /// Prevents the execution of instructions that reside in pages accessible by user-mode
+        /// software when the processor is in supervisor-mode.
         const SUPERVISOR_MODE_EXECUTION_PROTECTION = 1 << 20;
+        /// Enables restrictions for supervisor-mode software when reading data from user-mode
+        /// pages.
         const SUPERVISOR_MODE_ACCESS_PREVENTION = 1 << 21;
+        /// Enables 4-level paging to associate each linear address with a protection key.
         const PROTECTION_KEY = 1 << 22;
     }
 }


### PR DESCRIPTION
This builds upon https://github.com/rust-osdev/x86_64/pull/92 and additionally adds documentation for the CR4 fields.