### PR TITLE
Make FrameDeallocator::deallocate_frame unsafe

### DIFF
--- a/src/structures/paging/frame_alloc.rs
+++ b/src/structures/paging/frame_alloc.rs
@@ -14,8 +14,12 @@ pub unsafe trait FrameAllocator<S: PageSize> {
 
 /// A trait for types that can deallocate a frame of memory.
 pub trait FrameDeallocator<S: PageSize> {
-    /// Deallocate the given frame of memory.
-    fn deallocate_frame(&mut self, frame: PhysFrame<S>);
+    /// Deallocate the given unused frame.
+    ///
+    /// ## Safety
+    ///
+    /// The caller must ensure that the passed frame is unused.
+    unsafe fn deallocate_frame(&mut self, frame: PhysFrame<S>);
 }
 
 /// Represents a physical frame that is not used for any mapping.


### PR DESCRIPTION
This method should be unsafe because the caller must ensure that the passed frame is unused. Prior to #135, this was ensured by the `UnusedPhysFrame` type, which is now removed.

This is a **breaking change**.

Reported in https://github.com/rust-osdev/x86_64/commit/8a257cc78094c4f1d7fbaaa8c1c7ba11aa62bafe#r38430639.