### PR TITLE
Return the UnusedPhysFrame on MapToError::PageAlreadyMapped

### DIFF
--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -88,7 +88,7 @@ pub trait Mapper<S: PageSize> {
         frame: UnusedPhysFrame<S>,
         flags: PageTableFlags,
         frame_allocator: &mut A,
-    ) -> Result<MapperFlush<S>, MapToError>
+    ) -> Result<MapperFlush<S>, MapToError<S>>
     where
         Self: Sized,
         A: FrameAllocator<Size4KiB>;
@@ -117,7 +117,7 @@ pub trait Mapper<S: PageSize> {
         frame: UnusedPhysFrame<S>,
         flags: PageTableFlags,
         frame_allocator: &mut A,
-    ) -> Result<MapperFlush<S>, MapToError>
+    ) -> Result<MapperFlush<S>, MapToError<S>>
     where
         Self: Sized,
         A: FrameAllocator<Size4KiB>,
@@ -156,7 +156,7 @@ impl<S: PageSize> MapperFlush<S> {
 
 /// This error is returned from `map_to` and similar methods.
 #[derive(Debug)]
-pub enum MapToError {
+pub enum MapToError<S: PageSize> {
     /// An additional frame was needed for the mapping process, but the frame allocator
     /// returned `None`.
     FrameAllocationFailed,
@@ -164,7 +164,7 @@ pub enum MapToError {
     /// given page is part of an already mapped huge page.
     ParentEntryHugePage,
     /// The given page is already mapped to a physical frame.
-    PageAlreadyMapped,
+    PageAlreadyMapped(UnusedPhysFrame<S>),
 }
 
 /// An error indicating that an `unmap` call failed.

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -55,7 +55,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         frame: UnusedPhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
-    ) -> Result<MapperFlush<Size1GiB>, MapToError>
+    ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
@@ -89,7 +89,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         frame: UnusedPhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
-    ) -> Result<MapperFlush<Size2MiB>, MapToError>
+    ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {
@@ -123,7 +123,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         frame: UnusedPhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
-    ) -> Result<MapperFlush<Size4KiB>, MapToError>
+    ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
         A: FrameAllocator<Size4KiB>,
     {


### PR DESCRIPTION
The UnusedPhysFrame might want to be used otherwise.

This is a **breaking change**.

Fixes https://github.com/rust-osdev/x86_64/issues/117