### PR TITLE
CI: Use new environment files for modifying PATH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Install Rustup
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
-        echo ::add-path::$HOME/.cargo/bin
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       if: runner.os == 'macOS'
 
     - name: Set Rustup profile to minimal
@@ -56,7 +56,7 @@ jobs:
         path: binaries
         key: ${{ runner.OS }}-binaries
     - name: Add binaries/bin to PATH
-      run: echo ::add-path::$GITHUB_WORKSPACE/binaries/bin
+      run: echo "$GITHUB_WORKSPACE/binaries/bin" >> $GITHUB_PATH
       shell: bash
 
     - name: "Run cargo build"
@@ -119,7 +119,7 @@ jobs:
     - name: Install Scoop (Windows)
       run: |
         Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-        echo ::add-path::$HOME\scoop\shims
+        echo "$HOME\scoop\shims" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       if: runner.os == 'Windows'
       shell: pwsh
     - name: Install QEMU (Windows)


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/