### PR TITLE
Remove the `cast` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,5 @@ edition = "2018"
 bit_field = "0.9.0"
 bitflags = "1.0.4"
 
-[dependencies.cast]
-version = "0.2.2"
-default-features = false
-
 [features]
 deny-warnings = []

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -89,13 +89,13 @@ impl VirtAddr {
 
     /// Creates a virtual address from the given pointer
     pub fn from_ptr<T>(ptr: *const T) -> Self {
-        Self::new(cast::u64(ptr as usize))
+        Self::new(ptr as u64)
     }
 
     /// Converts the address to a raw pointer.
     #[cfg(target_pointer_width = "64")]
     pub fn as_ptr<T>(self) -> *const T {
-        cast::usize(self.as_u64()) as *const T
+        self.as_u64() as *const T
     }
 
     /// Converts the address to a mutable raw pointer.
@@ -181,14 +181,14 @@ impl AddAssign<u64> for VirtAddr {
 impl Add<usize> for VirtAddr {
     type Output = Self;
     fn add(self, rhs: usize) -> Self::Output {
-        self + cast::u64(rhs)
+        self + rhs as u64
     }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl AddAssign<usize> for VirtAddr {
     fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(cast::u64(rhs))
+        self.add_assign(rhs as u64)
     }
 }
 
@@ -209,14 +209,14 @@ impl SubAssign<u64> for VirtAddr {
 impl Sub<usize> for VirtAddr {
     type Output = Self;
     fn sub(self, rhs: usize) -> Self::Output {
-        self - cast::u64(rhs)
+        self - rhs as u64
     }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl SubAssign<usize> for VirtAddr {
     fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(cast::u64(rhs))
+        self.sub_assign(rhs as u64)
     }
 }
 
@@ -347,14 +347,14 @@ impl AddAssign<u64> for PhysAddr {
 impl Add<usize> for PhysAddr {
     type Output = Self;
     fn add(self, rhs: usize) -> Self::Output {
-        self + cast::u64(rhs)
+        self + rhs as u64
     }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl AddAssign<usize> for PhysAddr {
     fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(cast::u64(rhs))
+        self.add_assign(rhs as u64)
     }
 }
 
@@ -375,14 +375,14 @@ impl SubAssign<u64> for PhysAddr {
 impl Sub<usize> for PhysAddr {
     type Output = Self;
     fn sub(self, rhs: usize) -> Self::Output {
-        self - cast::u64(rhs)
+        self - rhs as u64
     }
 }
 
 #[cfg(target_pointer_width = "64")]
 impl SubAssign<usize> for PhysAddr {
     fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(cast::u64(rhs))
+        self.sub_assign(rhs as u64)
     }
 }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -88,6 +88,11 @@ impl VirtAddr {
     }
 
     /// Creates a virtual address from the given pointer
+    // cfg(target_pointer_width = "32") is only here for backwards
+    // compatibility: Earlier versions of this crate did not have any `cfg()`
+    // on this function. At least for 32- and 64-bit we know the `as u64` cast
+    // doesn't truncate.
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
     pub fn from_ptr<T>(ptr: *const T) -> Self {
         Self::new(ptr as u64)
     }


### PR DESCRIPTION
It was only used between usize and u64 in parts of the code that were
marked with `#[cfg(target_pointer_width = "64")]`, which guarantees
usize is 64 bits.

See #90.