### PR TITLE
enable usage with non-nightly rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,16 @@ jobs:
     - name: "Run cargo build"
       run: cargo build
 
+    - name: "Run cargo build for stable"
+      run: cargo build --no-default-features --features stable
+      if: runner.os != 'Windows'
+
     - name: "Run cargo test"
       run: cargo test
+
+    - name: "Run cargo test for stable"
+      run: cargo test --no-default-features --features stable
+      if: runner.os != 'Windows'
 
     - name: 'Deny Warnings'
       run: cargo build --features deny-warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,16 @@ edition = "2018"
 [dependencies]
 bit_field = "0.9.0"
 bitflags = "1.0.4"
+array-init = { version = "0.1.1", optional = true }
+
+[build-dependencies]
+cc = { version = "1.0.37", optional = true }
 
 [features]
+default = [ "nightly" ]
 deny-warnings = []
+stable = [ "cc", "array-init" ]
+nightly = [ "inline_asm", "const_fn", "abi_x86_interrupt" ]
+inline_asm = []
+abi_x86_interrupt = []
+const_fn = []

--- a/README.md
+++ b/README.md
@@ -3,3 +3,13 @@
 [![Build Status](https://github.com/rust-osdev/x86_64/workflows/Build/badge.svg)](https://github.com/rust-osdev/x86_64/actions?query=workflow%3ABuild) [![docs.rs](https://img.shields.io/badge/docs.rs-documentation-green.svg)](https://docs.rs/x86_64)
 
 Support for x86_64 specific instructions (e.g. TLB flush), registers (e.g. control registers), and structures (e.g. page tables).
+
+## Crate Feature Flags
+
+* `nightly`: This is the default.
+* `stable`: Use this to build with non-nightly rust. Needs `default-features = false`.
+
+## Building with stable rust
+
+This needs to have the [compile-time requirements](https://github.com/alexcrichton/cc-rs#compile-time-requirements) of the `cc` crate installed on your system.
+It was currently only tested on Linux and MacOS.

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,40 @@
+#[cfg(feature = "inline_asm")]
+fn main() {}
+
+#[cfg(all(not(feature = "inline_asm"), not(feature = "stable")))]
+fn check_inline_asm() {
+    compile_error!("Neither feature \"stable\" nor \"inline_asm\" was set!");
+}
+
+#[cfg(all(not(feature = "inline_asm"), feature = "stable"))]
+fn main() {
+    use std::ffi::OsString;
+    use std::fs;
+
+    println!("cargo:rerun-if-changed=build.rs");
+
+    let entries = fs::read_dir("src/asm")
+        .unwrap()
+        .filter_map(|f| {
+            f.ok().and_then(|e| {
+                let path = e.path();
+                match path.extension() {
+                    Some(ext) if ext.eq(&OsString::from("s")) => Some(path),
+                    _ => None,
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+
+    cc::Build::new()
+        .no_default_flags(true)
+        .files(&entries)
+        .pic(true)
+        .static_flag(true)
+        .shared_flag(false)
+        .compile("x86_64_asm");
+
+    for e in entries {
+        println!("cargo:rerun-if-changed={}", e.to_str().unwrap());
+    }
+}

--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -1,0 +1,228 @@
+.text
+.code64
+
+.global _x86_64_asm_interrupt_enable
+.p2align 4
+_x86_64_asm_interrupt_enable:
+    sti
+    retq
+
+.global _x86_64_asm_interrupt_disable
+.p2align 4
+_x86_64_asm_interrupt_disable:
+    cli
+    retq
+
+.global _x86_64_asm_int3
+.p2align 4
+_x86_64_asm_int3:
+    int3
+    retq
+
+.global _x86_64_asm_read_from_port_u8
+.p2align 4
+_x86_64_asm_read_from_port_u8:
+    mov    %edi, %edx
+    inb    (%dx), %al
+    retq
+
+.global _x86_64_asm_read_from_port_u16
+.p2align 4
+_x86_64_asm_read_from_port_u16:
+    mov    %edi, %edx
+    inw    (%dx), %ax
+    retq
+
+.global _x86_64_asm_read_from_port_u32
+.p2align 4
+_x86_64_asm_read_from_port_u32:
+    mov    %edi, %edx
+    inl    (%dx), %eax
+    retq
+
+
+.global _x86_64_asm_write_to_port_u8
+.p2align 4
+_x86_64_asm_write_to_port_u8:
+    mov    %edi, %edx
+    mov    %si, %ax
+    outb   %al, (%dx)
+    retq
+
+.global _x86_64_asm_write_to_port_u16
+.p2align 4
+_x86_64_asm_write_to_port_u16:
+    mov    %edi, %edx
+    mov    %si, %ax
+    outw   %ax, (%dx)
+    retq
+
+.global _x86_64_asm_write_to_port_u32
+.p2align 4
+_x86_64_asm_write_to_port_u32:
+    mov    %edi, %edx
+    mov    %esi, %eax
+    outl   %eax, (%dx)
+    retq
+
+.global _x86_64_asm_set_cs
+.p2align 4
+_x86_64_asm_set_cs:
+    pushq %rdi
+    leaq  1f(%rip), %rax
+    pushq %rax
+    lretq
+1:
+    retq
+
+.global _x86_64_asm_get_cs
+.p2align 4
+_x86_64_asm_get_cs:
+    mov %cs, %ax
+    retq
+
+.global _x86_64_asm_invlpg
+.p2align 4
+_x86_64_asm_invlpg:
+    invlpg (%rdi)
+    retq
+
+.global _x86_64_asm_ltr
+.p2align 4
+_x86_64_asm_ltr:
+    mov %edi, %edx
+    ltr %dx
+    retq
+
+.global _x86_64_asm_lgdt
+.p2align 4
+_x86_64_asm_lgdt:
+    lgdt (%rdi)
+    retq
+
+.global _x86_64_asm_lidt
+.p2align 4
+_x86_64_asm_lidt:
+    lidt (%rdi)
+    retq
+
+.global _x86_64_asm_write_rflags
+.p2align 4
+_x86_64_asm_write_rflags:
+    pushq %rdi
+    popfq
+    retq
+
+.global _x86_64_asm_read_rflags
+.p2align 4
+_x86_64_asm_read_rflags:
+    pushq   %rbp
+    movq    %rsp, %rbp
+    pushfq
+    popq    %rax
+    popq    %rbp
+    retq
+
+.global _x86_64_asm_load_ss
+.p2align 4
+_x86_64_asm_load_ss:
+    mov %di, %ss
+    retq
+
+.global _x86_64_asm_load_ds
+.p2align 4
+_x86_64_asm_load_ds:
+    mov %di, %ds
+    retq
+
+.global _x86_64_asm_load_es
+.p2align 4
+_x86_64_asm_load_es:
+    mov %di, %es
+    retq
+
+.global _x86_64_asm_load_fs
+.p2align 4
+_x86_64_asm_load_fs:
+    mov %di, %fs
+    retq
+
+.global _x86_64_asm_load_gs
+.p2align 4
+_x86_64_asm_load_gs:
+    mov %di, %gs
+    retq
+
+.global _x86_64_asm_swapgs
+.p2align 4
+_x86_64_asm_swapgs:
+    swapgs
+    retq
+
+.global _x86_64_asm_read_cr0
+.p2align 4
+_x86_64_asm_read_cr0:
+    movq %cr0, %rax
+    retq
+
+.global _x86_64_asm_read_cr2
+.p2align 4
+_x86_64_asm_read_cr2:
+    movq %cr2, %rax
+    retq
+
+.global _x86_64_asm_read_cr3
+.p2align 4
+_x86_64_asm_read_cr3:
+    movq %cr3, %rax
+    retq
+
+.global _x86_64_asm_read_cr4
+.p2align 4
+_x86_64_asm_read_cr4:
+    movq %cr4, %rax
+    retq
+
+.global _x86_64_asm_write_cr0
+.p2align 4
+_x86_64_asm_write_cr0:
+    movq %rdi, %cr0
+    retq
+
+.global _x86_64_asm_write_cr3
+.p2align 4
+_x86_64_asm_write_cr3:
+    movq %rdi, %cr3
+    retq
+
+.global _x86_64_asm_write_cr4
+.p2align 4
+_x86_64_asm_write_cr4:
+    movq %rdi, %cr4
+    retq
+
+.global _x86_64_asm_rdmsr
+.p2align 4
+_x86_64_asm_rdmsr:
+    mov   %edi,%ecx
+    rdmsr
+    shl    $0x20,%rdx   # shift edx to upper 32bit
+    mov    %eax,%eax    # clear upper 32bit of rax
+    or     %rdx,%rax    # or with rdx
+    retq
+
+.global _x86_64_asm_wrmsr
+.p2align 4
+_x86_64_asm_wrmsr:
+    mov   %edi,%ecx
+    movq  %rsi,%rax
+    movq  %rsi,%rdx
+    shr   $0x20,%rdx
+    wrmsr
+    retq
+
+.global _x86_64_asm_hlt
+.p2align 4
+_x86_64_asm_hlt:
+    hlt
+    retq

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,0 +1,69 @@
+#[link(name = "x86_64_asm", kind = "static")]
+extern "C" {
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_interrupt_enable")]
+    pub(crate) fn x86_64_asm_interrupt_enable();
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_interrupt_disable")]
+    pub(crate) fn x86_64_asm_interrupt_disable();
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_int3")]
+    pub(crate) fn x86_64_asm_int3();
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_hlt")]
+    pub(crate) fn x86_64_asm_hlt();
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u8")]
+    pub(crate) fn x86_64_asm_read_from_port_u8(port: u16) -> u8;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u16")]
+    pub(crate) fn x86_64_asm_read_from_port_u16(port: u16) -> u16;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u32")]
+    pub(crate) fn x86_64_asm_read_from_port_u32(port: u16) -> u32;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u8")]
+    pub(crate) fn x86_64_asm_write_to_port_u8(port: u16, value: u8);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u16")]
+    pub(crate) fn x86_64_asm_write_to_port_u16(port: u16, value: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u32")]
+    pub(crate) fn x86_64_asm_write_to_port_u32(port: u16, value: u32);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_set_cs")]
+    pub(crate) fn x86_64_asm_set_cs(sel: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_ss")]
+    pub(crate) fn x86_64_asm_load_ss(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_ds")]
+    pub(crate) fn x86_64_asm_load_ds(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_es")]
+    pub(crate) fn x86_64_asm_load_es(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_fs")]
+    pub(crate) fn x86_64_asm_load_fs(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_gs")]
+    pub(crate) fn x86_64_asm_load_gs(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_swapgs")]
+    pub(crate) fn x86_64_asm_swapgs();
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_get_cs")]
+    pub(crate) fn x86_64_asm_get_cs() -> u16;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_lgdt")]
+    pub(crate) fn x86_64_asm_lgdt(gdt: *const crate::instructions::tables::DescriptorTablePointer);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_lidt")]
+    pub(crate) fn x86_64_asm_lidt(idt: *const crate::instructions::tables::DescriptorTablePointer);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_ltr")]
+    pub(crate) fn x86_64_asm_ltr(sel: u16);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_invlpg")]
+    pub(crate) fn x86_64_asm_invlpg(addr: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr0")]
+    pub(crate) fn x86_64_asm_read_cr0() -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr0")]
+    pub(crate) fn x86_64_asm_write_cr0(value: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr2")]
+    pub(crate) fn x86_64_asm_read_cr2() -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr3")]
+    pub(crate) fn x86_64_asm_read_cr3() -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr3")]
+    pub(crate) fn x86_64_asm_write_cr3(value: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr4")]
+    pub(crate) fn x86_64_asm_read_cr4() -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr4")]
+    pub(crate) fn x86_64_asm_write_cr4(value: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_rdmsr")]
+    pub(crate) fn x86_64_asm_rdmsr(msr: u32) -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_wrmsr")]
+    pub(crate) fn x86_64_asm_wrmsr(msr: u32, value: u64);
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_rflags")]
+    pub(crate) fn x86_64_asm_read_rflags() -> u64;
+    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_rflags")]
+    pub(crate) fn x86_64_asm_write_rflags(val: u64);
+}

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -12,13 +12,20 @@ pub mod tlb;
 /// Halts the CPU until the next interrupt arrives.
 #[inline]
 pub fn hlt() {
+    #[cfg(feature = "inline_asm")]
     unsafe {
         asm!("hlt" :::: "volatile");
+    }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe {
+        crate::asm::x86_64_asm_hlt();
     }
 }
 
 /// Emits a '[magic breakpoint](https://wiki.osdev.org/Bochs#Magic_Breakpoint)' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
 /// emulator. Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
+#[cfg(feature = "inline_asm")]
 #[inline]
 pub fn bochs_breakpoint() {
     unsafe {

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -5,50 +5,86 @@ use core::marker::PhantomData;
 pub use crate::structures::port::{PortRead, PortReadWrite, PortWrite};
 
 impl PortRead for u8 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn read_from_port(port: u16) -> u8 {
         let value: u8;
         asm!("inb $1, $0" : "={al}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn read_from_port(port: u16) -> u8 {
+        crate::asm::x86_64_asm_read_from_port_u8(port)
+    }
 }
 
 impl PortRead for u16 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn read_from_port(port: u16) -> u16 {
         let value: u16;
         asm!("inw $1, $0" : "={ax}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn read_from_port(port: u16) -> u16 {
+        crate::asm::x86_64_asm_read_from_port_u16(port)
+    }
 }
 
 impl PortRead for u32 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn read_from_port(port: u16) -> u32 {
         let value: u32;
         asm!("inl $1, $0" : "={eax}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn read_from_port(port: u16) -> u32 {
+        crate::asm::x86_64_asm_read_from_port_u32(port)
+    }
 }
 
 impl PortWrite for u8 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u8) {
         asm!("outb $1, $0" :: "N{dx}"(port), "{al}"(value) :: "volatile");
     }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn write_to_port(port: u16, value: u8) {
+        crate::asm::x86_64_asm_write_to_port_u8(port, value)
+    }
 }
 
 impl PortWrite for u16 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u16) {
         asm!("outw $1, $0" :: "N{dx}"(port), "{ax}"(value) :: "volatile");
     }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn write_to_port(port: u16, value: u16) {
+        crate::asm::x86_64_asm_write_to_port_u16(port, value)
+    }
 }
 
 impl PortWrite for u32 {
+    #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u32) {
         asm!("outl $1, $0" :: "N{dx}"(port), "{eax}"(value) :: "volatile");
+    }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe fn write_to_port(port: u16, value: u32) {
+        crate::asm::x86_64_asm_write_to_port_u32(port, value)
     }
 }
 
@@ -79,7 +115,17 @@ pub struct Port<T: PortReadWrite> {
 
 impl<T: PortRead> PortReadOnly<T> {
     /// Creates a read only I/O port with the given port number.
+    #[cfg(feature = "const_fn")]
     pub const fn new(port: u16) -> PortReadOnly<T> {
+        PortReadOnly {
+            port: port,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates a read only I/O port with the given port number.
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new(port: u16) -> PortReadOnly<T> {
         PortReadOnly {
             port: port,
             phantom: PhantomData,
@@ -98,7 +144,17 @@ impl<T: PortRead> PortReadOnly<T> {
 
 impl<T: PortWrite> PortWriteOnly<T> {
     /// Creates a write only I/O port with the given port number.
+    #[cfg(feature = "const_fn")]
     pub const fn new(port: u16) -> PortWriteOnly<T> {
+        PortWriteOnly {
+            port: port,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates a write only I/O port with the given port number.
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new(port: u16) -> PortWriteOnly<T> {
         PortWriteOnly {
             port: port,
             phantom: PhantomData,
@@ -117,7 +173,17 @@ impl<T: PortWrite> PortWriteOnly<T> {
 
 impl<T: PortReadWrite> Port<T> {
     /// Creates an I/O port with the given port number.
+    #[cfg(feature = "const_fn")]
     pub const fn new(port: u16) -> Port<T> {
+        Port {
+            port: port,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Creates an I/O port with the given port number.
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new(port: u16) -> Port<T> {
         Port {
             port: port,
             phantom: PhantomData,

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -9,7 +9,11 @@ pub use crate::structures::DescriptorTablePointer;
 /// interface to loading a GDT.
 #[inline]
 pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
+    #[cfg(feature = "inline_asm")]
     asm!("lgdt ($0)" :: "r" (gdt) : "memory");
+
+    #[cfg(not(feature = "inline_asm"))]
+    crate::asm::x86_64_asm_lgdt(gdt as *const _);
 }
 
 /// Load an IDT. Use the
@@ -17,11 +21,19 @@ pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
 /// interface to loading an IDT.
 #[inline]
 pub unsafe fn lidt(idt: &DescriptorTablePointer) {
+    #[cfg(feature = "inline_asm")]
     asm!("lidt ($0)" :: "r" (idt) : "memory");
+
+    #[cfg(not(feature = "inline_asm"))]
+    crate::asm::x86_64_asm_lidt(idt as *const _);
 }
 
 /// Load the task state register using the `ltr` instruction.
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
+    #[cfg(feature = "inline_asm")]
     asm!("ltr $0" :: "r" (sel.0));
+
+    #[cfg(not(feature = "inline_asm"))]
+    crate::asm::x86_64_asm_ltr(sel.0)
 }

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -5,7 +5,15 @@ use crate::VirtAddr;
 /// Invalidate the given address in the TLB using the `invlpg` instruction.
 #[inline]
 pub fn flush(addr: VirtAddr) {
-    unsafe { asm!("invlpg ($0)" :: "r" (addr.as_u64()) : "memory") };
+    #[cfg(feature = "inline_asm")]
+    unsafe {
+        asm!("invlpg ($0)" :: "r" (addr.as_u64()) : "memory")
+    };
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe {
+        crate::asm::x86_64_asm_invlpg(addr.as_u64())
+    };
 }
 
 /// Invalidate the TLB completely by reloading the CR3 register.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,20 @@
 //! This crate provides x86_64 specific functions and data structures,
 //! and access to various system registers.
 
-#![feature(const_fn)]
-#![feature(asm)]
-#![feature(abi_x86_interrupt)]
-#![feature(const_in_array_repeat_expressions)]
 #![cfg_attr(not(test), no_std)]
+#![cfg_attr(feature = "const_fn", feature(const_fn))]
+#![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
+#![cfg_attr(feature = "inline_asm", feature(asm))]
+#![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]
 #![cfg_attr(not(feature = "deny-warnings"), warn(missing_docs))]
 #![deny(missing_debug_implementations)]
 
 pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};
+
+#[cfg(not(feature = "inline_asm"))]
+pub(crate) mod asm;
 
 pub mod instructions;
 pub mod registers;

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -140,9 +140,17 @@ mod x86_64 {
         /// Read the current raw CR0 value.
         pub fn read_raw() -> u64 {
             let value: u64;
+
+            #[cfg(feature = "inline_asm")]
             unsafe {
                 asm!("mov %cr0, $0" : "=r" (value));
             }
+
+            #[cfg(not(feature = "inline_asm"))]
+            unsafe {
+                value = crate::asm::x86_64_asm_read_cr0();
+            }
+
             value
         }
 
@@ -163,7 +171,11 @@ mod x86_64 {
         /// Does _not_ preserve any values, including reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. disabling paging.
         pub unsafe fn write_raw(value: u64) {
-            asm!("mov $0, %cr0" :: "r" (value) : "memory")
+            #[cfg(feature = "inline_asm")]
+            asm!("mov $0, %cr0" :: "r" (value) : "memory");
+
+            #[cfg(not(feature = "inline_asm"))]
+            crate::asm::x86_64_asm_write_cr0(value);
         }
 
         /// Updates CR0 flags.
@@ -184,9 +196,17 @@ mod x86_64 {
         /// Read the current page fault linear address from the CR3 register.
         pub fn read() -> VirtAddr {
             let value: u64;
+
+            #[cfg(feature = "inline_asm")]
             unsafe {
                 asm!("mov %cr2, $0" : "=r" (value));
             }
+
+            #[cfg(not(feature = "inline_asm"))]
+            unsafe {
+                value = crate::asm::x86_64_asm_read_cr2();
+            }
+
             VirtAddr::new(value)
         }
     }
@@ -195,9 +215,17 @@ mod x86_64 {
         /// Read the current P4 table address from the CR3 register.
         pub fn read() -> (PhysFrame, Cr3Flags) {
             let value: u64;
+
+            #[cfg(feature = "inline_asm")]
             unsafe {
                 asm!("mov %cr3, $0" : "=r" (value));
             }
+
+            #[cfg(not(feature = "inline_asm"))]
+            unsafe {
+                value = crate::asm::x86_64_asm_read_cr3();
+            }
+
             let flags = Cr3Flags::from_bits_truncate(value);
             let addr = PhysAddr::new(value & 0x_000f_ffff_ffff_f000);
             let frame = PhysFrame::containing_address(addr);
@@ -212,7 +240,12 @@ mod x86_64 {
         pub unsafe fn write(frame: PhysFrame, flags: Cr3Flags) {
             let addr = frame.start_address();
             let value = addr.as_u64() | flags.bits();
-            asm!("mov $0, %cr3" :: "r" (value) : "memory")
+
+            #[cfg(feature = "inline_asm")]
+            asm!("mov $0, %cr3" :: "r" (value) : "memory");
+
+            #[cfg(not(feature = "inline_asm"))]
+            crate::asm::x86_64_asm_write_cr3(value)
         }
     }
 
@@ -225,9 +258,17 @@ mod x86_64 {
         /// Read the current raw CR4 value.
         pub fn read_raw() -> u64 {
             let value: u64;
+
+            #[cfg(feature = "inline_asm")]
             unsafe {
                 asm!("mov %cr4, $0" : "=r" (value));
             }
+
+            #[cfg(not(feature = "inline_asm"))]
+            unsafe {
+                value = crate::asm::x86_64_asm_read_cr4();
+            }
+
             value
         }
 
@@ -248,7 +289,11 @@ mod x86_64 {
         /// Does _not_ preserve any values, including reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. physical address extension.
         pub unsafe fn write_raw(value: u64) {
-            asm!("mov $0, %cr4" :: "r" (value) : "memory")
+            #[cfg(feature = "inline_asm")]
+            asm!("mov $0, %cr4" :: "r" (value) : "memory");
+
+            #[cfg(not(feature = "inline_asm"))]
+            crate::asm::x86_64_asm_write_cr4(value);
         }
 
         /// Updates CR4 flags.

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -6,6 +6,7 @@ pub mod rflags;
 
 /// Gets the current instruction pointer. Note that this is only approximate as it requires a few
 /// instructions to execute.
+#[cfg(feature = "inline_asm")]
 #[inline(always)]
 pub fn read_rip() -> u64 {
     let rip: u64;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -371,7 +371,40 @@ pub struct InterruptDescriptorTable {
 
 impl InterruptDescriptorTable {
     /// Creates a new IDT filled with non-present entries.
+    #[cfg(feature = "const_fn")]
     pub const fn new() -> InterruptDescriptorTable {
+        InterruptDescriptorTable {
+            divide_error: Entry::missing(),
+            debug: Entry::missing(),
+            non_maskable_interrupt: Entry::missing(),
+            breakpoint: Entry::missing(),
+            overflow: Entry::missing(),
+            bound_range_exceeded: Entry::missing(),
+            invalid_opcode: Entry::missing(),
+            device_not_available: Entry::missing(),
+            double_fault: Entry::missing(),
+            coprocessor_segment_overrun: Entry::missing(),
+            invalid_tss: Entry::missing(),
+            segment_not_present: Entry::missing(),
+            stack_segment_fault: Entry::missing(),
+            general_protection_fault: Entry::missing(),
+            page_fault: Entry::missing(),
+            reserved_1: Entry::missing(),
+            x87_floating_point: Entry::missing(),
+            alignment_check: Entry::missing(),
+            machine_check: Entry::missing(),
+            simd_floating_point: Entry::missing(),
+            virtualization: Entry::missing(),
+            reserved_2: [Entry::missing(); 9],
+            security_exception: Entry::missing(),
+            reserved_3: Entry::missing(),
+            interrupts: [Entry::missing(); 256 - 32],
+        }
+    }
+
+    /// Creates a new IDT filled with non-present entries.
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new() -> InterruptDescriptorTable {
         InterruptDescriptorTable {
             divide_error: Entry::missing(),
             debug: Entry::missing(),

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,7 +1,11 @@
 //! Representations of various x86 specific structures and descriptor tables.
 
 pub mod gdt;
+
+// idt needs `feature(abi_x86_interrupt)`, which is not available on stable rust
+#[cfg(feature = "abi_x86_interrupt")]
 pub mod idt;
+
 pub mod paging;
 pub mod port;
 pub mod tss;

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -87,7 +87,15 @@ impl<S: PageSize> Page<S> {
     }
 
     /// Returns the size the page (4KB, 2MB or 1GB).
+    #[cfg(feature = "const_fn")]
     pub const fn size(&self) -> u64 {
+        S::SIZE
+    }
+
+    /// Returns the size the page (4KB, 2MB or 1GB).
+    #[cfg(not(feature = "const_fn"))]
+    #[inline]
+    pub fn size(&self) -> u64 {
         S::SIZE
     }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -27,7 +27,15 @@ pub struct PageTableEntry {
 
 impl PageTableEntry {
     /// Creates an unused page table entry.
+    #[cfg(feature = "const_fn")]
     pub const fn new() -> Self {
+        PageTableEntry { entry: 0 }
+    }
+
+    /// Creates an unused page table entry.
+    #[cfg(not(feature = "const_fn"))]
+    #[inline]
+    pub fn new() -> Self {
         PageTableEntry { entry: 0 }
     }
 
@@ -176,9 +184,18 @@ pub struct PageTable {
 
 impl PageTable {
     /// Creates an empty page table.
+    #[cfg(feature = "const_fn")]
     pub const fn new() -> Self {
         PageTable {
             entries: [PageTableEntry::new(); ENTRY_COUNT],
+        }
+    }
+
+    /// Creates an empty page table.
+    #[cfg(not(feature = "const_fn"))]
+    pub fn new() -> Self {
+        PageTable {
+            entries: array_init::array_init(|_| PageTableEntry::new()),
         }
     }
 


### PR DESCRIPTION
default is "nightly"

to compile with stable rust:
x86_64 = { version = "0.9", default-features = false, features = [ "stable" ] }