### PR TITLE
Add a `Mapper::map` convenience method

### DIFF
--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -1,6 +1,6 @@
 //! Traits for abstracting away frame allocation and deallocation.
 
-use crate::structures::paging::{PageSize, PhysFrame};
+use crate::structures::paging::{PageSize, PhysFrame, Size4KiB};
 
 /// A trait for types that can allocate a frame of memory.
 ///
@@ -15,4 +15,23 @@ pub unsafe trait FrameAllocator<S: PageSize> {
 pub trait FrameDeallocator<S: PageSize> {
     /// Deallocate the given frame of memory.
     fn deallocate_frame(&mut self, frame: PhysFrame<S>);
+}
+
+/// Represents a physical frame that is not used for any mapping.
+#[deprecated(note = "This wrapper type was removed. Use `PhysFrame` instead.")]
+#[derive(Debug)]
+pub struct UnusedPhysFrame<S: PageSize = Size4KiB>(PhysFrame<S>);
+
+#[allow(deprecated)]
+impl<S: PageSize> UnusedPhysFrame<S> {
+    /// Creates a new UnusedPhysFrame from the given frame.
+    ///
+    /// ## Safety
+    ///
+    /// This method is unsafe because the caller must guarantee
+    /// that the given frame is unused.
+    #[allow(clippy::new_ret_no_self)]
+    pub unsafe fn new(frame: PhysFrame<S>) -> PhysFrame<S> {
+        frame
+    }
 }

--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -1,7 +1,6 @@
 //! Traits for abstracting away frame allocation and deallocation.
 
-use crate::structures::paging::{PageSize, PhysFrame, Size4KiB};
-use core::ops::{Deref, DerefMut};
+use crate::structures::paging::{PageSize, PhysFrame};
 
 /// A trait for types that can allocate a frame of memory.
 ///
@@ -9,46 +8,11 @@ use core::ops::{Deref, DerefMut};
 /// the `allocate_frame` method returns only unique unused frames.
 pub unsafe trait FrameAllocator<S: PageSize> {
     /// Allocate a frame of the appropriate size and return it if possible.
-    fn allocate_frame(&mut self) -> Option<UnusedPhysFrame<S>>;
+    fn allocate_frame(&mut self) -> Option<PhysFrame<S>>;
 }
 
 /// A trait for types that can deallocate a frame of memory.
 pub trait FrameDeallocator<S: PageSize> {
     /// Deallocate the given frame of memory.
-    fn deallocate_frame(&mut self, frame: UnusedPhysFrame<S>);
-}
-
-/// Represents a physical frame that is not used for any mapping.
-#[derive(Debug)]
-pub struct UnusedPhysFrame<S: PageSize = Size4KiB>(PhysFrame<S>);
-
-impl<S: PageSize> UnusedPhysFrame<S> {
-    /// Creates a new UnusedPhysFrame from the given frame.
-    ///
-    /// ## Safety
-    ///
-    /// This method is unsafe because the caller must guarantee
-    /// that the given frame is unused.
-    pub unsafe fn new(frame: PhysFrame<S>) -> Self {
-        Self(frame)
-    }
-
-    /// Returns the physical frame as `PhysFrame` type.
-    pub fn frame(self) -> PhysFrame<S> {
-        self.0
-    }
-}
-
-impl<S: PageSize> Deref for UnusedPhysFrame<S> {
-    type Target = PhysFrame<S>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl<S: PageSize> DerefMut for UnusedPhysFrame<S> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
+    fn deallocate_frame(&mut self, frame: PhysFrame<S>);
 }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -161,7 +161,7 @@ impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
         flags: PageTableFlags,
@@ -237,7 +237,7 @@ impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
         flags: PageTableFlags,
@@ -315,7 +315,7 @@ impl<'a, P: PhysToVirt> Mapper<Size4KiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size4KiB>,
         flags: PageTableFlags,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -175,7 +175,7 @@ pub enum MapToError<S: PageSize> {
     /// given page is part of an already mapped huge page.
     ParentEntryHugePage,
     /// The given page is already mapped to a physical frame.
-    PageAlreadyMapped(UnusedPhysFrame<S>),
+    PageAlreadyMapped(PhysFrame<S>),
 }
 
 /// An error indicating that an `unmap` call failed.

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -178,6 +178,10 @@ pub trait Mapper<S: PageSize> {
 
     /// Maps the given frame to the virtual page with the same address.
     ///
+    /// This function might need additional physical frames to create new page
+    /// tables. These frames are allocated from the `frame_allocator` argument.
+    /// At most three frames are required.
+    ///
     /// ## Safety
     ///
     /// This is a convencience function that invokes [`map_to`] internally, so

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -83,8 +83,34 @@ pub trait Mapper<S: PageSize> {
     /// This function might need additional physical frames to create new page tables. These
     /// frames are allocated from the `allocator` argument. At most three frames are required.
     ///
-    /// This function is unsafe because the caller must guarantee that passed `frame` is
-    /// unused, i.e. not used for any other mappings.
+    /// ## Safety
+    ///
+    /// Creating page table mappings is a fundamentally unsafe operation because
+    /// there are various ways to break memory safety through it. For example,
+    /// re-mapping an in-use page to a different frame changes and invalidates
+    /// all values stored in that page, resulting in undefined behavior on the
+    /// next use.
+    ///
+    /// The caller must ensure that no undefined behavior or memory safety
+    /// violations can occur through the new mapping. Among other things, the
+    /// caller must prevent the following:
+    ///
+    /// - Aliasing of `&mut` references, i.e. two `&mut` references that point to
+    ///   the same physical address. This is undefined behavior in Rust.
+    ///     - This can be ensured by mapping each page to an individual physical
+    ///       frame that is not mapped anywhere else.
+    /// - Creating uninitalized or invalid values: Rust requires that all values
+    ///   have a correct memory layout. For example, a `bool` must be either a 0
+    ///   or a 1 in memory, but not a 3 or 4. An exception is the `MaybeUninit`
+    ///   wrapper type, which abstracts over possibly uninitialized memory.
+    ///     - This is only a problem when re-mapping pages to different physical
+    ///       frames. Mapping a page that is not in use yet is fine.
+    ///
+    /// Special care must be taken when sharing pages with other address spaces,
+    /// e.g. by setting the `GLOBAL` flag. For example, a global mapping must be
+    /// the same in all address spaces, otherwise undefined behavior can occur
+    /// because of TLB races. It's worth noting that all the above requirements
+    /// also apply to shared mappings, including the aliasing requirements.
     unsafe fn map_to<A>(
         &mut self,
         page: Page<S>,
@@ -118,8 +144,8 @@ pub trait Mapper<S: PageSize> {
     ///
     /// ## Safety
     ///
-    /// This function is unsafe because the caller must guarantee that the passed `frame` is
-    /// unused, i.e. not used for any other mappings.
+    /// This is a convencience function that invokes [`map_to`] internally, so
+    /// all safety requirements of it also apply for this function.
     #[inline]
     unsafe fn identity_map<A>(
         &mut self,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -148,6 +148,34 @@ pub trait Mapper<S: PageSize> {
     /// error otherwise.
     fn translate_page(&self, page: Page<S>) -> Result<PhysFrame<S>, TranslateError>;
 
+    /// Maps the given page to an unused frame obtained from the frame_allocator.
+    ///
+    /// This function allocates at least one physical frame from the given
+    /// frame allocator. It might also need additional physical frames to create
+    /// new page tables, which are also allocated from the `frame_allocator`
+    /// argument. At most four frames are required from the allocator in total.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`map_to`] internally, so
+    /// all safety requirements of it also apply for this function.
+    #[inline]
+    unsafe fn map<A>(
+        &mut self,
+        page: Page<S>,
+        flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlush<S>, MapToError<S>>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<S>,
+    {
+        let frame = frame_allocator
+            .allocate_frame()
+            .ok_or(MapToError::FrameAllocationFailed)?;
+        self.map_to(page, frame, flags, frame_allocator)
+    }
+
     /// Maps the given frame to the virtual page with the same address.
     ///
     /// ## Safety

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -128,7 +128,15 @@ pub trait Mapper<S: PageSize> {
     fn unmap(&mut self, page: Page<S>) -> Result<(PhysFrame<S>, MapperFlush<S>), UnmapError>;
 
     /// Updates the flags of an existing mapping.
-    fn update_flags(
+    ///
+    /// ## Safety
+    ///
+    /// This method is unsafe because changing the flags of a mapping
+    /// might result in undefined behavior. For example, setting the
+    /// `GLOBAL` and `MUTABLE` flags for a page might result in the corruption
+    /// of values stored in that page from processes running in other address
+    /// spaces.
+    unsafe fn update_flags(
         &mut self,
         page: Page<S>,
         flags: PageTableFlags,

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -53,10 +53,10 @@ impl PhysToVirt for PhysOffset {
 // delegate all trait implementations to inner
 
 impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: UnusedPhysFrame<Size1GiB>,
+        frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
@@ -91,10 +91,10 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
 
 impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     #[inline]
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: UnusedPhysFrame<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
@@ -129,10 +129,10 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
 
 impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     #[inline]
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: UnusedPhysFrame<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -75,7 +75,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
         flags: PageTableFlags,
@@ -113,7 +113,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
         flags: PageTableFlags,
@@ -151,7 +151,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn update_flags(
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size4KiB>,
         flags: PageTableFlags,

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -113,7 +113,7 @@ impl<'a> RecursivePageTable<'a> {
 
             if entry.is_unused() {
                 if let Some(frame) = allocator.allocate_frame() {
-                    entry.set_frame(frame.frame(), Flags::PRESENT | Flags::WRITABLE);
+                    entry.set_frame(frame, Flags::PRESENT | Flags::WRITABLE);
                     created = true;
                 } else {
                     return Err(MapToError::FrameAllocationFailed);
@@ -141,7 +141,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_1gib<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: UnusedPhysFrame<Size1GiB>,
+        frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
@@ -167,7 +167,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_2mib<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: UnusedPhysFrame<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
@@ -196,7 +196,7 @@ impl<'a> RecursivePageTable<'a> {
     fn map_to_4kib<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: UnusedPhysFrame<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
@@ -217,17 +217,17 @@ impl<'a> RecursivePageTable<'a> {
         if !p1[page.p1_index()].is_unused() {
             return Err(MapToError::PageAlreadyMapped(frame));
         }
-        p1[page.p1_index()].set_frame(frame.frame(), flags);
+        p1[page.p1_index()].set_frame(frame, flags);
 
         Ok(MapperFlush::new(page))
     }
 }
 
 impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
-        frame: UnusedPhysFrame<Size1GiB>,
+        frame: PhysFrame<Size1GiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
@@ -310,10 +310,10 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
 
 impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
     #[inline]
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
-        frame: UnusedPhysFrame<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
@@ -415,10 +415,10 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
-    fn map_to<A>(
+    unsafe fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
-        frame: UnusedPhysFrame<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
         flags: PageTableFlags,
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -267,7 +267,9 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    // allow unused_unsafe until https://github.com/rust-lang/rust/pull/69245 lands
+    #[allow(unused_unsafe)]
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
         flags: PageTableFlags,
@@ -359,7 +361,9 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    // allow unused_unsafe until https://github.com/rust-lang/rust/pull/69245 lands
+    #[allow(unused_unsafe)]
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
         flags: PageTableFlags,
@@ -465,7 +469,9 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    fn update_flags(
+    // allow unused_unsafe until https://github.com/rust-lang/rust/pull/69245 lands
+    #[allow(unused_unsafe)]
+    unsafe fn update_flags(
         &mut self,
         page: Page<Size4KiB>,
         flags: PageTableFlags,

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -3,6 +3,8 @@
 //! Page tables translate virtual memory “pages” to physical memory “frames”.
 
 pub use self::frame::PhysFrame;
+#[allow(deprecated)]
+pub use self::frame_alloc::UnusedPhysFrame;
 pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
 #[doc(no_inline)]
 pub use self::mapper::MappedPageTable;

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -3,7 +3,7 @@
 //! Page tables translate virtual memory “pages” to physical memory “frames”.
 
 pub use self::frame::PhysFrame;
-pub use self::frame_alloc::{FrameAllocator, FrameDeallocator, UnusedPhysFrame};
+pub use self::frame_alloc::{FrameAllocator, FrameDeallocator};
 #[doc(no_inline)]
 pub use self::mapper::MappedPageTable;
 pub use self::mapper::{Mapper, MapperAllSizes};


### PR DESCRIPTION
Instead of requiring the caller to specify the target frame, this method uses a frame allocated from the frame allocator. This makes the common use case of mapping a page to an unused physical frame more convenient.

Builds upon #135, so there are some additional commits in this PR. I will rebase it as soon as #135 is merged.