### PR TITLE
Use #[inline] everywhere.

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -44,6 +44,7 @@ impl VirtAddr {
     ///
     /// This function performs sign extension of bit 47 to make the address canonical. Panics
     /// if the bits in the range 48 to 64 contain data (i.e. are not null and no sign extension).
+    #[inline]
     pub fn new(addr: u64) -> VirtAddr {
         Self::try_new(addr).expect(
             "address passed to VirtAddr::new must not contain any data \
@@ -57,6 +58,7 @@ impl VirtAddr {
     /// extension of bit 47 to make the address canonical. It succeeds if bits 48 to 64 are
     /// either a correct sign extension (i.e. copies of bit 47) or all null. Else, an error
     /// is returned.
+    #[inline]
     pub fn try_new(addr: u64) -> Result<VirtAddr, VirtAddrNotValid> {
         match addr.get_bits(47..64) {
             0 | 0x1ffff => Ok(VirtAddr(addr)),     // address is canonical
@@ -201,12 +203,14 @@ impl fmt::Debug for VirtAddr {
 
 impl Add<u64> for VirtAddr {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: u64) -> Self::Output {
         VirtAddr::new(self.0 + rhs)
     }
 }
 
 impl AddAssign<u64> for VirtAddr {
+    #[inline]
     fn add_assign(&mut self, rhs: u64) {
         *self = *self + rhs;
     }
@@ -215,6 +219,7 @@ impl AddAssign<u64> for VirtAddr {
 #[cfg(target_pointer_width = "64")]
 impl Add<usize> for VirtAddr {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: usize) -> Self::Output {
         self + rhs as u64
     }
@@ -222,6 +227,7 @@ impl Add<usize> for VirtAddr {
 
 #[cfg(target_pointer_width = "64")]
 impl AddAssign<usize> for VirtAddr {
+    #[inline]
     fn add_assign(&mut self, rhs: usize) {
         self.add_assign(rhs as u64)
     }
@@ -229,12 +235,14 @@ impl AddAssign<usize> for VirtAddr {
 
 impl Sub<u64> for VirtAddr {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: u64) -> Self::Output {
         VirtAddr::new(self.0.checked_sub(rhs).unwrap())
     }
 }
 
 impl SubAssign<u64> for VirtAddr {
+    #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
     }
@@ -243,6 +251,7 @@ impl SubAssign<u64> for VirtAddr {
 #[cfg(target_pointer_width = "64")]
 impl Sub<usize> for VirtAddr {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: usize) -> Self::Output {
         self - rhs as u64
     }
@@ -250,6 +259,7 @@ impl Sub<usize> for VirtAddr {
 
 #[cfg(target_pointer_width = "64")]
 impl SubAssign<usize> for VirtAddr {
+    #[inline]
     fn sub_assign(&mut self, rhs: usize) {
         self.sub_assign(rhs as u64)
     }
@@ -257,6 +267,7 @@ impl SubAssign<usize> for VirtAddr {
 
 impl Sub<VirtAddr> for VirtAddr {
     type Output = u64;
+    #[inline]
     fn sub(self, rhs: VirtAddr) -> Self::Output {
         self.as_u64().checked_sub(rhs.as_u64()).unwrap()
     }
@@ -272,6 +283,7 @@ impl PhysAddr {
     /// Creates a new physical address.
     ///
     /// Panics if a bit in the range 52 to 64 is set.
+    #[inline]
     pub fn new(addr: u64) -> PhysAddr {
         assert_eq!(
             addr.get_bits(52..64),
@@ -300,6 +312,7 @@ impl PhysAddr {
     /// Tries to create a new physical address.
     ///
     /// Fails if any bits in the range 52 to 64 are set.
+    #[inline]
     pub fn try_new(addr: u64) -> Result<PhysAddr, PhysAddrNotValid> {
         match addr.get_bits(52..64) {
             0 => Ok(PhysAddr(addr)), // address is valid
@@ -365,24 +378,28 @@ impl fmt::Debug for PhysAddr {
 }
 
 impl fmt::Binary for PhysAddr {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
 impl fmt::LowerHex for PhysAddr {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
 impl fmt::Octal for PhysAddr {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
 }
 
 impl fmt::UpperHex for PhysAddr {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -390,12 +407,14 @@ impl fmt::UpperHex for PhysAddr {
 
 impl Add<u64> for PhysAddr {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: u64) -> Self::Output {
         PhysAddr::new(self.0 + rhs)
     }
 }
 
 impl AddAssign<u64> for PhysAddr {
+    #[inline]
     fn add_assign(&mut self, rhs: u64) {
         *self = *self + rhs;
     }
@@ -404,6 +423,7 @@ impl AddAssign<u64> for PhysAddr {
 #[cfg(target_pointer_width = "64")]
 impl Add<usize> for PhysAddr {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: usize) -> Self::Output {
         self + rhs as u64
     }
@@ -411,6 +431,7 @@ impl Add<usize> for PhysAddr {
 
 #[cfg(target_pointer_width = "64")]
 impl AddAssign<usize> for PhysAddr {
+    #[inline]
     fn add_assign(&mut self, rhs: usize) {
         self.add_assign(rhs as u64)
     }
@@ -418,12 +439,14 @@ impl AddAssign<usize> for PhysAddr {
 
 impl Sub<u64> for PhysAddr {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: u64) -> Self::Output {
         PhysAddr::new(self.0.checked_sub(rhs).unwrap())
     }
 }
 
 impl SubAssign<u64> for PhysAddr {
+    #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
     }
@@ -432,6 +455,7 @@ impl SubAssign<u64> for PhysAddr {
 #[cfg(target_pointer_width = "64")]
 impl Sub<usize> for PhysAddr {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: usize) -> Self::Output {
         self - rhs as u64
     }
@@ -439,6 +463,7 @@ impl Sub<usize> for PhysAddr {
 
 #[cfg(target_pointer_width = "64")]
 impl SubAssign<usize> for PhysAddr {
+    #[inline]
     fn sub_assign(&mut self, rhs: usize) {
         self.sub_assign(rhs as u64)
     }
@@ -446,6 +471,7 @@ impl SubAssign<usize> for PhysAddr {
 
 impl Sub<PhysAddr> for PhysAddr {
     type Output = u64;
+    #[inline]
     fn sub(self, rhs: PhysAddr) -> Self::Output {
         self.as_u64().checked_sub(rhs.as_u64()).unwrap()
     }
@@ -465,6 +491,7 @@ pub fn align_down(addr: u64, align: u64) -> u64 {
 ///
 /// Returns the smallest x with alignment `align` so that x >= addr. The alignment must be
 /// a power of 2.
+#[inline]
 pub fn align_up(addr: u64, align: u64) -> u64 {
     assert!(align.is_power_of_two(), "`align` must be a power of two");
     let align_mask = align - 1;

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -14,6 +14,7 @@ impl PortRead for u8 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn read_from_port(port: u16) -> u8 {
         crate::asm::x86_64_asm_read_from_port_u8(port)
     }
@@ -29,6 +30,7 @@ impl PortRead for u16 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn read_from_port(port: u16) -> u16 {
         crate::asm::x86_64_asm_read_from_port_u16(port)
     }
@@ -44,6 +46,7 @@ impl PortRead for u32 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn read_from_port(port: u16) -> u32 {
         crate::asm::x86_64_asm_read_from_port_u32(port)
     }
@@ -57,6 +60,7 @@ impl PortWrite for u8 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn write_to_port(port: u16, value: u8) {
         crate::asm::x86_64_asm_write_to_port_u8(port, value)
     }
@@ -70,6 +74,7 @@ impl PortWrite for u16 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn write_to_port(port: u16, value: u16) {
         crate::asm::x86_64_asm_write_to_port_u16(port, value)
     }
@@ -83,6 +88,7 @@ impl PortWrite for u32 {
     }
 
     #[cfg(not(feature = "inline_asm"))]
+    #[inline]
     unsafe fn write_to_port(port: u16, value: u32) {
         crate::asm::x86_64_asm_write_to_port_u32(port, value)
     }
@@ -116,6 +122,7 @@ pub struct Port<T: PortReadWrite> {
 impl<T: PortRead> PortReadOnly<T> {
     const_fn! {
         /// Creates a read only I/O port with the given port number.
+        #[inline]
         pub fn new(port: u16) -> PortReadOnly<T> {
             PortReadOnly {
                 port,
@@ -139,6 +146,7 @@ impl<T: PortRead> PortReadOnly<T> {
 impl<T: PortWrite> PortWriteOnly<T> {
     const_fn! {
         /// Creates a write only I/O port with the given port number.
+        #[inline]
         pub fn new(port: u16) -> PortWriteOnly<T> {
             PortWriteOnly {
                 port,
@@ -162,6 +170,7 @@ impl<T: PortWrite> PortWriteOnly<T> {
 impl<T: PortReadWrite> Port<T> {
     const_fn! {
         /// Creates an I/O port with the given port number.
+        #[inline]
         pub fn new(port: u16) -> Port<T> {
             Port {
                 port,

--- a/src/instructions/random.rs
+++ b/src/instructions/random.rs
@@ -8,6 +8,7 @@ pub struct RdRand(());
 #[allow(clippy::trivially_copy_pass_by_ref)]
 impl RdRand {
     /// Creates Some(RdRand) if RDRAND is supported, None otherwise
+    #[inline]
     pub fn new() -> Option<Self> {
         // RDRAND support indicated by CPUID page 01h, ecx bit 30
         // https://en.wikipedia.org/wiki/RdRand#Overview

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -13,6 +13,7 @@ use crate::structures::gdt::SegmentSelector;
 ///
 /// This function is unsafe because the caller must ensure that `sel`
 /// is a valid code segment descriptor.
+#[inline]
 pub unsafe fn set_cs(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
     #[inline(always)]

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -231,6 +231,7 @@ mod x86_64 {
 
     impl Cr3 {
         /// Read the current P4 table address from the CR3 register.
+        #[inline]
         pub fn read() -> (PhysFrame, Cr3Flags) {
             let value: u64;
 

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -13,6 +13,7 @@ pub struct Msr(u32);
 
 impl Msr {
     /// Create an instance from a register.
+    #[inline]
     pub const fn new(reg: u32) -> Msr {
         Msr(reg)
     }
@@ -324,6 +325,7 @@ mod x86_64 {
         /// This function will fail if the segment selectors are
         /// not in the correct offset of each other or if the
         /// segment selectors do not have correct privileges.
+        #[inline]
         pub fn write(
             cs_sysret: SegmentSelector,
             ss_sysret: SegmentSelector,

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -21,6 +21,7 @@ impl SegmentSelector {
     /// # Arguments
     ///  * `index`: index in GDT or LDT array (not the offset)
     ///  * `rpl`: the requested privilege level
+    #[inline]
     pub const fn new(index: u16, rpl: PrivilegeLevel) -> SegmentSelector {
         SegmentSelector(index << 3 | (rpl as u16))
     }
@@ -98,6 +99,7 @@ pub struct GlobalDescriptorTable {
 
 impl GlobalDescriptorTable {
     /// Creates an empty GDT.
+    #[inline]
     pub const fn new() -> GlobalDescriptorTable {
         GlobalDescriptorTable {
             table: [0; 8],
@@ -108,6 +110,7 @@ impl GlobalDescriptorTable {
     /// Adds the given segment descriptor to the GDT, returning the segment selector.
     ///
     /// Panics if the GDT has no free entries left.
+    #[inline]
     pub fn add_entry(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => self.push(value),
@@ -126,6 +129,7 @@ impl GlobalDescriptorTable {
     /// [load_ss](crate::instructions::segmentation::load_ss),
     /// [set_cs](crate::instructions::segmentation::set_cs).
     #[cfg(target_arch = "x86_64")]
+    #[inline]
     pub fn load(&'static self) {
         use crate::instructions::tables::{lgdt, DescriptorTablePointer};
         use core::mem::size_of;
@@ -138,6 +142,7 @@ impl GlobalDescriptorTable {
         unsafe { lgdt(&ptr) };
     }
 
+    #[inline]
     fn push(&mut self, value: u64) -> usize {
         if self.next_free < self.table.len() {
             let index = self.next_free;
@@ -220,6 +225,7 @@ impl Descriptor {
     }
 
     /// Creates a TSS system descriptor for the given TSS.
+    #[inline]
     pub fn tss_segment(tss: &'static TaskStateSegment) -> Descriptor {
         use self::DescriptorFlags as Flags;
         use core::mem::size_of;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -372,6 +372,7 @@ pub struct InterruptDescriptorTable {
 impl InterruptDescriptorTable {
     const_fn! {
         /// Creates a new IDT filled with non-present entries.
+        #[inline]
         pub fn new() -> InterruptDescriptorTable {
             InterruptDescriptorTable {
                 divide_error: Entry::missing(),
@@ -500,6 +501,7 @@ impl Index<usize> for InterruptDescriptorTable {
     ///
     /// Panics if index is outside the IDT (i.e. greater than 255) or if the entry is an
     /// exception that pushes an error code (use the struct fields for accessing these entries).
+    #[inline]
     fn index(&self, index: usize) -> &Self::Output {
         match index {
             0 => &self.divide_error,
@@ -530,6 +532,7 @@ impl IndexMut<usize> for InterruptDescriptorTable {
     ///
     /// Panics if index is outside the IDT (i.e. greater than 255) or if the entry is an
     /// exception that pushes an error code (use the struct fields for accessing these entries).
+    #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         match index {
             0 => &mut self.divide_error,
@@ -587,6 +590,7 @@ pub type DivergingHandlerFuncWithErrCode =
 
 impl<F> Entry<F> {
     /// Creates a non-present IDT entry (but sets the must-be-one bits).
+    #[inline]
     pub const fn missing() -> Self {
         Entry {
             gdt_selector: 0,
@@ -607,6 +611,7 @@ impl<F> Entry<F> {
     /// The function returns a mutable reference to the entry's options that allows
     /// further customization.
     #[cfg(target_arch = "x86_64")]
+    #[inline]
     fn set_handler_addr(&mut self, addr: u64) -> &mut EntryOptions {
         use crate::instructions::segmentation;
 
@@ -632,6 +637,7 @@ macro_rules! impl_set_handler_fn {
             ///
             /// The function returns a mutable reference to the entry's options that allows
             /// further customization.
+            #[inline]
             pub fn set_handler_fn(&mut self, handler: $h) -> &mut EntryOptions {
                 self.set_handler_addr(handler as u64)
             }
@@ -740,12 +746,14 @@ impl InterruptStackFrame {
 impl Deref for InterruptStackFrame {
     type Target = InterruptStackFrameValue;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
 
 impl fmt::Debug for InterruptStackFrame {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.value.fmt(f)
     }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -86,7 +86,6 @@ impl<S: PageSize> PhysFrame<S> {
 }
 
 impl<S: PageSize> fmt::Debug for PhysFrame<S> {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_fmt(format_args!(
             "PhysFrame[{}]({:#x})",
@@ -98,12 +97,14 @@ impl<S: PageSize> fmt::Debug for PhysFrame<S> {
 
 impl<S: PageSize> Add<u64> for PhysFrame<S> {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: u64) -> Self::Output {
         PhysFrame::containing_address(self.start_address() + rhs * S::SIZE)
     }
 }
 
 impl<S: PageSize> AddAssign<u64> for PhysFrame<S> {
+    #[inline]
     fn add_assign(&mut self, rhs: u64) {
         *self = *self + rhs;
     }
@@ -111,12 +112,14 @@ impl<S: PageSize> AddAssign<u64> for PhysFrame<S> {
 
 impl<S: PageSize> Sub<u64> for PhysFrame<S> {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: u64) -> Self::Output {
         PhysFrame::containing_address(self.start_address() - rhs * S::SIZE)
     }
 }
 
 impl<S: PageSize> SubAssign<u64> for PhysFrame<S> {
+    #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
     }
@@ -124,6 +127,7 @@ impl<S: PageSize> SubAssign<u64> for PhysFrame<S> {
 
 impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
     type Output = u64;
+    #[inline]
     fn sub(self, rhs: PhysFrame<S>) -> Self::Output {
         (self.start_address - rhs.start_address) / S::SIZE
     }
@@ -150,6 +154,7 @@ impl<S: PageSize> PhysFrameRange<S> {
 impl<S: PageSize> Iterator for PhysFrameRange<S> {
     type Item = PhysFrame<S>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.start < self.end {
             let frame = self.start;
@@ -191,6 +196,7 @@ impl<S: PageSize> PhysFrameRangeInclusive<S> {
 impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
     type Item = PhysFrame<S>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
             let frame = self.start;

--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -31,11 +31,13 @@ impl<S: PageSize> UnusedPhysFrame<S> {
     ///
     /// This method is unsafe because the caller must guarantee
     /// that the given frame is unused.
+    #[inline]
     pub unsafe fn new(frame: PhysFrame<S>) -> Self {
         Self(frame)
     }
 
     /// Returns the physical frame as `PhysFrame` type.
+    #[inline]
     pub fn frame(self) -> PhysFrame<S> {
         self.0
     }
@@ -45,6 +47,7 @@ impl<S: PageSize> UnusedPhysFrame<S> {
 impl<S: PageSize> Deref for UnusedPhysFrame<S> {
     type Target = PhysFrame<S>;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -52,6 +55,7 @@ impl<S: PageSize> Deref for UnusedPhysFrame<S> {
 
 #[allow(deprecated)]
 impl<S: PageSize> DerefMut for UnusedPhysFrame<S> {
+    #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -29,6 +29,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
     /// closure is correct. Also, the passed `level_4_table` must point to the level 4 page table
     /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
     /// by writing to an illegal memory location.
+    #[inline]
     pub unsafe fn new(level_4_table: &'a mut PageTable, phys_to_virt: P) -> Self {
         Self {
             level_4_table,
@@ -122,6 +123,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
@@ -195,6 +197,7 @@ impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size2MiB>,
@@ -276,6 +279,7 @@ impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
 }
 
 impl<'a, P: PhysToVirt> Mapper<Size4KiB> for MappedPageTable<'a, P> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,
@@ -408,6 +412,7 @@ struct PageTableWalker<P: PhysToVirt> {
 }
 
 impl<P: PhysToVirt> PageTableWalker<P> {
+    #[inline]
     pub unsafe fn new(phys_to_virt: P) -> Self {
         Self { phys_to_virt }
     }
@@ -502,6 +507,7 @@ enum PageTableCreateError {
 }
 
 impl From<PageTableCreateError> for MapToError<Size4KiB> {
+    #[inline]
     fn from(err: PageTableCreateError) -> Self {
         match err {
             PageTableCreateError::MappedToHugePage => MapToError::ParentEntryHugePage,
@@ -511,6 +517,7 @@ impl From<PageTableCreateError> for MapToError<Size4KiB> {
 }
 
 impl From<PageTableCreateError> for MapToError<Size2MiB> {
+    #[inline]
     fn from(err: PageTableCreateError) -> Self {
         match err {
             PageTableCreateError::MappedToHugePage => MapToError::ParentEntryHugePage,
@@ -520,6 +527,7 @@ impl From<PageTableCreateError> for MapToError<Size2MiB> {
 }
 
 impl From<PageTableCreateError> for MapToError<Size1GiB> {
+    #[inline]
     fn from(err: PageTableCreateError) -> Self {
         match err {
             PageTableCreateError::MappedToHugePage => MapToError::ParentEntryHugePage,
@@ -529,6 +537,7 @@ impl From<PageTableCreateError> for MapToError<Size1GiB> {
 }
 
 impl From<FrameError> for PageTableWalkError {
+    #[inline]
     fn from(err: FrameError) -> Self {
         match err {
             FrameError::HugeFrame => PageTableWalkError::MappedToHugePage,
@@ -538,6 +547,7 @@ impl From<FrameError> for PageTableWalkError {
 }
 
 impl From<PageTableWalkError> for UnmapError {
+    #[inline]
     fn from(err: PageTableWalkError) -> Self {
         match err {
             PageTableWalkError::MappedToHugePage => UnmapError::ParentEntryHugePage,
@@ -547,6 +557,7 @@ impl From<PageTableWalkError> for UnmapError {
 }
 
 impl From<PageTableWalkError> for FlagUpdateError {
+    #[inline]
     fn from(err: PageTableWalkError) -> Self {
         match err {
             PageTableWalkError::MappedToHugePage => FlagUpdateError::ParentEntryHugePage,
@@ -556,6 +567,7 @@ impl From<PageTableWalkError> for FlagUpdateError {
 }
 
 impl From<PageTableWalkError> for TranslateError {
+    #[inline]
     fn from(err: PageTableWalkError) -> Self {
         match err {
             PageTableWalkError::MappedToHugePage => TranslateError::ParentEntryHugePage,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -183,6 +183,7 @@ pub struct MapperFlush<S: PageSize>(Page<S>);
 
 impl<S: PageSize> MapperFlush<S> {
     /// Create a new flush promise
+    #[inline]
     fn new(page: Page<S>) -> Self {
         MapperFlush(page)
     }

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -53,6 +53,7 @@ impl PhysToVirt for PhysOffset {
 // delegate all trait implementations to inner
 
 impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -44,6 +44,7 @@ impl<'a> RecursivePageTable<'a> {
     /// - The page table must be active, i.e. the CR3 register must contain its physical address.
     ///
     /// Otherwise `Err(())` is returned.
+    #[inline]
     pub fn new(table: &'a mut PageTable) -> Result<Self, ()> {
         let page = Page::containing_address(VirtAddr::new(table as *const _ as u64));
         let recursive_index = page.p4_index();
@@ -224,6 +225,7 @@ impl<'a> RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size1GiB>,
@@ -419,6 +421,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
 }
 
 impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
+    #[inline]
     unsafe fn map_to<A>(
         &mut self,
         page: Page<Size4KiB>,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -161,6 +161,7 @@ impl<S: NotGiantPageSize> Page<S> {
 
 impl Page<Size1GiB> {
     /// Returns the 1GiB memory page with the specified page table indices.
+    #[inline]
     pub fn from_page_table_indices_1gib(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
@@ -176,6 +177,7 @@ impl Page<Size1GiB> {
 
 impl Page<Size2MiB> {
     /// Returns the 2MiB memory page with the specified page table indices.
+    #[inline]
     pub fn from_page_table_indices_2mib(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
@@ -193,6 +195,7 @@ impl Page<Size2MiB> {
 
 impl Page<Size4KiB> {
     /// Returns the 4KiB memory page with the specified page table indices.
+    #[inline]
     pub fn from_page_table_indices(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
@@ -231,12 +234,14 @@ impl<S: PageSize> fmt::Debug for Page<S> {
 
 impl<S: PageSize> Add<u64> for Page<S> {
     type Output = Self;
+    #[inline]
     fn add(self, rhs: u64) -> Self::Output {
         Page::containing_address(self.start_address() + rhs * S::SIZE)
     }
 }
 
 impl<S: PageSize> AddAssign<u64> for Page<S> {
+    #[inline]
     fn add_assign(&mut self, rhs: u64) {
         *self = *self + rhs;
     }
@@ -244,12 +249,14 @@ impl<S: PageSize> AddAssign<u64> for Page<S> {
 
 impl<S: PageSize> Sub<u64> for Page<S> {
     type Output = Self;
+    #[inline]
     fn sub(self, rhs: u64) -> Self::Output {
         Page::containing_address(self.start_address() - rhs * S::SIZE)
     }
 }
 
 impl<S: PageSize> SubAssign<u64> for Page<S> {
+    #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
     }
@@ -257,6 +264,7 @@ impl<S: PageSize> SubAssign<u64> for Page<S> {
 
 impl<S: PageSize> Sub<Self> for Page<S> {
     type Output = u64;
+    #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         (self.start_address - rhs.start_address) / S::SIZE
     }
@@ -274,6 +282,7 @@ pub struct PageRange<S: PageSize = Size4KiB> {
 
 impl<S: PageSize> PageRange<S> {
     /// Returns wether this range contains no pages.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.start >= self.end
     }
@@ -282,6 +291,7 @@ impl<S: PageSize> PageRange<S> {
 impl<S: PageSize> Iterator for PageRange<S> {
     type Item = Page<S>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.start < self.end {
             let page = self.start;
@@ -325,6 +335,7 @@ pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
 
 impl<S: PageSize> PageRangeInclusive<S> {
     /// Returns wether this range contains no pages.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.start >= self.end
     }
@@ -333,6 +344,7 @@ impl<S: PageSize> PageRangeInclusive<S> {
 impl<S: PageSize> Iterator for PageRangeInclusive<S> {
     type Item = Page<S>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
             let page = self.start;

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -27,6 +27,7 @@ pub struct PageTableEntry {
 
 impl PageTableEntry {
     /// Creates an unused page table entry.
+    #[inline]
     pub const fn new() -> Self {
         PageTableEntry { entry: 0 }
     }
@@ -62,6 +63,7 @@ impl PageTableEntry {
     /// - `FrameError::FrameNotPresent` if the entry doesn't have the `PRESENT` flag set.
     /// - `FrameError::HugeFrame` if the entry has the `HUGE_PAGE` flag set (for huge pages the
     ///    `addr` function must be used)
+    #[inline]
     pub fn frame(&self) -> Result<PhysFrame, FrameError> {
         if !self.flags().contains(PageTableFlags::PRESENT) {
             Err(FrameError::FrameNotPresent)
@@ -184,6 +186,7 @@ pub struct PageTable {
 impl PageTable {
     /// Creates an empty page table.
     #[cfg(feature = "const_fn")]
+    #[inline]
     pub const fn new() -> Self {
         PageTable {
             entries: [PageTableEntry::new(); ENTRY_COUNT],
@@ -192,6 +195,7 @@ impl PageTable {
 
     /// Creates an empty page table.
     #[cfg(not(feature = "const_fn"))]
+    #[inline]
     pub fn new() -> Self {
         PageTable {
             entries: array_init::array_init(|_| PageTableEntry::new()),
@@ -207,11 +211,13 @@ impl PageTable {
     }
 
     /// Returns an iterator over the entries of the page table.
+    #[inline]
     pub fn iter(&self) -> impl Iterator<Item = &PageTableEntry> {
         self.entries.iter()
     }
 
     /// Returns an iterator that allows modifying the entries of the page table.
+    #[inline]
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut PageTableEntry> {
         self.entries.iter_mut()
     }
@@ -220,12 +226,14 @@ impl PageTable {
 impl Index<usize> for PageTable {
     type Output = PageTableEntry;
 
+    #[inline]
     fn index(&self, index: usize) -> &Self::Output {
         &self.entries[index]
     }
 }
 
 impl IndexMut<usize> for PageTable {
+    #[inline]
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
         &mut self.entries[index]
     }
@@ -248,6 +256,7 @@ impl IndexMut<PageTableIndex> for PageTable {
 }
 
 impl fmt::Debug for PageTable {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.entries[..].fmt(f)
     }
@@ -263,6 +272,7 @@ pub struct PageTableIndex(u16);
 
 impl PageTableIndex {
     /// Creates a new index from the given `u16`. Panics if the given value is >=512.
+    #[inline]
     pub fn new(index: u16) -> Self {
         assert!(usize::from(index) < ENTRY_COUNT);
         Self(index)
@@ -313,6 +323,7 @@ pub struct PageOffset(u16);
 
 impl PageOffset {
     /// Creates a new offset from the given `u16`. Panics if the passed value is >=4096.
+    #[inline]
     pub fn new(offset: u16) -> Self {
         assert!(offset < (1 << 12));
         Self(offset)

--- a/src/structures/tss.rs
+++ b/src/structures/tss.rs
@@ -24,6 +24,7 @@ pub struct TaskStateSegment {
 impl TaskStateSegment {
     /// Creates a new TSS with zeroed privilege and interrupt stack table and a zero
     /// `iomap_base`.
+    #[inline]
     pub const fn new() -> TaskStateSegment {
         TaskStateSegment {
             privilege_stack_table: [VirtAddr::zero(); 3],


### PR DESCRIPTION
I tried to follow the following rules for determining if something
should be #[inline]:

- Functions that are trivial. (E.g. implementations of `Add`, or a
  trivial `new` function.)
- Functions that do not appear trivial, but would generate trivial
  assembly. (E.g. functions with mostly Rust code that don't result much
  generated code: `use` statements, wrapping values, bit twiddling,
  `#[cfg]`, `PhantomData`, etc.)
- Functions that only call another function.
- Functions that could benefit a lot from inline optimization:
  - Functions that have asserts/matches/ifs on the parameters, which are
    likely constant or known to be in a certain range:
    If a function starts with `assert!(param < 32)`, inlining enables
    the compiler to completely optimize the check away if it already
    knows the value to always be less than 32.
    If a function matches on a parameter, inlining allows throwing all
   but one match arm away.
- Functions where knowing the return value could benefit optimization on
  later calls/code.