### PR TITLE
Export PhysAddrNotValid and VirtAddrNotValid

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1,3 +1,5 @@
+//! Physical and virtal addresses manipulation
+
 use core::fmt;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,10 @@ macro_rules! const_fn {
 #[cfg(not(feature = "inline_asm"))]
 pub(crate) mod asm;
 
+pub mod addr;
 pub mod instructions;
 pub mod registers;
 pub mod structures;
-
-mod addr;
 
 /// Represents a protection ring level.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Those two structs are exported by making the `addr` module public.

Close #162