### PR TITLE
Don't pass small trivially copyable types by reference.

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -38,7 +38,6 @@ pub struct PhysAddr(u64);
 #[derive(Debug)]
 pub struct VirtAddrNotValid(u64);
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
 impl VirtAddr {
     /// Creates a new canonical virtual address.
     ///
@@ -166,31 +165,31 @@ impl VirtAddr {
 
     /// Returns the 12-bit page offset of this virtual address.
     #[inline]
-    pub const fn page_offset(&self) -> PageOffset {
+    pub const fn page_offset(self) -> PageOffset {
         PageOffset::new_truncate(self.0 as u16)
     }
 
     /// Returns the 9-bit level 1 page table index.
     #[inline]
-    pub const fn p1_index(&self) -> PageTableIndex {
+    pub const fn p1_index(self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12) as u16)
     }
 
     /// Returns the 9-bit level 2 page table index.
     #[inline]
-    pub const fn p2_index(&self) -> PageTableIndex {
+    pub const fn p2_index(self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9) as u16)
     }
 
     /// Returns the 9-bit level 3 page table index.
     #[inline]
-    pub const fn p3_index(&self) -> PageTableIndex {
+    pub const fn p3_index(self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9 >> 9) as u16)
     }
 
     /// Returns the 9-bit level 4 page table index.
     #[inline]
-    pub const fn p4_index(&self) -> PageTableIndex {
+    pub const fn p4_index(self) -> PageTableIndex {
         PageTableIndex::new_truncate((self.0 >> 12 >> 9 >> 9 >> 9) as u16)
     }
 }
@@ -333,9 +332,8 @@ impl PhysAddr {
     }
 
     /// Convenience method for checking if a physical address is null.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub const fn is_null(&self) -> bool {
+    pub const fn is_null(self) -> bool {
         self.0 == 0
     }
 

--- a/src/instructions/random.rs
+++ b/src/instructions/random.rs
@@ -5,7 +5,6 @@
 pub struct RdRand(());
 
 #[cfg(target_arch = "x86_64")]
-#[allow(clippy::trivially_copy_pass_by_ref)]
 impl RdRand {
     /// Creates Some(RdRand) if RDRAND is supported, None otherwise
     #[inline]
@@ -23,7 +22,7 @@ impl RdRand {
     /// Uniformly sampled u64.
     /// May fail in rare circumstances or heavy load.
     #[inline]
-    pub fn get_u64(&self) -> Option<u64> {
+    pub fn get_u64(self) -> Option<u64> {
         let mut res: u64 = 0;
         unsafe {
             match core::arch::x86_64::_rdrand64_step(&mut res) {
@@ -38,7 +37,7 @@ impl RdRand {
     /// Uniformly sampled u32.
     /// May fail in rare circumstances or heavy load.
     #[inline]
-    pub fn get_u32(&self) -> Option<u32> {
+    pub fn get_u32(self) -> Option<u32> {
         let mut res: u32 = 0;
         unsafe {
             match core::arch::x86_64::_rdrand32_step(&mut res) {
@@ -53,7 +52,7 @@ impl RdRand {
     /// Uniformly sampled u16.
     /// May fail in rare circumstances or heavy load.
     #[inline]
-    pub fn get_u16(&self) -> Option<u16> {
+    pub fn get_u16(self) -> Option<u16> {
         let mut res: u16 = 0;
         unsafe {
             match core::arch::x86_64::_rdrand16_step(&mut res) {

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -27,16 +27,14 @@ impl SegmentSelector {
     }
 
     /// Returns the GDT index.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub fn index(&self) -> u16 {
+    pub fn index(self) -> u16 {
         self.0 >> 3
     }
 
     /// Returns the requested privilege level.
-    #[allow(clippy::trivially_copy_pass_by_ref)]
     #[inline]
-    pub fn rpl(&self) -> PrivilegeLevel {
+    pub fn rpl(self) -> PrivilegeLevel {
         PrivilegeLevel::from_u16(self.0.get_bits(0..2))
     }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -52,18 +52,16 @@ impl<S: PageSize> PhysFrame<S> {
 
     const_fn! {
         /// Returns the start address of the frame.
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         #[inline]
-        pub fn start_address(&self) -> PhysAddr {
+        pub fn start_address(self) -> PhysAddr {
             self.start_address
         }
     }
 
     const_fn! {
         /// Returns the size the frame (4KB, 2MB or 1GB).
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         #[inline]
-        pub fn size(&self) -> u64 {
+        pub fn size(self) -> u64 {
             S::SIZE
         }
     }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -59,7 +59,6 @@ pub struct Page<S: PageSize = Size4KiB> {
     size: PhantomData<S>,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
 impl<S: PageSize> Page<S> {
     /// The page size in bytes.
     pub const SIZE: u64 = S::SIZE;
@@ -102,7 +101,7 @@ impl<S: PageSize> Page<S> {
     const_fn! {
         /// Returns the start address of the page.
         #[inline]
-        pub fn start_address(&self) -> VirtAddr {
+        pub fn start_address(self) -> VirtAddr {
             self.start_address
         }
     }
@@ -110,7 +109,7 @@ impl<S: PageSize> Page<S> {
     const_fn! {
         /// Returns the size the page (4KB, 2MB or 1GB).
         #[inline]
-        pub fn size(&self) -> u64 {
+        pub fn size(self) -> u64 {
             S::SIZE
         }
     }
@@ -118,7 +117,7 @@ impl<S: PageSize> Page<S> {
     const_fn! {
         /// Returns the level 4 page table index of this page.
         #[inline]
-        pub fn p4_index(&self) -> PageTableIndex {
+        pub fn p4_index(self) -> PageTableIndex {
             self.start_address().p4_index()
         }
     }
@@ -126,7 +125,7 @@ impl<S: PageSize> Page<S> {
     const_fn! {
         /// Returns the level 3 page table index of this page.
         #[inline]
-        pub fn p3_index(&self) -> PageTableIndex {
+        pub fn p3_index(self) -> PageTableIndex {
             self.start_address().p3_index()
         }
     }
@@ -151,9 +150,8 @@ impl<S: PageSize> Page<S> {
 impl<S: NotGiantPageSize> Page<S> {
     const_fn! {
         /// Returns the level 2 page table index of this page.
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         #[inline]
-        pub fn p2_index(&self) -> PageTableIndex {
+        pub fn p2_index(self) -> PageTableIndex {
             self.start_address().p2_index()
         }
     }
@@ -214,9 +212,8 @@ impl Page<Size4KiB> {
 
     const_fn! {
         /// Returns the level 1 page table index of this page.
-        #[allow(clippy::trivially_copy_pass_by_ref)]
         #[inline]
-        pub fn p1_index(&self) -> PageTableIndex {
+        pub fn p1_index(self) -> PageTableIndex {
             self.start_address().p1_index()
         }
     }


### PR DESCRIPTION
_Edit(phil-opp)_: This is a **breaking change**.