### PR TITLE
Various improvements to VirtAddr and PhysAddr.

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -81,9 +81,19 @@ impl VirtAddr {
 
     /// Alias for [`new_truncate`][VirtAddr::new_truncate] for backwards compatibility.
     #[inline]
-    #[deprecated(note = "Use new_truncate instead")]
+    #[deprecated(note = "Use new_truncate or new_unsafe instead")]
     pub const fn new_unchecked(addr: u64) -> VirtAddr {
         Self::new_truncate(addr)
+    }
+
+    /// Creates a new virtual address, without any checks.
+    ///
+    /// ## Safety
+    ///
+    /// You must make sure bits 48..64 are equal to bit 47. This is not checked.
+    #[inline]
+    pub const unsafe fn new_unsafe(addr: u64) -> VirtAddr {
+        VirtAddr(addr)
     }
 
     /// Creates a virtual address that points to `0`.
@@ -277,6 +287,16 @@ impl PhysAddr {
     #[inline]
     pub const fn new_truncate(addr: u64) -> PhysAddr {
         PhysAddr(addr % (1 << 52))
+    }
+
+    /// Creates a new physical address, without any checks.
+    ///
+    /// ## Safety
+    ///
+    /// You must make sure bits 52..64 are zero. This is not checked.
+    #[inline]
+    pub const unsafe fn new_unsafe(addr: u64) -> PhysAddr {
+        PhysAddr(addr)
     }
 
     /// Tries to create a new physical address.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -309,6 +309,12 @@ impl PhysAddr {
         }
     }
 
+    /// Creates a physical address that points to `0`.
+    #[inline]
+    pub const fn zero() -> PhysAddr {
+        PhysAddr(0)
+    }
+
     /// Converts the address to an `u64`.
     #[inline]
     pub fn as_u64(self) -> u64 {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -266,7 +266,7 @@ impl Sub<VirtAddr> for VirtAddr {
 
 /// A passed `u64` was not a valid physical address.
 ///
-/// This means that bits 52 to 64 are not were not all null.
+/// This means that bits 52 to 64 were not all null.
 #[derive(Debug)]
 pub struct PhysAddrNotValid(u64);
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -317,14 +317,14 @@ impl PhysAddr {
 
     /// Converts the address to an `u64`.
     #[inline]
-    pub fn as_u64(self) -> u64 {
+    pub const fn as_u64(self) -> u64 {
         self.0
     }
 
     /// Convenience method for checking if a physical address is null.
     #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub fn is_null(&self) -> bool {
+    pub const fn is_null(&self) -> bool {
         self.0 == 0
     }
 


### PR DESCRIPTION
`VirtAddr::new_unchecked` didn't behave like [the `new_unchecked` functions in `core`](https://doc.rust-lang.org/std/num/struct.NonZeroU64.html#method.new_unchecked) which just wrap the value without checks or modifications, but instead behaved like `PhysAddr::new_truncate`. This change renames it to `new_truncate`, and adds unsafe ~~`new_unchecked`~~ `new_unsafe` functions.

~~Unfortunately, that does mean it's a breaking change. However,~~ I think following this convention for "unchecked" is important to not cause confusion:

- When looking for something that fixes/truncates the address, I couldn't find any function that did that. (I didn't think that `new_unchecked` would do that.)
- When looking for something that lets me unsafely wrap an address, I used `new_unchecked`, and was surprised by the compiler warning that the `unsafe` block was unnecessary.

Also fixes and adds some other small things.