### PR TITLE
Make more functions const.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ edition = "2018"
 [dependencies]
 bit_field = "0.9.0"
 bitflags = "1.0.4"
-array-init = "0.0.4"
 
 [dependencies.cast]
 version = "0.2.2"

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -71,6 +71,10 @@ impl VirtAddr {
     /// bits 48 to 64 are overwritten. If you want to check that these bits contain no data,
     /// use `new` or `try_new`.
     pub const fn new_unchecked(addr: u64) -> VirtAddr {
+        // Rust doesn't accept shift operators in const functions at the moment,
+        // so we use a multiplication and division by 0x1_0000 instead of `<< 16` and `>> 16`.
+        // By doing the right shift as a signed operation (on a i64), it will
+        // sign extend the value, repeating the leftmost bit.
         VirtAddr((addr.wrapping_mul(0x1_0000) as i64 / 0x1_0000) as u64)
     }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -70,13 +70,8 @@ impl VirtAddr {
     /// This function performs sign extension of bit 47 to make the address canonical, so
     /// bits 48 to 64 are overwritten. If you want to check that these bits contain no data,
     /// use `new` or `try_new`.
-    pub fn new_unchecked(mut addr: u64) -> VirtAddr {
-        if addr.get_bit(47) {
-            addr.set_bits(48..64, 0xffff);
-        } else {
-            addr.set_bits(48..64, 0);
-        }
-        VirtAddr(addr)
+    pub const fn new_unchecked(addr: u64) -> VirtAddr {
+        VirtAddr((addr.wrapping_mul(0x1_0000) as i64 / 0x1_0000) as u64)
     }
 
     /// Creates a virtual address that points to `0`.
@@ -85,7 +80,7 @@ impl VirtAddr {
     }
 
     /// Converts the address to an `u64`.
-    pub fn as_u64(self) -> u64 {
+    pub const fn as_u64(self) -> u64 {
         self.0
     }
 
@@ -416,6 +411,14 @@ pub fn align_up(addr: u64, align: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    pub fn virtaddr_new_unchecked() {
+        assert_eq!(VirtAddr::new_unchecked(0), VirtAddr(0));
+        assert_eq!(VirtAddr::new_unchecked(1 << 47), VirtAddr(0xfffff << 47));
+        assert_eq!(VirtAddr::new_unchecked(123), VirtAddr(123));
+        assert_eq!(VirtAddr::new_unchecked(123 << 47), VirtAddr(0xfffff << 47));
+    }
 
     #[test]
     pub fn test_align_up() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![feature(const_fn)]
 #![feature(asm)]
 #![feature(abi_x86_interrupt)]
+#![feature(const_in_array_repeat_expressions)]
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -88,7 +88,7 @@ pub struct GlobalDescriptorTable {
 
 impl GlobalDescriptorTable {
     /// Creates an empty GDT.
-    pub fn new() -> GlobalDescriptorTable {
+    pub const fn new() -> GlobalDescriptorTable {
         GlobalDescriptorTable {
             table: [0; 8],
             next_free: 1,

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -27,12 +27,12 @@ pub struct PageTableEntry {
 
 impl PageTableEntry {
     /// Creates an unused page table entry.
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         PageTableEntry { entry: 0 }
     }
 
     /// Returns whether this entry is zero.
-    pub fn is_unused(&self) -> bool {
+    pub const fn is_unused(&self) -> bool {
         self.entry == 0
     }
 
@@ -42,7 +42,7 @@ impl PageTableEntry {
     }
 
     /// Returns the flags of this entry.
-    pub fn flags(&self) -> PageTableFlags {
+    pub const fn flags(&self) -> PageTableFlags {
         PageTableFlags::from_bits_truncate(self.entry)
     }
 
@@ -176,11 +176,9 @@ pub struct PageTable {
 
 impl PageTable {
     /// Creates an empty page table.
-    pub fn new() -> Self {
-        use array_init::array_init;
-
+    pub const fn new() -> Self {
         PageTable {
-            entries: array_init(|_| PageTableEntry::new()),
+            entries: [PageTableEntry::new(); ENTRY_COUNT],
         }
     }
 


### PR DESCRIPTION
Other than just adding `const` a few times, this:

- Replaces the `array_init` dependency by the `const_in_array_repeat_expressions` feature.

- Implements `VirtAddr::new_unchecked` using a multiply and divide instead of `set_bits` in an if. (Bonus: Resulting assembly is much much shorter.)