### PR TITLE
Add a badge to crates.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # x86_64 library
 
+[![Crates.io](https://img.shields.io/crates/v/x86_64)](https://crates.io/crates/x86_64)
 [![Build Status](https://github.com/rust-osdev/x86_64/workflows/Build/badge.svg)](https://github.com/rust-osdev/x86_64/actions?query=workflow%3ABuild) [![docs.rs](https://img.shields.io/badge/docs.rs-documentation-green.svg)](https://docs.rs/x86_64)
 
 Support for x86_64 specific instructions (e.g. TLB flush), registers (e.g. control registers), and structures (e.g. page tables).


### PR DESCRIPTION
uefi-rs' README.md has the badge. I thought this repo also should have one.