### PR TITLE
Add a function for the `nop` instruction

### DIFF
--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -234,6 +234,12 @@ _x86_64_asm_hlt:
     hlt
     retq
 
+.global _x86_64_asm_nop
+.p2align 4
+_x86_64_asm_nop:
+    nop
+    retq
+
 .global _x86_64_asm_rdfsbase
 .p2align 4
 _x86_64_asm_rdfsbase:

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -32,6 +32,12 @@ extern "C" {
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_nop"
+    )]
+    pub(crate) fn x86_64_asm_nop();
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_read_from_port_u8"
     )]
     pub(crate) fn x86_64_asm_read_from_port_u8(port: u16) -> u8;

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -23,6 +23,25 @@ pub fn hlt() {
     }
 }
 
+/// Executes the `nop` instructions, which performs no operation (i.e. does nothing).
+///
+/// This operation is useful to work around the LLVM bug that endless loops are illegally
+/// optimized away (see https://github.com/rust-lang/rust/issues/28728). By invoking this
+/// instruction (which is marked as volatile), the compiler should no longer optimize the
+/// endless loop away.
+#[inline]
+pub fn nop() {
+    #[cfg(feature = "inline_asm")]
+    unsafe {
+        llvm_asm!("nop" :::: "volatile");
+    }
+
+    #[cfg(not(feature = "inline_asm"))]
+    unsafe {
+        crate::asm::x86_64_asm_nop();
+    }
+}
+
 /// Emits a '[magic breakpoint](https://wiki.osdev.org/Bochs#Magic_Breakpoint)' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
 /// emulator. Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
 #[cfg(feature = "inline_asm")]


### PR DESCRIPTION
Executes the `nop` instructions, which performs no operation (i.e. does nothing).

This operation is useful to work around the LLVM bug that endless loops are illegally optimized away (see https://github.com/rust-lang/rust/issues/28728). By invoking this instruction (which is marked as volatile) in the endless loop, the compiler should no longer optimize it away.