### PR TITLE
Remove Trait constraint for Port::new()

### DIFF
--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -100,37 +100,37 @@ impl PortReadWrite for u32 {}
 
 /// A read only I/O port.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PortReadOnly<T: PortRead> {
+pub struct PortReadOnly<T> {
     port: u16,
     phantom: PhantomData<T>,
 }
 
 /// A write only I/O port.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PortWriteOnly<T: PortWrite> {
+pub struct PortWriteOnly<T> {
     port: u16,
     phantom: PhantomData<T>,
 }
 
 /// An I/O port.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Port<T: PortReadWrite> {
+pub struct Port<T> {
     port: u16,
     phantom: PhantomData<T>,
 }
 
-impl<T: PortRead> PortReadOnly<T> {
-    const_fn! {
-        /// Creates a read only I/O port with the given port number.
-        #[inline]
-        pub fn new(port: u16) -> PortReadOnly<T> {
-            PortReadOnly {
-                port,
-                phantom: PhantomData,
-            }
+impl<T> PortReadOnly<T> {
+    /// Creates a read only I/O port with the given port number.
+    #[inline]
+    pub const fn new(port: u16) -> PortReadOnly<T> {
+        PortReadOnly {
+            port,
+            phantom: PhantomData,
         }
     }
+}
 
+impl<T: PortRead> PortReadOnly<T> {
     /// Reads from the port.
     ///
     /// ## Safety
@@ -143,18 +143,18 @@ impl<T: PortRead> PortReadOnly<T> {
     }
 }
 
-impl<T: PortWrite> PortWriteOnly<T> {
-    const_fn! {
-        /// Creates a write only I/O port with the given port number.
-        #[inline]
-        pub fn new(port: u16) -> PortWriteOnly<T> {
-            PortWriteOnly {
-                port,
-                phantom: PhantomData,
-            }
+impl<T> PortWriteOnly<T> {
+    /// Creates a write only I/O port with the given port number.
+    #[inline]
+    pub const fn new(port: u16) -> PortWriteOnly<T> {
+        PortWriteOnly {
+            port,
+            phantom: PhantomData,
         }
     }
+}
 
+impl<T: PortWrite> PortWriteOnly<T> {
     /// Writes to the port.
     ///
     /// ## Safety
@@ -167,18 +167,18 @@ impl<T: PortWrite> PortWriteOnly<T> {
     }
 }
 
-impl<T: PortReadWrite> Port<T> {
-    const_fn! {
-        /// Creates an I/O port with the given port number.
-        #[inline]
-        pub fn new(port: u16) -> Port<T> {
-            Port {
-                port,
-                phantom: PhantomData,
-            }
+impl<T> Port<T> {
+    /// Creates an I/O port with the given port number.
+    #[inline]
+    pub const fn new(port: u16) -> Port<T> {
+        Port {
+            port,
+            phantom: PhantomData,
         }
     }
+}
 
+impl<T: PortReadWrite> Port<T> {
     /// Reads from the port.
     ///
     /// ## Safety

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_fn))]
+#![cfg_attr(feature = "const_fn", feature(const_fn))] // Needed for generic access to associated consts
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))]
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))]
 #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]


### PR DESCRIPTION
Right now we use Traits with `const fn` in two different ways:
  1. `PortRead`/`PortWrite`/`PortReadWrite`, which can never have `const fn` implementaitons
  2. `PageSize` which _always_ has a `const fn` implementation (as it's just  two associated consts)

The use of (1) can be eliminated by only constraining the `Port::read` method instead of the `Port::new` method. This is similar to what the standard library does for [Once::new](https://doc.rust-lang.org/beta/std/sync/struct.Once.html#method.new).

Signed-off-by: Joe Richey <joerichey@google.com>