### PR TITLE
Fix build error on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "const_fn", feature(const_fn))]
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))]
+#![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))]
 #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
 #![cfg_attr(feature = "inline_asm", feature(llvm_asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -17,12 +17,16 @@ name = "double_fault_stack_overflow"
 harness = false
 
 [dependencies]
-bootloader = "0.9.3"
-uart_16550 = "0.2.0"
+bootloader = "0.9.10"
+uart_16550 = "0.2.8"
 spin = "0.5.0"
 
+# Overwrite the x86_64 crate for both direct and indirect dependencies.
 [dependencies.x86_64]
 path = ".."
+[patch.crates-io]
+x86_64 = { path = ".." }
+
 
 [dependencies.lazy_static]
 version = "1.3.0"


### PR DESCRIPTION
```
error[E0658]: function pointers cannot appear in constant functions
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.12.1/src/structures/idt.rs:378:31
    |
378 |                 divide_error: Entry::missing(),
    |                               ^^^^^^^^^^^^^^^^
    |
    = note: see issue #57563 <https://github.com/rust-lang/rust/issues/57563> for more information
    = help: add `#![feature(const_fn_fn_ptr_basics)]` to the crate attributes to enable
```

bisect: https://gist.github.com/50b4d25cbcd7f712a2253316ca76f1d9

I wonder why we have to add this crate attribute...