### PR TITLE
Return the correct RPL from GDT::add_entry()

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -118,7 +118,20 @@ impl GlobalDescriptorTable {
                 index
             }
         };
-        SegmentSelector::new(index as u16, PrivilegeLevel::Ring0)
+
+        let rpl = match entry {
+            Descriptor::UserSegment(value) => {
+                match DescriptorFlags::from_bits_truncate(value)
+                    .contains(DescriptorFlags::DPL_RING_3)
+                {
+                    true => PrivilegeLevel::Ring3,
+                    false => PrivilegeLevel::Ring0,
+                }
+            }
+            Descriptor::SystemSegment(_, _) => PrivilegeLevel::Ring0,
+        };
+
+        SegmentSelector::new(index as u16, rpl)
     }
 
     /// Loads the GDT in the CPU using the `lgdt` instruction. This does **not** alter any of the

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -121,11 +121,11 @@ impl GlobalDescriptorTable {
 
         let rpl = match entry {
             Descriptor::UserSegment(value) => {
-                match DescriptorFlags::from_bits_truncate(value)
-                    .contains(DescriptorFlags::DPL_RING_3)
+                if DescriptorFlags::from_bits_truncate(value).contains(DescriptorFlags::DPL_RING_3)
                 {
-                    true => PrivilegeLevel::Ring3,
-                    false => PrivilegeLevel::Ring0,
+                    PrivilegeLevel::Ring3
+                } else {
+                    PrivilegeLevel::Ring0
                 }
             }
             Descriptor::SystemSegment(_, _) => PrivilegeLevel::Ring0,


### PR DESCRIPTION
Now the RPL of the returning selector is determined from whether the given descriptor has its `DPL_RING_3` set.