### PR TITLE
asm: add target_env = "musl" to pickup the underscore asm names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,12 @@ jobs:
     - name: Set Rustup profile to minimal
       run: rustup set profile minimal
 
+    - name: Install musl target on Linux
+      run: |
+        rustup target add x86_64-unknown-linux-musl
+        sudo apt-get install musl-tools musl-dev
+      if: runner.os == 'Linux'
+
     - name: "Print Rust Version"
       run: |
         rustc -Vv
@@ -60,12 +66,20 @@ jobs:
       run: cargo build --no-default-features --features stable
       if: runner.os != 'Windows'
 
+    - name: "Run cargo build for stable on musl"
+      run: cargo build --target x86_64-unknown-linux-musl --no-default-features --features stable
+      if: runner.os == 'Linux'
+
     - name: "Run cargo test"
       run: cargo test
 
     - name: "Run cargo test for stable"
       run: cargo test --no-default-features --features stable
       if: runner.os != 'Windows'
+
+    - name: "Run cargo test for stable on musl"
+      run: cargo test --target x86_64-unknown-linux-musl --no-default-features --features stable
+      if: runner.os == 'Linux'
 
     - name: 'Deny Warnings'
       run: cargo build --features deny-warnings

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,69 +1,200 @@
 #[link(name = "x86_64_asm", kind = "static")]
 extern "C" {
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_interrupt_enable")]
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_interrupt_enable"
+    )]
     pub(crate) fn x86_64_asm_interrupt_enable();
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_interrupt_disable")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_interrupt_disable"
+    )]
     pub(crate) fn x86_64_asm_interrupt_disable();
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_int3")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_int3"
+    )]
     pub(crate) fn x86_64_asm_int3();
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_hlt")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_hlt"
+    )]
     pub(crate) fn x86_64_asm_hlt();
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u8")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_from_port_u8"
+    )]
     pub(crate) fn x86_64_asm_read_from_port_u8(port: u16) -> u8;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u16")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_from_port_u16"
+    )]
     pub(crate) fn x86_64_asm_read_from_port_u16(port: u16) -> u16;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_from_port_u32")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_from_port_u32"
+    )]
     pub(crate) fn x86_64_asm_read_from_port_u32(port: u16) -> u32;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u8")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_to_port_u8"
+    )]
     pub(crate) fn x86_64_asm_write_to_port_u8(port: u16, value: u8);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u16")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_to_port_u16"
+    )]
     pub(crate) fn x86_64_asm_write_to_port_u16(port: u16, value: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_to_port_u32")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_to_port_u32"
+    )]
     pub(crate) fn x86_64_asm_write_to_port_u32(port: u16, value: u32);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_set_cs")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_set_cs"
+    )]
     pub(crate) fn x86_64_asm_set_cs(sel: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_ss")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_load_ss"
+    )]
     pub(crate) fn x86_64_asm_load_ss(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_ds")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_load_ds"
+    )]
     pub(crate) fn x86_64_asm_load_ds(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_es")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_load_es"
+    )]
     pub(crate) fn x86_64_asm_load_es(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_fs")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_load_fs"
+    )]
     pub(crate) fn x86_64_asm_load_fs(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_load_gs")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_load_gs"
+    )]
     pub(crate) fn x86_64_asm_load_gs(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_swapgs")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_swapgs"
+    )]
     pub(crate) fn x86_64_asm_swapgs();
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_get_cs")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_cs"
+    )]
     pub(crate) fn x86_64_asm_get_cs() -> u16;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_lgdt")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_lgdt"
+    )]
     pub(crate) fn x86_64_asm_lgdt(gdt: *const crate::instructions::tables::DescriptorTablePointer);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_lidt")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_lidt"
+    )]
     pub(crate) fn x86_64_asm_lidt(idt: *const crate::instructions::tables::DescriptorTablePointer);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_ltr")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_ltr"
+    )]
     pub(crate) fn x86_64_asm_ltr(sel: u16);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_invlpg")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_invlpg"
+    )]
     pub(crate) fn x86_64_asm_invlpg(addr: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr0")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_cr0"
+    )]
     pub(crate) fn x86_64_asm_read_cr0() -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr0")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_cr0"
+    )]
     pub(crate) fn x86_64_asm_write_cr0(value: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr2")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_cr2"
+    )]
     pub(crate) fn x86_64_asm_read_cr2() -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr3")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_cr3"
+    )]
     pub(crate) fn x86_64_asm_read_cr3() -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr3")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_cr3"
+    )]
     pub(crate) fn x86_64_asm_write_cr3(value: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_cr4")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_cr4"
+    )]
     pub(crate) fn x86_64_asm_read_cr4() -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_cr4")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_cr4"
+    )]
     pub(crate) fn x86_64_asm_write_cr4(value: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_rdmsr")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_rdmsr"
+    )]
     pub(crate) fn x86_64_asm_rdmsr(msr: u32) -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_wrmsr")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_wrmsr"
+    )]
     pub(crate) fn x86_64_asm_wrmsr(msr: u32, value: u64);
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_read_rflags")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_rflags"
+    )]
     pub(crate) fn x86_64_asm_read_rflags() -> u64;
-    #[cfg_attr(target_env = "gnu", link_name = "_x86_64_asm_write_rflags")]
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_rflags"
+    )]
     pub(crate) fn x86_64_asm_write_rflags(val: u64);
 }


### PR DESCRIPTION
`musl` is like `gnu` and does not add an underscore to external
function names as the real `link_name`.