### PR TITLE
Paging/Mapper: include active page table flags in translate() result

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -376,13 +376,10 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Ok(page_table) => page_table,
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
-                let frame = PhysFrame::containing_address(p3[addr.p3_index()].addr());
-                let flags = p3[addr.p3_index()].flags();
-                let offset = addr.as_u64() & 0o_777_777_7777;
                 return TranslateResult::Frame1GiB {
-                    frame,
-                    offset,
-                    flags,
+                    frame: PhysFrame::containing_address(p3[addr.p3_index()].addr()),
+                    offset: addr.as_u64() & 0o_777_777_7777,
+                    flags: p3[addr.p3_index()].flags(),
                 };
             }
         };
@@ -390,13 +387,10 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Ok(page_table) => page_table,
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
-                let frame = PhysFrame::containing_address(p2[addr.p2_index()].addr());
-                let flags = p2[addr.p2_index()].flags();
-                let offset = addr.as_u64() & 0o_777_7777;
                 return TranslateResult::Frame2MiB {
-                    frame,
-                    offset,
-                    flags,
+                    frame: PhysFrame::containing_address(p2[addr.p2_index()].addr()),
+                    offset: addr.as_u64() & 0o_777_7777,
+                    flags: p2[addr.p2_index()].flags(),
                 };
             }
         };
@@ -411,12 +405,10 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Ok(frame) => frame,
             Err(()) => return TranslateResult::InvalidFrameAddress(p1_entry.addr()),
         };
-        let offset = u64::from(addr.page_offset());
-        let flags = p1_entry.flags();
         TranslateResult::Frame4KiB {
             frame,
-            offset,
-            flags,
+            offset: u64::from(addr.page_offset()),
+            flags: p1_entry.flags(),
         }
     }
 }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -377,8 +377,13 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
                 let frame = PhysFrame::containing_address(p3[addr.p3_index()].addr());
+                let flags = p3[addr.p3_index()].flags();
                 let offset = addr.as_u64() & 0o_777_777_7777;
-                return TranslateResult::Frame1GiB { frame, offset };
+                return TranslateResult::Frame1GiB {
+                    frame,
+                    offset,
+                    flags,
+                };
             }
         };
         let p1 = match self.page_table_walker.next_table(&p2[addr.p2_index()]) {
@@ -386,8 +391,13 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
                 let frame = PhysFrame::containing_address(p2[addr.p2_index()].addr());
+                let flags = p2[addr.p2_index()].flags();
                 let offset = addr.as_u64() & 0o_777_7777;
-                return TranslateResult::Frame2MiB { frame, offset };
+                return TranslateResult::Frame2MiB {
+                    frame,
+                    offset,
+                    flags,
+                };
             }
         };
 
@@ -402,7 +412,12 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Err(()) => return TranslateResult::InvalidFrameAddress(p1_entry.addr()),
         };
         let offset = u64::from(addr.page_offset());
-        TranslateResult::Frame4KiB { frame, offset }
+        let flags = p1_entry.flags();
+        TranslateResult::Frame4KiB {
+            frame,
+            offset,
+            flags,
+        }
     }
 }
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -59,28 +59,28 @@ pub enum TranslateResult {
     Frame4KiB {
         /// The mapped frame.
         frame: PhysFrame<Size4KiB>,
-        /// Flags in the pagetable for this entry
-        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
     },
     /// The page is mapped to a physical frame of size 2MiB.
     Frame2MiB {
         /// The mapped frame.
         frame: PhysFrame<Size2MiB>,
-        /// Flags in the pagetable for this entry
-        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
     },
     /// The page is mapped to a physical frame of size 2MiB.
     Frame1GiB {
         /// The mapped frame.
         frame: PhysFrame<Size1GiB>,
-        /// Flags in the pagetable for this entry
-        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
     },
     /// The given page is not mapped to a physical frame.
     PageNotMapped,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -36,9 +36,15 @@ pub trait MapperAllSizes: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB>
     fn translate_addr(&self, addr: VirtAddr) -> Option<PhysAddr> {
         match self.translate(addr) {
             TranslateResult::PageNotMapped | TranslateResult::InvalidFrameAddress(_) => None,
-            TranslateResult::Frame4KiB { frame, offset } => Some(frame.start_address() + offset),
-            TranslateResult::Frame2MiB { frame, offset } => Some(frame.start_address() + offset),
-            TranslateResult::Frame1GiB { frame, offset } => Some(frame.start_address() + offset),
+            TranslateResult::Frame4KiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
+            TranslateResult::Frame2MiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
+            TranslateResult::Frame1GiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
         }
     }
 }
@@ -53,6 +59,8 @@ pub enum TranslateResult {
     Frame4KiB {
         /// The mapped frame.
         frame: PhysFrame<Size4KiB>,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
     },
@@ -60,6 +68,8 @@ pub enum TranslateResult {
     Frame2MiB {
         /// The mapped frame.
         frame: PhysFrame<Size2MiB>,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
     },
@@ -67,6 +77,8 @@ pub enum TranslateResult {
     Frame1GiB {
         /// The mapped frame.
         frame: PhysFrame<Size1GiB>,
+        /// Flags in the pagetable for this entry
+        flags: PageTableFlags,
         /// The offset whithin the mapped frame.
         offset: u64,
     },

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -561,13 +561,10 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
             return TranslateResult::PageNotMapped;
         }
         if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-            let frame = PhysFrame::containing_address(p3[addr.p3_index()].addr());
-            let flags = p3[addr.p3_index()].flags();
-            let offset = addr.as_u64() & 0o_777_777_7777;
             return TranslateResult::Frame1GiB {
-                frame,
-                offset,
-                flags,
+                frame: PhysFrame::containing_address(p3[addr.p3_index()].addr()),
+                offset: addr.as_u64() & 0o_777_777_7777,
+                flags: p3[addr.p3_index()].flags(),
             };
         }
 
@@ -577,13 +574,10 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
             return TranslateResult::PageNotMapped;
         }
         if p2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-            let frame = PhysFrame::containing_address(p2[addr.p2_index()].addr());
-            let flags = p2[addr.p2_index()].flags();
-            let offset = addr.as_u64() & 0o_777_7777;
             return TranslateResult::Frame2MiB {
-                frame,
-                offset,
-                flags,
+                frame: PhysFrame::containing_address(p2[addr.p2_index()].addr()),
+                offset: addr.as_u64() & 0o_777_7777,
+                flags: p2[addr.p2_index()].flags(),
             };
         }
 
@@ -600,12 +594,10 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
             Ok(frame) => frame,
             Err(()) => return TranslateResult::InvalidFrameAddress(p1_entry.addr()),
         };
-        let offset = u64::from(addr.page_offset());
-        let flags = p1_entry.flags();
         TranslateResult::Frame4KiB {
             frame,
-            offset,
-            flags,
+            offset: u64::from(addr.page_offset()),
+            flags: p1_entry.flags(),
         }
     }
 }

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -562,8 +562,13 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
         }
         if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             let frame = PhysFrame::containing_address(p3[addr.p3_index()].addr());
+            let flags = p3[addr.p3_index()].flags();
             let offset = addr.as_u64() & 0o_777_777_7777;
-            return TranslateResult::Frame1GiB { frame, offset };
+            return TranslateResult::Frame1GiB {
+                frame,
+                offset,
+                flags,
+            };
         }
 
         let p2 = unsafe { &*(p2_ptr(page, self.recursive_index)) };
@@ -573,8 +578,13 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
         }
         if p2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             let frame = PhysFrame::containing_address(p2[addr.p2_index()].addr());
+            let flags = p2[addr.p2_index()].flags();
             let offset = addr.as_u64() & 0o_777_7777;
-            return TranslateResult::Frame2MiB { frame, offset };
+            return TranslateResult::Frame2MiB {
+                frame,
+                offset,
+                flags,
+            };
         }
 
         let p1 = unsafe { &*(p1_ptr(page, self.recursive_index)) };
@@ -591,7 +601,12 @@ impl<'a> MapperAllSizes for RecursivePageTable<'a> {
             Err(()) => return TranslateResult::InvalidFrameAddress(p1_entry.addr()),
         };
         let offset = u64::from(addr.page_offset());
-        TranslateResult::Frame4KiB { frame, offset }
+        let flags = p1_entry.flags();
+        TranslateResult::Frame4KiB {
+            frame,
+            offset,
+            flags,
+        }
     }
 }
 


### PR DESCRIPTION
This is code for the issue #149 to retrieve the active pagetable flags during translation. It does not provide the active flags if the table is not mapped but from what I've tested, works perfectly well in providing the flags for mapped pages.

It does break the API of the library as it adds a new field to the enum.