### PR TITLE
Don't rely on promotion of `PageTableEntry::new` inside a `const fn`

### DIFF
--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -189,7 +189,7 @@ impl PageTable {
     #[inline]
     pub const fn new() -> Self {
         PageTable {
-            entries: [PageTableEntry::new(); ENTRY_COUNT],
+            entries: [PageTableEntry { entry: 0 }; ENTRY_COUNT],
         }
     }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -188,8 +188,9 @@ impl PageTable {
     #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new() -> Self {
+        const EMPTY: PageTableEntry = PageTableEntry::new();
         PageTable {
-            entries: [PageTableEntry { entry: 0 }; ENTRY_COUNT],
+            entries: [EMPTY; ENTRY_COUNT],
         }
     }
 


### PR DESCRIPTION
Hi! Rust compiler team member here. When the `const_fn` feature is enabled, the implementation of `PageTable::new` relies on a compiler bug to work. Specifically, `PageTableEntry::new` should not be eligible for promotion as part of an array initializer. See rust-lang/rust#75502 for more information. This bug may be fixed in the future, which would cause this crate to stop compiling.