### PR TITLE
Add `#[inline]` attribute to small functions

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -69,6 +69,7 @@ impl VirtAddr {
     /// This function performs sign extension of bit 47 to make the address canonical, so
     /// bits 48 to 64 are overwritten. If you want to check that these bits contain no data,
     /// use `new` or `try_new`.
+    #[inline]
     pub const fn new_unchecked(addr: u64) -> VirtAddr {
         // Rust doesn't accept shift operators in const functions at the moment,
         // so we use a multiplication and division by 0x1_0000 instead of `<< 16` and `>> 16`.
@@ -78,11 +79,13 @@ impl VirtAddr {
     }
 
     /// Creates a virtual address that points to `0`.
+    #[inline]
     pub const fn zero() -> VirtAddr {
         VirtAddr(0)
     }
 
     /// Converts the address to an `u64`.
+    #[inline]
     pub const fn as_u64(self) -> u64 {
         self.0
     }
@@ -93,18 +96,21 @@ impl VirtAddr {
     // on this function. At least for 32- and 64-bit we know the `as u64` cast
     // doesn't truncate.
     #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    #[inline]
     pub fn from_ptr<T>(ptr: *const T) -> Self {
         Self::new(ptr as u64)
     }
 
     /// Converts the address to a raw pointer.
     #[cfg(target_pointer_width = "64")]
+    #[inline]
     pub fn as_ptr<T>(self) -> *const T {
         self.as_u64() as *const T
     }
 
     /// Converts the address to a mutable raw pointer.
     #[cfg(target_pointer_width = "64")]
+    #[inline]
     pub fn as_mut_ptr<T>(self) -> *mut T {
         self.as_ptr::<T>() as *mut T
     }
@@ -112,6 +118,7 @@ impl VirtAddr {
     /// Aligns the virtual address upwards to the given alignment.
     ///
     /// See the `align_up` function for more information.
+    #[inline]
     pub fn align_up<U>(self, align: U) -> Self
     where
         U: Into<u64>,
@@ -122,6 +129,7 @@ impl VirtAddr {
     /// Aligns the virtual address downwards to the given alignment.
     ///
     /// See the `align_down` function for more information.
+    #[inline]
     pub fn align_down<U>(self, align: U) -> Self
     where
         U: Into<u64>,
@@ -130,6 +138,7 @@ impl VirtAddr {
     }
 
     /// Checks whether the virtual address has the demanded alignment.
+    #[inline]
     pub fn is_aligned<U>(self, align: U) -> bool
     where
         U: Into<u64>,
@@ -138,26 +147,31 @@ impl VirtAddr {
     }
 
     /// Returns the 12-bit page offset of this virtual address.
+    #[inline]
     pub fn page_offset(&self) -> PageOffset {
         PageOffset::new_truncate(self.0 as u16)
     }
 
     /// Returns the 9-bit level 1 page table index.
+    #[inline]
     pub fn p1_index(&self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12) as u16)
     }
 
     /// Returns the 9-bit level 2 page table index.
+    #[inline]
     pub fn p2_index(&self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9) as u16)
     }
 
     /// Returns the 9-bit level 3 page table index.
+    #[inline]
     pub fn p3_index(&self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9 >> 9) as u16)
     }
 
     /// Returns the 9-bit level 4 page table index.
+    #[inline]
     pub fn p4_index(&self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9 >> 9 >> 9) as u16)
     }
@@ -252,6 +266,7 @@ impl PhysAddr {
     }
 
     /// Creates a new physical address, throwing bits 52..64 away.
+    #[inline]
     pub const fn new_truncate(addr: u64) -> PhysAddr {
         PhysAddr(addr % (1 << 52))
     }
@@ -267,11 +282,13 @@ impl PhysAddr {
     }
 
     /// Converts the address to an `u64`.
+    #[inline]
     pub fn as_u64(self) -> u64 {
         self.0
     }
 
     /// Convenience method for checking if a physical address is null.
+    #[inline]
     pub fn is_null(&self) -> bool {
         self.0 == 0
     }
@@ -279,6 +296,7 @@ impl PhysAddr {
     /// Aligns the physical address upwards to the given alignment.
     ///
     /// See the `align_up` function for more information.
+    #[inline]
     pub fn align_up<U>(self, align: U) -> Self
     where
         U: Into<u64>,
@@ -289,6 +307,7 @@ impl PhysAddr {
     /// Aligns the physical address downwards to the given alignment.
     ///
     /// See the `align_down` function for more information.
+    #[inline]
     pub fn align_down<U>(self, align: U) -> Self
     where
         U: Into<u64>,
@@ -297,6 +316,7 @@ impl PhysAddr {
     }
 
     /// Checks whether the physical address has the demanded alignment.
+    #[inline]
     pub fn is_aligned<U>(self, align: U) -> bool
     where
         U: Into<u64>,
@@ -402,6 +422,7 @@ impl Sub<PhysAddr> for PhysAddr {
 ///
 /// Returns the greatest x with alignment `align` so that x <= addr. The alignment must be
 ///  a power of 2.
+#[inline]
 pub fn align_down(addr: u64, align: u64) -> u64 {
     assert!(align.is_power_of_two(), "`align` must be a power of two");
     addr & !(align - 1)

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -1,6 +1,7 @@
 //! Enabling and disabling interrupts
 
 /// Returns whether interrupts are enabled.
+#[inline]
 pub fn are_enabled() -> bool {
     use crate::registers::rflags::{self, RFlags};
 
@@ -58,6 +59,7 @@ pub fn disable() {
 /// });
 /// // interrupts are enabled again
 /// ```
+#[inline]
 pub fn without_interrupts<F, R>(f: F) -> R
 where
     F: FnOnce() -> R,

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -89,6 +89,7 @@ pub unsafe fn swap_gs() {
 }
 
 /// Returns the current value of the code segment register.
+#[inline]
 pub fn cs() -> SegmentSelector {
     #[cfg(feature = "inline_asm")]
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ impl PrivilegeLevel {
     /// Creates a `PrivilegeLevel` from a numeric value. The value must be in the range 0..4.
     ///
     /// This function panics if the passed value is >3.
+    #[inline]
     pub fn from_u16(value: u16) -> PrivilegeLevel {
         match value {
             0 => PrivilegeLevel::Ring0,

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -133,11 +133,13 @@ mod x86_64 {
 
     impl Cr0 {
         /// Read the current set of CR0 flags.
+        #[inline]
         pub fn read() -> Cr0Flags {
             Cr0Flags::from_bits_truncate(Self::read_raw())
         }
 
         /// Read the current raw CR0 value.
+        #[inline]
         pub fn read_raw() -> u64 {
             let value: u64;
 
@@ -158,6 +160,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. disabling paging.
+        #[inline]
         pub unsafe fn write(flags: Cr0Flags) {
             let old_value = Self::read_raw();
             let reserved = old_value & !(Cr0Flags::all().bits());
@@ -170,6 +173,7 @@ mod x86_64 {
         ///
         /// Does _not_ preserve any values, including reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. disabling paging.
+        #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
             asm!("mov $0, %cr0" :: "r" (value) : "memory");
@@ -182,6 +186,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. disabling paging.
+        #[inline]
         pub unsafe fn update<F>(f: F)
         where
             F: FnOnce(&mut Cr0Flags),
@@ -194,6 +199,7 @@ mod x86_64 {
 
     impl Cr2 {
         /// Read the current page fault linear address from the CR3 register.
+        #[inline]
         pub fn read() -> VirtAddr {
             let value: u64;
 
@@ -237,6 +243,7 @@ mod x86_64 {
         /// ## Safety
         /// Changing the level 4 page table is unsafe, because it's possible to violate memory safety by
         /// changing the page mapping.
+        #[inline]
         pub unsafe fn write(frame: PhysFrame, flags: Cr3Flags) {
             let addr = frame.start_address();
             let value = addr.as_u64() | flags.bits();
@@ -251,11 +258,13 @@ mod x86_64 {
 
     impl Cr4 {
         /// Read the current set of CR4 flags.
+        #[inline]
         pub fn read() -> Cr4Flags {
             Cr4Flags::from_bits_truncate(Self::read_raw())
         }
 
         /// Read the current raw CR4 value.
+        #[inline]
         pub fn read_raw() -> u64 {
             let value: u64;
 
@@ -276,6 +285,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. physical address extension.
+        #[inline]
         pub unsafe fn write(flags: Cr4Flags) {
             let old_value = Self::read_raw();
             let reserved = old_value & !(Cr4Flags::all().bits());
@@ -288,6 +298,7 @@ mod x86_64 {
         ///
         /// Does _not_ preserve any values, including reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. physical address extension.
+        #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
             asm!("mov $0, %cr4" :: "r" (value) : "memory");
@@ -300,6 +311,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to violate memory
         /// safety by e.g. physical address extension.
+        #[inline]
         pub unsafe fn update<F>(f: F)
         where
             F: FnOnce(&mut Cr4Flags),

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -110,6 +110,7 @@ mod x86_64 {
 
     impl Msr {
         /// Read 64 bits msr register.
+        #[inline]
         pub unsafe fn read(&self) -> u64 {
             #[cfg(feature = "inline_asm")]
             {
@@ -123,6 +124,7 @@ mod x86_64 {
         }
 
         /// Write 64 bits to msr register.
+        #[inline]
         pub unsafe fn write(&mut self, value: u64) {
             #[cfg(feature = "inline_asm")]
             {
@@ -138,11 +140,13 @@ mod x86_64 {
 
     impl Efer {
         /// Read the current EFER flags.
+        #[inline]
         pub fn read() -> EferFlags {
             EferFlags::from_bits_truncate(Self::read_raw())
         }
 
         /// Read the current raw EFER flags.
+        #[inline]
         pub fn read_raw() -> u64 {
             unsafe { Self::MSR.read() }
         }
@@ -151,6 +155,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
         /// safety, e.g. by disabling long mode.
+        #[inline]
         pub unsafe fn write(flags: EferFlags) {
             let old_value = Self::read_raw();
             let reserved = old_value & !(EferFlags::all().bits());
@@ -163,6 +168,7 @@ mod x86_64 {
         ///
         /// Does not preserve any bits, including reserved fields. Unsafe because it's possible to
         /// break memory safety, e.g. by disabling long mode.
+        #[inline]
         pub unsafe fn write_raw(flags: u64) {
             Self::MSR.write(flags);
         }
@@ -171,6 +177,7 @@ mod x86_64 {
         ///
         /// Preserves the value of reserved fields. Unsafe because it's possible to break memory
         /// safety, e.g. by disabling long mode.
+        #[inline]
         pub unsafe fn update<F>(f: F)
         where
             F: FnOnce(&mut EferFlags),
@@ -183,11 +190,13 @@ mod x86_64 {
 
     impl FsBase {
         /// Read the current FsBase register.
+        #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the FS.Base register.
+        #[inline]
         pub fn write(address: VirtAddr) {
             unsafe { Self::MSR.write(address.as_u64()) };
         }
@@ -195,11 +204,13 @@ mod x86_64 {
 
     impl GsBase {
         /// Read the current GsBase register.
+        #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the GS.Base register.
+        #[inline]
         pub fn write(address: VirtAddr) {
             unsafe { Self::MSR.write(address.as_u64()) };
         }
@@ -207,11 +218,13 @@ mod x86_64 {
 
     impl KernelGsBase {
         /// Read the current KernelGsBase register.
+        #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the KernelGsBase register.
+        #[inline]
         pub fn write(address: VirtAddr) {
             unsafe { Self::MSR.write(address.as_u64()) };
         }
@@ -229,6 +242,7 @@ mod x86_64 {
         /// - Field 2 (SYSCALL): This field is copied directly into CS.Sel. SS.Sel is set to
         ///  this field + 8. Because SYSCALL always switches to CPL 0, the RPL bits
         /// 33:32 should be initialized to 00b.
+        #[inline]
         pub fn read_raw() -> (u16, u16) {
             let msr_value = unsafe { Self::MSR.read() };
             let sysret = msr_value.get_bits(48..64);
@@ -242,6 +256,7 @@ mod x86_64 {
         /// - SS Selector SYSRET
         /// - CS Selector SYSCALL
         /// - SS Selector SYSCALL
+        #[inline]
         pub fn read() -> (
             SegmentSelector,
             SegmentSelector,
@@ -272,6 +287,7 @@ mod x86_64 {
         /// # Unsafety
         /// Unsafe because this can cause system instability if passed in the
         /// wrong values for the fields.
+        #[inline]
         pub unsafe fn write_raw(sysret: u16, syscall: u16) {
             let mut msr_value = 0u64;
             msr_value.set_bits(48..64, sysret.into());
@@ -316,12 +332,14 @@ mod x86_64 {
     impl LStar {
         /// Read the current LStar register.
         /// This holds the target RIP of a syscall.
+        #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the LStar register.
         /// This holds the target RIP of a syscall.
+        #[inline]
         pub fn write(address: VirtAddr) {
             unsafe { Self::MSR.write(address.as_u64()) };
         }
@@ -335,6 +353,7 @@ mod x86_64 {
         /// executed. If a bit in SFMASK is set to 1, the corresponding
         /// bit in RFLAGS is cleared to 0. If a bit in SFMASK is cleared
         /// to 0, the corresponding rFLAGS bit is not modified.
+        #[inline]
         pub fn read() -> RFlags {
             RFlags::from_bits(unsafe { Self::MSR.read() }).unwrap()
         }
@@ -346,6 +365,7 @@ mod x86_64 {
         /// executed. If a bit in SFMASK is set to 1, the corresponding
         /// bit in RFLAGS is cleared to 0. If a bit in SFMASK is cleared
         /// to 0, the corresponding rFLAGS bit is not modified.
+        #[inline]
         pub fn write(value: RFlags) {
             unsafe { Self::MSR.write(value.bits()) };
         }

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -69,11 +69,13 @@ mod x86_64 {
     /// Returns the current value of the RFLAGS register.
     ///
     /// Drops any unknown bits.
+    #[inline]
     pub fn read() -> RFlags {
         RFlags::from_bits_truncate(read_raw())
     }
 
     /// Returns the raw current value of the RFLAGS register.
+    #[inline]
     pub fn read_raw() -> u64 {
         let r: u64;
         #[cfg(feature = "inline_asm")]
@@ -90,6 +92,7 @@ mod x86_64 {
     }
 
     /// Writes the RFLAGS register, preserves reserved bits.
+    #[inline]
     pub fn write(flags: RFlags) {
         let old_value = read_raw();
         let reserved = old_value & !(RFlags::all().bits());
@@ -101,6 +104,7 @@ mod x86_64 {
     /// Writes the RFLAGS register.
     ///
     /// Does not preserve any bits, including reserved bits.
+    #[inline]
     pub fn write_raw(val: u64) {
         #[cfg(feature = "inline_asm")]
         unsafe {

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -26,16 +26,19 @@ impl SegmentSelector {
     }
 
     /// Returns the GDT index.
+    #[inline]
     pub fn index(&self) -> u16 {
         self.0 >> 3
     }
 
     /// Returns the requested privilege level.
+    #[inline]
     pub fn rpl(&self) -> PrivilegeLevel {
         PrivilegeLevel::from_u16(self.0.get_bits(0..2))
     }
 
     /// Set the privilege level for this Segment selector.
+    #[inline]
     pub fn set_rpl(&mut self, rpl: PrivilegeLevel) {
         self.0.set_bits(0..2, rpl as u16);
     }
@@ -184,6 +187,7 @@ bitflags! {
 
 impl Descriptor {
     /// Creates a segment descriptor for a long mode kernel code segment.
+    #[inline]
     pub fn kernel_code_segment() -> Descriptor {
         use self::DescriptorFlags as Flags;
 
@@ -192,6 +196,7 @@ impl Descriptor {
     }
 
     /// Creates a segment descriptor for a long mode ring 3 data segment.
+    #[inline]
     pub fn user_data_segment() -> Descriptor {
         use self::DescriptorFlags as Flags;
 
@@ -200,6 +205,7 @@ impl Descriptor {
     }
 
     /// Creates a segment descriptor for a long mode ring 3 code segment.
+    #[inline]
     pub fn user_code_segment() -> Descriptor {
         use self::DescriptorFlags as Flags;
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -465,6 +465,7 @@ impl InterruptDescriptorTable {
 
     /// Loads the IDT in the CPU using the `lidt` command.
     #[cfg(target_arch = "x86_64")]
+    #[inline]
     pub fn load(&'static self) {
         use crate::instructions::tables::{lidt, DescriptorTablePointer};
         use core::mem::size_of;
@@ -506,6 +507,7 @@ impl InterruptDescriptorTable {
     ///
     /// Panics if range is outside the range of user interrupts (i.e. greater than 255) or if the entry is an
     /// exception
+    #[inline]
     pub fn slice(&self, bounds: impl RangeBounds<usize>) -> &[Entry<HandlerFunc>] {
         let (lower_idx, upper_idx) = self.condition_slice_bounds(bounds);
         &self.interrupts[(lower_idx - 32)..(upper_idx - 32)]
@@ -515,6 +517,7 @@ impl InterruptDescriptorTable {
     ///
     /// Panics if range is outside the range of user interrupts (i.e. greater than 255) or if the entry is an
     /// exception
+    #[inline]
     pub fn slice_mut(&mut self, bounds: impl RangeBounds<usize>) -> &mut [Entry<HandlerFunc>] {
         let (lower_idx, upper_idx) = self.condition_slice_bounds(bounds);
         &mut self.interrupts[(lower_idx - 32)..(upper_idx - 32)]
@@ -680,11 +683,13 @@ pub struct EntryOptions(u16);
 
 impl EntryOptions {
     /// Creates a minimal options field with all the must-be-one bits set.
+    #[inline]
     const fn minimal() -> Self {
         EntryOptions(0b1110_0000_0000)
     }
 
     /// Set or reset the preset bit.
+    #[inline]
     pub fn set_present(&mut self, present: bool) -> &mut Self {
         self.0.set_bit(15, present);
         self
@@ -692,6 +697,7 @@ impl EntryOptions {
 
     /// Let the CPU disable hardware interrupts when the handler is invoked. By default,
     /// interrupts are disabled on handler invocation.
+    #[inline]
     pub fn disable_interrupts(&mut self, disable: bool) -> &mut Self {
         self.0.set_bit(8, !disable);
         self
@@ -701,6 +707,7 @@ impl EntryOptions {
     /// or 3, the default is 0. If CPL < DPL, a general protection fault occurs.
     ///
     /// This function panics for a DPL > 3.
+    #[inline]
     pub fn set_privilege_level(&mut self, dpl: PrivilegeLevel) -> &mut Self {
         self.0.set_bits(13..15, dpl as u16);
         self
@@ -718,6 +725,7 @@ impl EntryOptions {
     /// ## Safety
     /// This function is unsafe because the caller must ensure that the passed stack index is
     /// valid and not used by other interrupts. Otherwise, memory safety violations are possible.
+    #[inline]
     pub unsafe fn set_stack_index(&mut self, index: u16) -> &mut Self {
         // The hardware IST index starts at 1, but our software IST index
         // starts at 0. Therefore we need to add 1 here.
@@ -751,6 +759,7 @@ impl InterruptStackFrame {
     /// can easily lead to undefined behavior. For example, by writing an invalid value to
     /// the instruction pointer field, the CPU can jump to arbitrary code at the end of the
     /// interrupt.
+    #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut InterruptStackFrameValue {
         &mut self.value
     }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -18,6 +18,7 @@ impl<S: PageSize> PhysFrame<S> {
     /// Returns the frame that starts at the given virtual address.
     ///
     /// Returns an error if the address is not correctly aligned (i.e. is not a valid frame start).
+    #[inline]
     pub fn from_start_address(address: PhysAddr) -> Result<Self, ()> {
         if !address.is_aligned(S::SIZE) {
             return Err(());
@@ -26,6 +27,7 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame that contains the given physical address.
+    #[inline]
     pub fn containing_address(address: PhysAddr) -> Self {
         PhysFrame {
             start_address: address.align_down(S::SIZE),
@@ -34,27 +36,32 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the start address of the frame.
+    #[inline]
     pub fn start_address(&self) -> PhysAddr {
         self.start_address
     }
 
     /// Returns the size the frame (4KB, 2MB or 1GB).
+    #[inline]
     pub fn size(&self) -> u64 {
         S::SIZE
     }
 
     /// Returns a range of frames, exclusive `end`.
+    #[inline]
     pub fn range(start: PhysFrame<S>, end: PhysFrame<S>) -> PhysFrameRange<S> {
         PhysFrameRange { start, end }
     }
 
     /// Returns a range of frames, inclusive `end`.
+    #[inline]
     pub fn range_inclusive(start: PhysFrame<S>, end: PhysFrame<S>) -> PhysFrameRangeInclusive<S> {
         PhysFrameRangeInclusive { start, end }
     }
 }
 
 impl<S: PageSize> fmt::Debug for PhysFrame<S> {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_fmt(format_args!(
             "PhysFrame[{}]({:#x})",
@@ -109,6 +116,7 @@ pub struct PhysFrameRange<S: PageSize = Size4KiB> {
 
 impl<S: PageSize> PhysFrameRange<S> {
     /// Returns whether the range contains no frames.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         !(self.start < self.end)
     }
@@ -149,6 +157,7 @@ pub struct PhysFrameRangeInclusive<S: PageSize = Size4KiB> {
 
 impl<S: PageSize> PhysFrameRangeInclusive<S> {
     /// Returns whether the range contains no frames.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         !(self.start <= self.end)
     }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -414,6 +414,7 @@ impl<P: PhysToVirt> PageTableWalker<P> {
     /// Returns `PageTableWalkError::NotMapped` if the entry is unused. Returns
     /// `PageTableWalkError::MappedToHugePage` if the `HUGE_PAGE` flag is set
     /// in the passed entry.
+    #[inline]
     fn next_table<'b>(
         &self,
         entry: &'b PageTableEntry,
@@ -429,6 +430,7 @@ impl<P: PhysToVirt> PageTableWalker<P> {
     /// Returns `PageTableWalkError::NotMapped` if the entry is unused. Returns
     /// `PageTableWalkError::MappedToHugePage` if the `HUGE_PAGE` flag is set
     /// in the passed entry.
+    #[inline]
     fn next_table_mut<'b>(
         &self,
         entry: &'b mut PageTableEntry,
@@ -575,6 +577,7 @@ impl<T> PhysToVirt for T
 where
     T: Fn(PhysFrame) -> *mut PageTable,
 {
+    #[inline]
     fn phys_to_virt(&self, phys_frame: PhysFrame) -> *mut PageTable {
         self(phys_frame)
     }

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -33,6 +33,7 @@ pub trait MapperAllSizes: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB>
     ///
     /// This is a convenience method. For more information about a mapping see the
     /// [`translate`](MapperAllSizes::translate) method.
+    #[inline]
     fn translate_addr(&self, addr: VirtAddr) -> Option<PhysAddr> {
         match self.translate(addr) {
             TranslateResult::PageNotMapped | TranslateResult::InvalidFrameAddress(_) => None,
@@ -112,6 +113,7 @@ pub trait Mapper<S: PageSize> {
     fn translate_page(&self, page: Page<S>) -> Result<PhysFrame<S>, TranslateError>;
 
     /// Maps the given frame to the virtual page with the same address.
+    #[inline]
     unsafe fn identity_map<A>(
         &mut self,
         frame: UnusedPhysFrame<S>,
@@ -146,11 +148,13 @@ impl<S: PageSize> MapperFlush<S> {
 
     /// Flush the page from the TLB to ensure that the newest mapping is used.
     #[cfg(target_arch = "x86_64")]
+    #[inline]
     pub fn flush(self) {
         crate::instructions::tlb::flush(self.0.start_address());
     }
 
     /// Don't flush the TLB and silence the “must be used” warning.
+    #[inline]
     pub fn ignore(self) {}
 }
 

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -23,6 +23,7 @@ impl<'a> OffsetPageTable<'a> {
     /// is correct. Also, the passed `level_4_table` must point to the level 4 page table
     /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
     /// by writing to an illegal memory location.
+    #[inline]
     pub unsafe fn new(level_4_table: &'a mut PageTable, phys_offset: VirtAddr) -> Self {
         let phys_offset = PhysOffset {
             offset: phys_offset,
@@ -39,6 +40,7 @@ struct PhysOffset {
 }
 
 impl PhysToVirt for PhysOffset {
+    #[inline]
     fn phys_to_virt(&self, frame: PhysFrame) -> *mut PageTable {
         let phys = frame.start_address().as_u64();
         let virt = self.offset + phys;
@@ -62,6 +64,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         self.inner.map_to(page, frame, flags, allocator)
     }
 
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size1GiB>,
@@ -69,6 +72,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         self.inner.unmap(page)
     }
 
+    #[inline]
     fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
@@ -77,12 +81,14 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         self.inner.update_flags(page, flags)
     }
 
+    #[inline]
     fn translate_page(&self, page: Page<Size1GiB>) -> Result<PhysFrame<Size1GiB>, TranslateError> {
         self.inner.translate_page(page)
     }
 }
 
 impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
+    #[inline]
     fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
@@ -96,6 +102,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         self.inner.map_to(page, frame, flags, allocator)
     }
 
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
@@ -103,6 +110,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         self.inner.unmap(page)
     }
 
+    #[inline]
     fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
@@ -111,12 +119,14 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         self.inner.update_flags(page, flags)
     }
 
+    #[inline]
     fn translate_page(&self, page: Page<Size2MiB>) -> Result<PhysFrame<Size2MiB>, TranslateError> {
         self.inner.translate_page(page)
     }
 }
 
 impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
+    #[inline]
     fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
@@ -130,6 +140,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         self.inner.map_to(page, frame, flags, allocator)
     }
 
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
@@ -137,6 +148,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         self.inner.unmap(page)
     }
 
+    #[inline]
     fn update_flags(
         &mut self,
         page: Page<Size4KiB>,
@@ -145,12 +157,14 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         self.inner.update_flags(page, flags)
     }
 
+    #[inline]
     fn translate_page(&self, page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, TranslateError> {
         self.inner.translate_page(page)
     }
 }
 
 impl<'a> MapperAllSizes for OffsetPageTable<'a> {
+    #[inline]
     fn translate(&self, addr: VirtAddr) -> TranslateResult {
         self.inner.translate(addr)
     }

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -67,6 +67,7 @@ impl<'a> RecursivePageTable<'a> {
     /// Creates a new RecursivePageTable without performing any checks.
     ///
     /// The `recursive_index` parameter must be the index of the recursively mapped entry.
+    #[inline]
     pub unsafe fn new_unchecked(table: &'a mut PageTable, recursive_index: PageTableIndex) -> Self {
         RecursivePageTable {
             p4: table,
@@ -306,6 +307,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
+    #[inline]
     fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
@@ -581,10 +583,12 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
     }
 }
 
+#[inline]
 fn p3_ptr<S: PageSize>(page: Page<S>, recursive_index: PageTableIndex) -> *mut PageTable {
     p3_page(page, recursive_index).start_address().as_mut_ptr()
 }
 
+#[inline]
 fn p3_page<S: PageSize>(page: Page<S>, recursive_index: PageTableIndex) -> Page {
     Page::from_page_table_indices(
         recursive_index,
@@ -594,10 +598,12 @@ fn p3_page<S: PageSize>(page: Page<S>, recursive_index: PageTableIndex) -> Page 
     )
 }
 
+#[inline]
 fn p2_ptr<S: NotGiantPageSize>(page: Page<S>, recursive_index: PageTableIndex) -> *mut PageTable {
     p2_page(page, recursive_index).start_address().as_mut_ptr()
 }
 
+#[inline]
 fn p2_page<S: NotGiantPageSize>(page: Page<S>, recursive_index: PageTableIndex) -> Page {
     Page::from_page_table_indices(
         recursive_index,
@@ -607,10 +613,12 @@ fn p2_page<S: NotGiantPageSize>(page: Page<S>, recursive_index: PageTableIndex) 
     )
 }
 
+#[inline]
 fn p1_ptr(page: Page<Size4KiB>, recursive_index: PageTableIndex) -> *mut PageTable {
     p1_page(page, recursive_index).start_address().as_mut_ptr()
 }
 
+#[inline]
 fn p1_page(page: Page<Size4KiB>, recursive_index: PageTableIndex) -> Page {
     Page::from_page_table_indices(
         recursive_index,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -66,6 +66,7 @@ impl<S: PageSize> Page<S> {
     /// Returns the page that starts at the given virtual address.
     ///
     /// Returns an error if the address is not correctly aligned (i.e. is not a valid page start).
+    #[inline]
     pub fn from_start_address(address: VirtAddr) -> Result<Self, ()> {
         if !address.is_aligned(S::SIZE) {
             return Err(());
@@ -74,6 +75,7 @@ impl<S: PageSize> Page<S> {
     }
 
     /// Returns the page that contains the given virtual address.
+    #[inline]
     pub fn containing_address(address: VirtAddr) -> Self {
         Page {
             start_address: address.align_down(S::SIZE),
@@ -82,12 +84,14 @@ impl<S: PageSize> Page<S> {
     }
 
     /// Returns the start address of the page.
+    #[inline]
     pub fn start_address(&self) -> VirtAddr {
         self.start_address
     }
 
     /// Returns the size the page (4KB, 2MB or 1GB).
     #[cfg(feature = "const_fn")]
+    #[inline]
     pub const fn size(&self) -> u64 {
         S::SIZE
     }
@@ -100,21 +104,25 @@ impl<S: PageSize> Page<S> {
     }
 
     /// Returns the level 4 page table index of this page.
+    #[inline]
     pub fn p4_index(&self) -> PageTableIndex {
         self.start_address().p4_index()
     }
 
     /// Returns the level 3 page table index of this page.
+    #[inline]
     pub fn p3_index(&self) -> PageTableIndex {
         self.start_address().p3_index()
     }
 
     /// Returns a range of pages, exclusive `end`.
+    #[inline]
     pub fn range(start: Self, end: Self) -> PageRange<S> {
         PageRange { start, end }
     }
 
     /// Returns a range of pages, inclusive `end`.
+    #[inline]
     pub fn range_inclusive(start: Self, end: Self) -> PageRangeInclusive<S> {
         PageRangeInclusive { start, end }
     }
@@ -122,6 +130,7 @@ impl<S: PageSize> Page<S> {
 
 impl<S: NotGiantPageSize> Page<S> {
     /// Returns the level 2 page table index of this page.
+    #[inline]
     pub fn p2_index(&self) -> PageTableIndex {
         self.start_address().p2_index()
     }
@@ -178,6 +187,7 @@ impl Page<Size4KiB> {
     }
 
     /// Returns the level 1 page table index of this page.
+    #[inline]
     pub fn p1_index(&self) -> PageTableIndex {
         self.start_address().p1_index()
     }
@@ -259,6 +269,7 @@ impl<S: PageSize> Iterator for PageRange<S> {
 
 impl PageRange<Size2MiB> {
     /// Converts the range of 2MiB pages to a range of 4KiB pages.
+    #[inline]
     pub fn as_4kib_page_range(self) -> PageRange<Size4KiB> {
         PageRange {
             start: Page::containing_address(self.start.start_address()),

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -40,21 +40,25 @@ impl PageTableEntry {
     }
 
     /// Returns whether this entry is zero.
+    #[inline]
     pub const fn is_unused(&self) -> bool {
         self.entry == 0
     }
 
     /// Sets this entry to zero.
+    #[inline]
     pub fn set_unused(&mut self) {
         self.entry = 0;
     }
 
     /// Returns the flags of this entry.
+    #[inline]
     pub const fn flags(&self) -> PageTableFlags {
         PageTableFlags::from_bits_truncate(self.entry)
     }
 
     /// Returns the physical address mapped by this entry, might be zero.
+    #[inline]
     pub fn addr(&self) -> PhysAddr {
         PhysAddr::new(self.entry & 0x000fffff_fffff000)
     }
@@ -77,18 +81,21 @@ impl PageTableEntry {
     }
 
     /// Map the entry to the specified physical address with the specified flags.
+    #[inline]
     pub fn set_addr(&mut self, addr: PhysAddr, flags: PageTableFlags) {
         assert!(addr.is_aligned(Size4KiB::SIZE));
         self.entry = (addr.as_u64()) | flags.bits();
     }
 
     /// Map the entry to the specified physical frame with the specified flags.
+    #[inline]
     pub fn set_frame(&mut self, frame: PhysFrame, flags: PageTableFlags) {
         assert!(!flags.contains(PageTableFlags::HUGE_PAGE));
         self.set_addr(frame.start_address(), flags)
     }
 
     /// Sets the flags of this entry.
+    #[inline]
     pub fn set_flags(&mut self, flags: PageTableFlags) {
         self.entry = self.addr().as_u64() | flags.bits();
     }
@@ -200,6 +207,7 @@ impl PageTable {
     }
 
     /// Clears all entries.
+    #[inline]
     pub fn zero(&mut self) {
         for entry in self.entries.iter_mut() {
             entry.set_unused();
@@ -269,30 +277,35 @@ impl PageTableIndex {
     }
 
     /// Creates a new index from the given `u16`. Throws away bits if the value is >=512.
+    #[inline]
     pub const fn new_truncate(index: u16) -> Self {
         Self(index % ENTRY_COUNT as u16)
     }
 }
 
 impl From<PageTableIndex> for u16 {
+    #[inline]
     fn from(index: PageTableIndex) -> Self {
         index.0
     }
 }
 
 impl From<PageTableIndex> for u32 {
+    #[inline]
     fn from(index: PageTableIndex) -> Self {
         u32::from(index.0)
     }
 }
 
 impl From<PageTableIndex> for u64 {
+    #[inline]
     fn from(index: PageTableIndex) -> Self {
         u64::from(index.0)
     }
 }
 
 impl From<PageTableIndex> for usize {
+    #[inline]
     fn from(index: PageTableIndex) -> Self {
         usize::from(index.0)
     }
@@ -314,30 +327,35 @@ impl PageOffset {
     }
 
     /// Creates a new offset from the given `u16`. Throws away bits if the value is >=4096.
+    #[inline]
     pub const fn new_truncate(offset: u16) -> Self {
         Self(offset % (1 << 12))
     }
 }
 
 impl From<PageOffset> for u16 {
+    #[inline]
     fn from(offset: PageOffset) -> Self {
         offset.0
     }
 }
 
 impl From<PageOffset> for u32 {
+    #[inline]
     fn from(offset: PageOffset) -> Self {
         u32::from(offset.0)
     }
 }
 
 impl From<PageOffset> for u64 {
+    #[inline]
     fn from(offset: PageOffset) -> Self {
         u64::from(offset.0)
     }
 }
 
 impl From<PageOffset> for usize {
+    #[inline]
     fn from(offset: PageOffset) -> Self {
         usize::from(offset.0)
     }


### PR DESCRIPTION
I tried to mark as inlined functions that I estimated suitable, up to 4 lines of codes or distinct language statements/expressions.
I discarded operator overloadings and `new()`.
Hope that helps !