### PR TITLE
Don't deny warnings on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,4 +150,4 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: rustup toolchain install nightly --profile minimal --component clippy
-    - run: cargo +nightly clippy -- -D warnings
+    - run: cargo +nightly clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,28 +60,47 @@ jobs:
       shell: bash
 
     - name: "Run cargo build"
-      run: cargo build
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
 
     - name: "Run cargo build for stable without instructions"
-      run: cargo build --no-default-features
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --no-default-features
 
     - name: "Run cargo build for stable"
-      run: cargo build --no-default-features --features external_asm,instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --no-default-features --features external_asm,instructions
       if: runner.os != 'Windows'
 
     - name: "Run cargo build for stable on musl"
-      run: cargo build --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
       if: runner.os == 'Linux'
 
     - name: "Run cargo test"
-      run: cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
 
     - name: "Run cargo test for stable"
-      run: cargo test --no-default-features --features external_asm,instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features --features external_asm,instructions
       if: runner.os != 'Windows'
 
     - name: "Run cargo test for stable on musl"
-      run: cargo test --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
       if: runner.os == 'Linux'
 
     - name: "Install Rustup Targets"
@@ -147,4 +166,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - run: rustup toolchain install nightly --profile minimal --component clippy
-    - run: cargo +nightly clippy
+    - name: "Run `cargo clippy`"
+      uses: actions-rs/cargo@v1
+      with:
+        command: clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,9 +84,6 @@ jobs:
       run: cargo test --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
       if: runner.os == 'Linux'
 
-    - name: 'Deny Warnings'
-      run: cargo build --features deny-warnings
-
     - name: "Install Rustup Targets"
       run: |
         rustup target add i686-unknown-linux-gnu


### PR DESCRIPTION
Sometimes Rust/Cargo or clippy introduce new (stylistic) warnings. We don't want to break our CI build over those. This PR changes or CI script to report these warning in the Github UI instead.
