### PR TITLE
Use `llvm_asm!` instead of deprecated `asm!` macro

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -15,7 +15,7 @@ pub fn are_enabled() -> bool {
 pub fn enable() {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("sti" :::: "volatile");
+        llvm_asm!("sti" :::: "volatile");
     }
     #[cfg(not(feature = "inline_asm"))]
     unsafe {
@@ -30,7 +30,7 @@ pub fn enable() {
 pub fn disable() {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("cli" :::: "volatile");
+        llvm_asm!("cli" :::: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]
@@ -131,7 +131,7 @@ where
 pub fn enable_interrupts_and_hlt() {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("sti; hlt" :::: "volatile");
+        llvm_asm!("sti; hlt" :::: "volatile");
     }
     #[cfg(not(feature = "inline_asm"))]
     unsafe {
@@ -144,7 +144,7 @@ pub fn enable_interrupts_and_hlt() {
 pub fn int3() {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("int3" :::: "volatile");
+        llvm_asm!("int3" :::: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]
@@ -162,7 +162,7 @@ pub fn int3() {
 #[macro_export]
 macro_rules! software_interrupt {
     ($x:expr) => {{
-        asm!("int $0" :: "N" ($x) :: "volatile");
+        llvm_asm!("int $0" :: "N" ($x) :: "volatile");
     }};
 }
 

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -14,7 +14,7 @@ pub mod tlb;
 pub fn hlt() {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("hlt" :::: "volatile");
+        llvm_asm!("hlt" :::: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]
@@ -29,6 +29,6 @@ pub fn hlt() {
 #[inline]
 pub fn bochs_breakpoint() {
     unsafe {
-        asm!("xchgw %bx, %bx" :::: "volatile");
+        llvm_asm!("xchgw %bx, %bx" :::: "volatile");
     }
 }

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -9,7 +9,7 @@ impl PortRead for u8 {
     #[inline]
     unsafe fn read_from_port(port: u16) -> u8 {
         let value: u8;
-        asm!("inb $1, $0" : "={al}"(value) : "N{dx}"(port) :: "volatile");
+        llvm_asm!("inb $1, $0" : "={al}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
 
@@ -25,7 +25,7 @@ impl PortRead for u16 {
     #[inline]
     unsafe fn read_from_port(port: u16) -> u16 {
         let value: u16;
-        asm!("inw $1, $0" : "={ax}"(value) : "N{dx}"(port) :: "volatile");
+        llvm_asm!("inw $1, $0" : "={ax}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
 
@@ -41,7 +41,7 @@ impl PortRead for u32 {
     #[inline]
     unsafe fn read_from_port(port: u16) -> u32 {
         let value: u32;
-        asm!("inl $1, $0" : "={eax}"(value) : "N{dx}"(port) :: "volatile");
+        llvm_asm!("inl $1, $0" : "={eax}"(value) : "N{dx}"(port) :: "volatile");
         value
     }
 
@@ -56,7 +56,7 @@ impl PortWrite for u8 {
     #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u8) {
-        asm!("outb $1, $0" :: "N{dx}"(port), "{al}"(value) :: "volatile");
+        llvm_asm!("outb $1, $0" :: "N{dx}"(port), "{al}"(value) :: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]
@@ -70,7 +70,7 @@ impl PortWrite for u16 {
     #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u16) {
-        asm!("outw $1, $0" :: "N{dx}"(port), "{ax}"(value) :: "volatile");
+        llvm_asm!("outw $1, $0" :: "N{dx}"(port), "{ax}"(value) :: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]
@@ -84,7 +84,7 @@ impl PortWrite for u32 {
     #[cfg(feature = "inline_asm")]
     #[inline]
     unsafe fn write_to_port(port: u16, value: u32) {
-        asm!("outl $1, $0" :: "N{dx}"(port), "{eax}"(value) :: "volatile");
+        llvm_asm!("outl $1, $0" :: "N{dx}"(port), "{eax}"(value) :: "volatile");
     }
 
     #[cfg(not(feature = "inline_asm"))]

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -18,7 +18,7 @@ pub unsafe fn set_cs(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
     #[inline(always)]
     unsafe fn inner(sel: SegmentSelector) {
-        asm!("pushq $0; \
+        llvm_asm!("pushq $0; \
               leaq  1f(%rip), %rax; \
               pushq %rax; \
               lretq; \
@@ -43,7 +43,7 @@ pub unsafe fn set_cs(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("movw $0, %ss " :: "r" (sel.0) : "memory");
+    llvm_asm!("movw $0, %ss " :: "r" (sel.0) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_load_ss(sel.0);
@@ -58,7 +58,7 @@ pub unsafe fn load_ss(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("movw $0, %ds " :: "r" (sel.0) : "memory");
+    llvm_asm!("movw $0, %ds " :: "r" (sel.0) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_load_ds(sel.0);
@@ -73,7 +73,7 @@ pub unsafe fn load_ds(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("movw $0, %es " :: "r" (sel.0) : "memory");
+    llvm_asm!("movw $0, %es " :: "r" (sel.0) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_load_es(sel.0);
@@ -88,7 +88,7 @@ pub unsafe fn load_es(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn load_fs(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("movw $0, %fs " :: "r" (sel.0) : "memory");
+    llvm_asm!("movw $0, %fs " :: "r" (sel.0) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_load_fs(sel.0);
@@ -103,7 +103,7 @@ pub unsafe fn load_fs(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn load_gs(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("movw $0, %gs " :: "r" (sel.0) : "memory");
+    llvm_asm!("movw $0, %gs " :: "r" (sel.0) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_load_gs(sel.0);
@@ -118,7 +118,7 @@ pub unsafe fn load_gs(sel: SegmentSelector) {
 #[inline]
 pub unsafe fn swap_gs() {
     #[cfg(feature = "inline_asm")]
-    asm!("swapgs" ::: "memory" : "volatile");
+    llvm_asm!("swapgs" ::: "memory" : "volatile");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_swapgs();
@@ -130,7 +130,7 @@ pub fn cs() -> SegmentSelector {
     #[cfg(feature = "inline_asm")]
     {
         let segment: u16;
-        unsafe { asm!("mov %cs, $0" : "=r" (segment) ) };
+        unsafe { llvm_asm!("mov %cs, $0" : "=r" (segment) ) };
         SegmentSelector(segment)
     }
 

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -18,7 +18,7 @@ pub use crate::structures::DescriptorTablePointer;
 #[inline]
 pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
     #[cfg(feature = "inline_asm")]
-    asm!("lgdt ($0)" :: "r" (gdt) : "memory");
+    llvm_asm!("lgdt ($0)" :: "r" (gdt) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_lgdt(gdt as *const _);
@@ -38,7 +38,7 @@ pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
 #[inline]
 pub unsafe fn lidt(idt: &DescriptorTablePointer) {
     #[cfg(feature = "inline_asm")]
-    asm!("lidt ($0)" :: "r" (idt) : "memory");
+    llvm_asm!("lidt ($0)" :: "r" (idt) : "memory");
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_lidt(idt as *const _);
@@ -54,7 +54,7 @@ pub unsafe fn lidt(idt: &DescriptorTablePointer) {
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("ltr $0" :: "r" (sel.0));
+    llvm_asm!("ltr $0" :: "r" (sel.0));
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_ltr(sel.0)

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -7,7 +7,7 @@ use crate::VirtAddr;
 pub fn flush(addr: VirtAddr) {
     #[cfg(feature = "inline_asm")]
     unsafe {
-        asm!("invlpg ($0)" :: "r" (addr.as_u64()) : "memory")
+        llvm_asm!("invlpg ($0)" :: "r" (addr.as_u64()) : "memory")
     };
 
     #[cfg(not(feature = "inline_asm"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "const_fn", feature(const_fn))]
 #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
-#![cfg_attr(feature = "inline_asm", feature(asm))]
+#![cfg_attr(feature = "inline_asm", feature(llvm_asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "deny-warnings", deny(warnings))]
 #![cfg_attr(feature = "deny-warnings", deny(missing_docs))]

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -145,7 +145,7 @@ mod x86_64 {
 
             #[cfg(feature = "inline_asm")]
             unsafe {
-                asm!("mov %cr0, $0" : "=r" (value));
+                llvm_asm!("mov %cr0, $0" : "=r" (value));
             }
 
             #[cfg(not(feature = "inline_asm"))]
@@ -184,7 +184,7 @@ mod x86_64 {
         #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
-            asm!("mov $0, %cr0" :: "r" (value) : "memory");
+            llvm_asm!("mov $0, %cr0" :: "r" (value) : "memory");
 
             #[cfg(not(feature = "inline_asm"))]
             crate::asm::x86_64_asm_write_cr0(value);
@@ -217,7 +217,7 @@ mod x86_64 {
 
             #[cfg(feature = "inline_asm")]
             unsafe {
-                asm!("mov %cr2, $0" : "=r" (value));
+                llvm_asm!("mov %cr2, $0" : "=r" (value));
             }
 
             #[cfg(not(feature = "inline_asm"))]
@@ -237,7 +237,7 @@ mod x86_64 {
 
             #[cfg(feature = "inline_asm")]
             unsafe {
-                asm!("mov %cr3, $0" : "=r" (value));
+                llvm_asm!("mov %cr3, $0" : "=r" (value));
             }
 
             #[cfg(not(feature = "inline_asm"))]
@@ -262,7 +262,7 @@ mod x86_64 {
             let value = addr.as_u64() | flags.bits();
 
             #[cfg(feature = "inline_asm")]
-            asm!("mov $0, %cr3" :: "r" (value) : "memory");
+            llvm_asm!("mov $0, %cr3" :: "r" (value) : "memory");
 
             #[cfg(not(feature = "inline_asm"))]
             crate::asm::x86_64_asm_write_cr3(value)
@@ -283,7 +283,7 @@ mod x86_64 {
 
             #[cfg(feature = "inline_asm")]
             unsafe {
-                asm!("mov %cr4, $0" : "=r" (value));
+                llvm_asm!("mov %cr4, $0" : "=r" (value));
             }
 
             #[cfg(not(feature = "inline_asm"))]
@@ -324,7 +324,7 @@ mod x86_64 {
         #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
-            asm!("mov $0, %cr4" :: "r" (value) : "memory");
+            llvm_asm!("mov $0, %cr4" :: "r" (value) : "memory");
 
             #[cfg(not(feature = "inline_asm"))]
             crate::asm::x86_64_asm_write_cr4(value);

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -11,7 +11,7 @@ pub mod rflags;
 pub fn read_rip() -> u64 {
     let rip: u64;
     unsafe {
-        asm!(
+        llvm_asm!(
             "lea (%rip), $0"
             : "=r"(rip) ::: "volatile"
         );

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -121,7 +121,7 @@ mod x86_64 {
             #[cfg(feature = "inline_asm")]
             {
                 let (high, low): (u32, u32);
-                asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (self.0) : "memory" : "volatile");
+                llvm_asm!("rdmsr" : "={eax}" (low), "={edx}" (high) : "{ecx}" (self.0) : "memory" : "volatile");
                 ((high as u64) << 32) | (low as u64)
             }
 
@@ -141,7 +141,7 @@ mod x86_64 {
             {
                 let low = value as u32;
                 let high = (value >> 32) as u32;
-                asm!("wrmsr" :: "{ecx}" (self.0), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
+                llvm_asm!("wrmsr" :: "{ecx}" (self.0), "{eax}" (low), "{edx}" (high) : "memory" : "volatile" );
             }
 
             #[cfg(not(feature = "inline_asm"))]

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -80,7 +80,7 @@ mod x86_64 {
         let r: u64;
         #[cfg(feature = "inline_asm")]
         unsafe {
-            asm!("pushfq; popq $0" : "=r"(r) :: "memory")
+            llvm_asm!("pushfq; popq $0" : "=r"(r) :: "memory")
         };
 
         #[cfg(not(feature = "inline_asm"))]
@@ -108,7 +108,7 @@ mod x86_64 {
     pub fn write_raw(val: u64) {
         #[cfg(feature = "inline_asm")]
         unsafe {
-            asm!("pushq $0; popfq" :: "r"(val) : "memory" "flags")
+            llvm_asm!("pushq $0; popfq" :: "r"(val) : "memory" "flags")
         };
 
         #[cfg(not(feature = "inline_asm"))]


### PR DESCRIPTION
Fixes #140 