### PR TITLE
Add ability to add iomap to TSS (take 2)

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -306,6 +306,17 @@ impl Descriptor {
     /// Creates a TSS system descriptor for the given TSS.
     #[inline]
     pub fn tss_segment(tss: &'static TaskStateSegment) -> Descriptor {
+        // SAFETY: if iomap_size is zero, there are no requirements to uphold.
+        unsafe { Self::tss_segment_with_iomap(tss, 0) }
+    }
+
+    /// Creates a TSS system descriptor for the given TSS, setting up the IO permissions bitmap.
+    ///
+    /// # Safety
+    ///
+    /// If `iomap_size` is greater than zero, there **must** be a valid IO map at `tss_ptr + iomap_base`.
+    /// The size of the IO map must correspond with the given `iomap_size`.
+    pub unsafe fn tss_segment_with_iomap(tss: &'static TaskStateSegment, iomap_size: u16) -> Descriptor {
         use self::DescriptorFlags as Flags;
         use core::mem::size_of;
 
@@ -315,8 +326,11 @@ impl Descriptor {
         // base
         low.set_bits(16..40, ptr.get_bits(0..24));
         low.set_bits(56..64, ptr.get_bits(24..32));
-        // limit (the `-1` in needed since the bound is inclusive)
-        low.set_bits(0..16, (size_of::<TaskStateSegment>() - 1) as u64);
+        // limit (the `-1` is needed since the bound is inclusive)
+        low.set_bits(
+            0..16,
+            (size_of::<TaskStateSegment>() + (tss.iomap_base + iomap_size) as usize - 1) as u64
+        );
         // type (0b1001 = available 64-bit tss)
         low.set_bits(40..44, 0b1001);
 


### PR DESCRIPTION
I've refactored #68 to add a new method which allows you to specify IO permissions bitmap size, rather than incorporating it into the existing method. The existing method is now implemented by calling the new, unsafe method with an io permissions bitmap size of 0.