### PR TITLE
Fix GitHub actions to run latest available rustfmt.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,13 +115,5 @@ jobs:
     timeout-minutes: 2
     steps:
     - uses: actions/checkout@v1
-    - name: Set Rustup profile to minimal
-      run: rustup set profile minimal
-    - name: "Add a rustup override for rustfmt nightly"
-      uses: actions-rs/toolchain@v1
-      with:
-          toolchain: nightly
-          components: rustfmt
-          override: true
-    - run: rustup component add rustfmt
-    - run: cargo fmt -- --check
+    - run: rustup install nightly
+    - run: cargo +nightly fmt -- --check


### PR DESCRIPTION
It tried to use rustfmt from the latest nightly, but nightly doesn't always include rustfmt. By using rustup to install the default profile of nightly, it automatically looks for the latest nightly that includes rustfmt.