### PR TITLE
gdt: make GlobalDescriptorTable Copy

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -89,7 +89,7 @@ impl fmt::Debug for SegmentSelector {
 /// // Add entry for TSS, call gdt.load() then update segment registers
 /// ```
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct GlobalDescriptorTable {
     table: [u64; 8],
     next_free: usize,


### PR DESCRIPTION
Make GlobalDescriptorTable `Copy`,
so the const `new()` can be used in array initialization.

```rust
static mut GDT: [GlobalDescriptorTable; MAX_CPUS] = [GlobalDescriptorTable::new(); MAX_CPUS];
```