### PR TITLE
Provide functions for accessing the underlying L4 table for mapper types

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -37,6 +37,11 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         }
     }
 
+    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&mut self) -> &mut PageTable {
+        &mut self.level_4_table
+    }
+
     /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
     /// https://github.com/rust-lang/rfcs/pull/2585.
     fn map_to_1gib<A>(

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -36,6 +36,11 @@ impl<'a> OffsetPageTable<'a> {
             inner: MappedPageTable::new(level_4_table, phys_offset),
         }
     }
+
+    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&mut self) -> &mut PageTable {
+        self.inner.level_4_table()
+    }
 }
 
 #[derive(Debug)]

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -81,6 +81,11 @@ impl<'a> RecursivePageTable<'a> {
         }
     }
 
+    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&mut self) -> &mut PageTable {
+        &mut self.p4
+    }
+
     /// Internal helper function to create the page table of the next level if needed.
     ///
     /// If the passed entry is unused, a new frame is allocated from the given allocator, zeroed,


### PR DESCRIPTION
This is useful for setting up the recursive page table mapping in the UEFI bootloader implementation. I also think that this method makes sense in general, e.g. for determining unused memory ranges for new mappings.
