### PR TITLE
Add p23_insert_flag_mask argument to mapper.map_to()

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -44,15 +44,18 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
         let p4 = &mut self.level_4_table;
-        let p3 = self
-            .page_table_walker
-            .create_next_table(&mut p4[page.p4_index()], allocator)?;
+        let p3 = self.page_table_walker.create_next_table(
+            &mut p4[page.p4_index()],
+            parent_table_flags,
+            allocator,
+        )?;
 
         if !p3[page.p3_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -69,18 +72,23 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         page: Page<Size2MiB>,
         frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
         let p4 = &mut self.level_4_table;
-        let p3 = self
-            .page_table_walker
-            .create_next_table(&mut p4[page.p4_index()], allocator)?;
-        let p2 = self
-            .page_table_walker
-            .create_next_table(&mut p3[page.p3_index()], allocator)?;
+        let p3 = self.page_table_walker.create_next_table(
+            &mut p4[page.p4_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p2 = self.page_table_walker.create_next_table(
+            &mut p3[page.p3_index()],
+            parent_table_flags,
+            allocator,
+        )?;
 
         if !p2[page.p2_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -97,21 +105,28 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         page: Page<Size4KiB>,
         frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
         let p4 = &mut self.level_4_table;
-        let p3 = self
-            .page_table_walker
-            .create_next_table(&mut p4[page.p4_index()], allocator)?;
-        let p2 = self
-            .page_table_walker
-            .create_next_table(&mut p3[page.p3_index()], allocator)?;
-        let p1 = self
-            .page_table_walker
-            .create_next_table(&mut p2[page.p2_index()], allocator)?;
+        let p3 = self.page_table_walker.create_next_table(
+            &mut p4[page.p4_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p2 = self.page_table_walker.create_next_table(
+            &mut p3[page.p3_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p1 = self.page_table_walker.create_next_table(
+            &mut p2[page.p2_index()],
+            parent_table_flags,
+            allocator,
+        )?;
 
         if !p1[page.p1_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -124,17 +139,18 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
 
 impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_1gib(page, frame, flags, allocator)
+        self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -198,17 +214,18 @@ impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
 
 impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size2MiB>,
         frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_2mib(page, frame, flags, allocator)
+        self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -280,17 +297,18 @@ impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
 
 impl<'a, P: PhysToVirt> Mapper<Size4KiB> for MappedPageTable<'a, P> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size4KiB>,
         frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_4kib(page, frame, flags, allocator)
+        self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -461,6 +479,7 @@ impl<P: PhysToVirt> PageTableWalker<P> {
     fn create_next_table<'b, A>(
         &self,
         entry: &'b mut PageTableEntry,
+        insert_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<&'b mut PageTable, PageTableCreateError>
     where
@@ -470,12 +489,15 @@ impl<P: PhysToVirt> PageTableWalker<P> {
 
         if entry.is_unused() {
             if let Some(frame) = allocator.allocate_frame() {
-                entry.set_frame(frame, PageTableFlags::PRESENT | PageTableFlags::WRITABLE);
+                entry.set_frame(frame, insert_flags);
                 created = true;
             } else {
                 return Err(PageTableCreateError::FrameAllocationFailed);
             }
         } else {
+            if !insert_flags.is_empty() && !entry.flags().contains(insert_flags) {
+                entry.set_flags(entry.flags() | insert_flags);
+            }
             created = false;
         }
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -83,6 +83,13 @@ pub trait Mapper<S: PageSize> {
     /// This function might need additional physical frames to create new page tables. These
     /// frames are allocated from the `allocator` argument. At most three frames are required.
     ///
+    /// Parent page table entries are automatically updated with `PRESENT | WRITABLE | USER_ACCESSIBLE`
+    /// if present in the `PageTableFlags`. Depending on the used mapper implementation
+    /// the `PRESENT` and `WRITABLE` flags might be set for parent tables,
+    /// even if they are not set in `PageTableFlags`.
+    ///
+    /// The `map_to_with_table_flags` method gives explicit control over the parent page table flags.
+    ///
     /// ## Safety
     ///
     /// Creating page table mappings is a fundamentally unsafe operation because
@@ -111,11 +118,125 @@ pub trait Mapper<S: PageSize> {
     /// the same in all address spaces, otherwise undefined behavior can occur
     /// because of TLB races. It's worth noting that all the above requirements
     /// also apply to shared mappings, including the aliasing requirements.
+    ///
+    /// # Examples
+    ///
+    /// Create a USER_ACCESSIBLE mapping:
+    ///
+    /// ```
+    /// # use x86_64::structures::paging::{
+    /// #    Mapper, Page, PhysFrame, FrameAllocator,
+    /// #    Size4KiB, OffsetPageTable, page_table::PageTableFlags
+    /// # };
+    /// # unsafe fn test(mapper: &mut OffsetPageTable, frame_allocator: &mut impl FrameAllocator<Size4KiB>,
+    /// #         page: Page<Size4KiB>, frame: PhysFrame) {
+    ///         mapper
+    ///           .map_to(
+    ///               page,
+    ///               frame,
+    ///              PageTableFlags::PRESENT
+    ///                   | PageTableFlags::WRITABLE
+    ///                   | PageTableFlags::USER_ACCESSIBLE,
+    ///               frame_allocator,
+    ///           )
+    ///           .unwrap()
+    ///           .flush();
+    /// # }
+    /// ```
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<S>,
         frame: PhysFrame<S>,
         flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlush<S>, MapToError<S>>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB>,
+    {
+        let parent_table_flags = flags
+            & (PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE);
+
+        self.map_to_with_table_flags(page, frame, flags, parent_table_flags, frame_allocator)
+    }
+
+    /// Creates a new mapping in the page table.
+    ///
+    /// This function might need additional physical frames to create new page tables. These
+    /// frames are allocated from the `allocator` argument. At most three frames are required.
+    ///
+    /// The flags of the parent table(s) can be explicitly specified. Those flags are used for
+    /// newly created table entries, and for existing entries the flags are added.
+    ///
+    /// Depending on the used mapper implementation, the `PRESENT` and `WRITABLE` flags might
+    /// be set for parent tables, even if they are not specified in `parent_table_flags`.
+    ///
+    /// ## Safety
+    ///
+    /// Creating page table mappings is a fundamentally unsafe operation because
+    /// there are various ways to break memory safety through it. For example,
+    /// re-mapping an in-use page to a different frame changes and invalidates
+    /// all values stored in that page, resulting in undefined behavior on the
+    /// next use.
+    ///
+    /// The caller must ensure that no undefined behavior or memory safety
+    /// violations can occur through the new mapping. Among other things, the
+    /// caller must prevent the following:
+    ///
+    /// - Aliasing of `&mut` references, i.e. two `&mut` references that point to
+    ///   the same physical address. This is undefined behavior in Rust.
+    ///     - This can be ensured by mapping each page to an individual physical
+    ///       frame that is not mapped anywhere else.
+    /// - Creating uninitalized or invalid values: Rust requires that all values
+    ///   have a correct memory layout. For example, a `bool` must be either a 0
+    ///   or a 1 in memory, but not a 3 or 4. An exception is the `MaybeUninit`
+    ///   wrapper type, which abstracts over possibly uninitialized memory.
+    ///     - This is only a problem when re-mapping pages to different physical
+    ///       frames. Mapping a page that is not in use yet is fine.
+    ///
+    /// Special care must be taken when sharing pages with other address spaces,
+    /// e.g. by setting the `GLOBAL` flag. For example, a global mapping must be
+    /// the same in all address spaces, otherwise undefined behavior can occur
+    /// because of TLB races. It's worth noting that all the above requirements
+    /// also apply to shared mappings, including the aliasing requirements.
+    ///
+    /// # Examples
+    ///
+    /// Create USER_ACCESSIBLE | NO_EXECUTE | NO_CACHE mapping and update
+    /// the top hierarchy only with USER_ACCESSIBLE:
+    ///
+    /// ```
+    /// # use x86_64::structures::paging::{
+    /// #    Mapper, PhysFrame, Page, FrameAllocator,
+    /// #    Size4KiB, OffsetPageTable, page_table::PageTableFlags
+    /// # };
+    /// # unsafe fn test(mapper: &mut OffsetPageTable, frame_allocator: &mut impl FrameAllocator<Size4KiB>,
+    /// #         page: Page<Size4KiB>, frame: PhysFrame) {
+    ///         mapper
+    ///           .map_to_with_table_flags(
+    ///               page,
+    ///               frame,
+    ///              PageTableFlags::PRESENT
+    ///                   | PageTableFlags::WRITABLE
+    ///                   | PageTableFlags::USER_ACCESSIBLE
+    ///                   | PageTableFlags::NO_EXECUTE
+    ///                   | PageTableFlags::NO_CACHE,
+    ///              PageTableFlags::USER_ACCESSIBLE,
+    ///               frame_allocator,
+    ///           )
+    ///           .unwrap()
+    ///           .flush();
+    /// # }
+    /// ```
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<S>,
+        frame: PhysFrame<S>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         frame_allocator: &mut A,
     ) -> Result<MapperFlush<S>, MapToError<S>>
     where

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -89,6 +89,33 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
+    }
+
+    #[inline]
     fn translate_page(&self, page: Page<Size1GiB>) -> Result<PhysFrame<Size1GiB>, TranslateError> {
         self.inner.translate_page(page)
     }
@@ -129,6 +156,33 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
+    }
+
+    #[inline]
     fn translate_page(&self, page: Page<Size2MiB>) -> Result<PhysFrame<Size2MiB>, TranslateError> {
         self.inner.translate_page(page)
     }
@@ -166,6 +220,33 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         flags: PageTableFlags,
     ) -> Result<MapperFlush<Size4KiB>, FlagUpdateError> {
         self.inner.update_flags(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
     }
 
     #[inline]

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -1,6 +1,8 @@
 #![cfg(target_arch = "x86_64")]
 
-use crate::structures::paging::{frame::PhysFrame, mapper::*, page_table::PageTable};
+use crate::structures::paging::{
+    frame::PhysFrame, mapper::*, page_table::PageTable, Page, PageTableFlags,
+};
 
 /// A Mapper implementation that requires that the complete physically memory is mapped at some
 /// offset in the virtual address space.
@@ -54,17 +56,19 @@ impl PhysToVirt for PhysOffset {
 
 impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.inner.map_to(page, frame, flags, allocator)
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
     }
 
     #[inline]
@@ -92,17 +96,19 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
 
 impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size2MiB>,
         frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.inner.map_to(page, frame, flags, allocator)
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
     }
 
     #[inline]
@@ -130,17 +136,19 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
 
 impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size4KiB>,
         frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.inner.map_to(page, frame, flags, allocator)
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
     }
 
     #[inline]

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -26,6 +26,9 @@ use crate::VirtAddr;
 ///   level 3 index, then the level 2 index.
 ///
 /// This struct implements the `Mapper` trait.
+///
+/// The page table flags `PRESENT` and `WRITABLE` are always set for higher level page table
+/// entries, even if not specified, because the design of the recursive page table requires it.
 #[derive(Debug)]
 pub struct RecursivePageTable<'a> {
     p4: &'a mut PageTable,
@@ -84,6 +87,10 @@ impl<'a> RecursivePageTable<'a> {
     /// and the entry is updated to that address. If the passed entry is already mapped, the next
     /// table is returned directly.
     ///
+    /// The page table flags `PRESENT` and `WRITABLE` are always set for higher level page table
+    /// entries, even if not specified in the `insert_flags`, because the design of the
+    /// recursive page table requires it.
+    ///
     /// The `next_page_table` page must be the page of the next page table in the hierarchy.
     ///
     /// Returns `MapToError::FrameAllocationFailed` if the entry is unused and the allocator
@@ -92,6 +99,7 @@ impl<'a> RecursivePageTable<'a> {
     unsafe fn create_next_table<'b, A, S: PageSize>(
         entry: &'b mut PageTableEntry,
         next_table_page: Page,
+        insert_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<&'b mut PageTable, MapToError<S>>
     where
@@ -103,6 +111,7 @@ impl<'a> RecursivePageTable<'a> {
         fn inner<'b, A, S: PageSize>(
             entry: &'b mut PageTableEntry,
             next_table_page: Page,
+            insert_flags: PageTableFlags,
             allocator: &mut A,
         ) -> Result<&'b mut PageTable, MapToError<S>>
         where
@@ -114,12 +123,15 @@ impl<'a> RecursivePageTable<'a> {
 
             if entry.is_unused() {
                 if let Some(frame) = allocator.allocate_frame() {
-                    entry.set_frame(frame, Flags::PRESENT | Flags::WRITABLE);
+                    entry.set_frame(frame, Flags::PRESENT | Flags::WRITABLE | insert_flags);
                     created = true;
                 } else {
                     return Err(MapToError::FrameAllocationFailed);
                 }
             } else {
+                if !insert_flags.is_empty() && !entry.flags().contains(insert_flags) {
+                    entry.set_flags(entry.flags() | insert_flags);
+                }
                 created = false;
             }
             if entry.flags().contains(Flags::HUGE_PAGE) {
@@ -134,7 +146,7 @@ impl<'a> RecursivePageTable<'a> {
             Ok(page_table)
         }
 
-        inner(entry, next_table_page, allocator)
+        inner(entry, next_table_page, insert_flags, allocator)
     }
 
     /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
@@ -144,6 +156,7 @@ impl<'a> RecursivePageTable<'a> {
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
@@ -153,7 +166,14 @@ impl<'a> RecursivePageTable<'a> {
         let p4 = &mut self.p4;
 
         let p3_page = p3_page(page, self.recursive_index);
-        let p3 = unsafe { Self::create_next_table(&mut p4[page.p4_index()], p3_page, allocator)? };
+        let p3 = unsafe {
+            Self::create_next_table(
+                &mut p4[page.p4_index()],
+                p3_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         if !p3[page.p3_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -170,6 +190,7 @@ impl<'a> RecursivePageTable<'a> {
         page: Page<Size2MiB>,
         frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
@@ -179,10 +200,24 @@ impl<'a> RecursivePageTable<'a> {
         let p4 = &mut self.p4;
 
         let p3_page = p3_page(page, self.recursive_index);
-        let p3 = unsafe { Self::create_next_table(&mut p4[page.p4_index()], p3_page, allocator)? };
+        let p3 = unsafe {
+            Self::create_next_table(
+                &mut p4[page.p4_index()],
+                p3_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         let p2_page = p2_page(page, self.recursive_index);
-        let p2 = unsafe { Self::create_next_table(&mut p3[page.p3_index()], p2_page, allocator)? };
+        let p2 = unsafe {
+            Self::create_next_table(
+                &mut p3[page.p3_index()],
+                p2_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         if !p2[page.p2_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -199,6 +234,7 @@ impl<'a> RecursivePageTable<'a> {
         page: Page<Size4KiB>,
         frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
@@ -207,13 +243,34 @@ impl<'a> RecursivePageTable<'a> {
         let p4 = &mut self.p4;
 
         let p3_page = p3_page(page, self.recursive_index);
-        let p3 = unsafe { Self::create_next_table(&mut p4[page.p4_index()], p3_page, allocator)? };
+        let p3 = unsafe {
+            Self::create_next_table(
+                &mut p4[page.p4_index()],
+                p3_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         let p2_page = p2_page(page, self.recursive_index);
-        let p2 = unsafe { Self::create_next_table(&mut p3[page.p3_index()], p2_page, allocator)? };
+        let p2 = unsafe {
+            Self::create_next_table(
+                &mut p3[page.p3_index()],
+                p2_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         let p1_page = p1_page(page, self.recursive_index);
-        let p1 = unsafe { Self::create_next_table(&mut p2[page.p2_index()], p1_page, allocator)? };
+        let p1 = unsafe {
+            Self::create_next_table(
+                &mut p2[page.p2_index()],
+                p1_page,
+                parent_table_flags,
+                allocator,
+            )?
+        };
 
         if !p1[page.p1_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
@@ -226,17 +283,18 @@ impl<'a> RecursivePageTable<'a> {
 
 impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_1gib(page, frame, flags, allocator)
+        self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -314,17 +372,18 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
 
 impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size2MiB>,
         frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_2mib(page, frame, flags, allocator)
+        self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -422,17 +481,18 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
 
 impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
     #[inline]
-    unsafe fn map_to<A>(
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size4KiB>,
         frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
-        self.map_to_4kib(page, frame, flags, allocator)
+        self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -351,6 +351,39 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         Ok(MapperFlush::new(page))
     }
 
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+        let p4_entry = &mut p4[page.p4_index()];
+
+        if p4_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p4_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
+    }
+
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        _page: Page<Size1GiB>,
+        _flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        Err(FlagUpdateError::ParentEntryHugePage)
+    }
+
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        _page: Page<Size1GiB>,
+        _flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        Err(FlagUpdateError::ParentEntryHugePage)
+    }
+
     fn translate_page(&self, page: Page<Size1GiB>) -> Result<PhysFrame<Size1GiB>, TranslateError> {
         let p4 = &self.p4;
 
@@ -451,6 +484,54 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         p2[page.p2_index()].set_flags(flags | Flags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
+    }
+
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+        let p4_entry = &mut p4[page.p4_index()];
+
+        if p4_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p4_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
+    }
+
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+        let p3_entry = &mut p3[page.p3_index()];
+
+        if p3_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p3_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
+    }
+
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        _page: Page<Size2MiB>,
+        _flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        Err(FlagUpdateError::ParentEntryHugePage)
     }
 
     fn translate_page(&self, page: Page<Size2MiB>) -> Result<PhysFrame<Size2MiB>, TranslateError> {
@@ -566,6 +647,75 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         p1[page.p1_index()].set_flags(flags);
 
         Ok(MapperFlush::new(page))
+    }
+
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+        let p4_entry = &mut p4[page.p4_index()];
+
+        if p4_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p4_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
+    }
+
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+        let p3_entry = &mut p3[page.p3_index()];
+
+        if p3_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p3_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
+    }
+
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        let p4 = &mut self.p4;
+
+        if p4[page.p4_index()].is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+
+        if p3[page.p3_index()].is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        let p2 = &mut *(p2_ptr(page, self.recursive_index));
+        let p2_entry = &mut p2[page.p2_index()];
+
+        if p2_entry.is_unused() {
+            return Err(FlagUpdateError::PageNotMapped);
+        }
+
+        p2_entry.set_flags(flags);
+
+        Ok(MapperFlushAll::new())
     }
 
     fn translate_page(&self, page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, TranslateError> {


### PR DESCRIPTION
It will update the parent hierarchy tables with (flags & p23_insert_flag_mask).

```rust
    mapper
        .map_to(
            page,
            frame,
            PageTableFlags::PRESENT
                | PageTableFlags::WRITABLE
                | PageTableFlags::USER_ACCESSIBLE,
            PageTableFlags::USER_ACCESSIBLE,
            frame_allocator,
        )
        .unwrap()
        .flush();

```

will update the hierarchy with `PageTableFlags::USER_ACCESSIBLE`. If the
flags would not contain `USER_ACCESSIBLE`, the hierarchy would not be
updated.

If you don't want any updates, pass `PageTableFlags::empty()` as the
mask.

Fixes #113 

_Edit (phil-opp)_: This is a **breaking change**.