### PR TITLE
Correct Cr2::read documentation

### DIFF
--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -210,7 +210,7 @@ mod x86_64 {
     }
 
     impl Cr2 {
-        /// Read the current page fault linear address from the CR3 register.
+        /// Read the current page fault linear address from the CR2 register.
         #[inline]
         pub fn read() -> VirtAddr {
             let value: u64;


### PR DESCRIPTION
The documentation on Cr2::read refered to the Cr3 register