### PR TITLE
Add an enable_interrupts_and_hlt function that executes `sti; hlt`

### DIFF
--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -13,6 +13,13 @@ _x86_64_asm_interrupt_disable:
     cli
     retq
 
+.global _x86_64_asm_interrupt_enable_and_hlt
+.p2align 4
+_x86_64_asm_interrupt_enable_and_hlt:
+    sti
+    hlt
+    retq
+
 .global _x86_64_asm_int3
 .p2align 4
 _x86_64_asm_int3:

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -14,6 +14,12 @@ extern "C" {
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_interrupt_enable_and_hlt"
+    )]
+    pub(crate) fn x86_64_asm_interrupt_enable_and_hlt();
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_int3"
     )]
     pub(crate) fn x86_64_asm_int3();


### PR DESCRIPTION
This function atomically enable interrupts and put the CPU to sleep by executing the `sti; hlt` instruction sequence. Since the sti instruction keeps interrupts disabled until after the immediately following instruction (called "interrupt shadow"), no interrupt can occur between the two instructions.