### PR TITLE
gdt: Add remaining GDT flags

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Add additional `DescriptorFlags` and aliases compatible with `syscall`/`sysenter` ([#181](https://github.com/rust-osdev/x86_64/pull/181))
+- Fix (another) build error on latest nightly ([#186](https://github.com/rust-osdev/x86_64/pull/186))
+
 # 0.12.1 – 2020-09-24
 
 - Fix build error on latest nightly ([#182](https://github.com/rust-osdev/x86_64/pull/182))


### PR DESCRIPTION
Add the remaining GDT flags. This now allows users to create 32-bit
and 64-bit GDTs. I also added more explanations about what each flag
does, and in which modes it is ignored.

We also add flag aliases for common cases. We then verify that these
cases match what the Linux kernel uses by default. Note that these defaults
are in some sense "mandatory" as the `syscall`/`sysenter` instructions load
constants into the various GDT registers. This also allows us
to make additional methods `const fn`.

I used [AMD64 Architecture Programmer’s Manual, Volume 2: System Programming](https://www.amd.com/system/files/TechDocs/24593.pdf)
as the main reference for this PR.

Two remaining open questions:

1. Should we set `WRITABLE` (aka Readable for code-segments) by default?
    - This bit is ignored in 64-bit Mode (code and data)
    - Linux always sets it by default
    - This is probably what users want for 32-bit mode segments.
2. Should we set `ACCESSED` by default?
    - Linux [sets it by default](https://github.com/torvalds/linux/blob/00e4db51259a5f936fec1424b884f029479d3981/arch/x86/kernel/cpu/common.c#L124-L129)
    - Except [sometimes it doesn't](https://github.com/torvalds/linux/blob/ab851d49f6bfc781edd8bd44c72ec1e49211670b/arch/x86/platform/pvh/head.S#L160-L166)
    - AMD claims this is ignored, but Intel doesn't make the same claim.
    - Setting this prevents a write on first access (useful when your GDT is mapped read-only).

Signed-off-by: Joe Richey <joerichey@google.com>