### PR TITLE
Relaxe `Sized` requirement for `FrameAllocator` in `Mapper::map_to`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - **Breaking:** Also return flags for `MapperAllSizes::translate()` ([#207](https://github.com/rust-osdev/x86_64/pull/207))
+- Relaxe `Sized` requirement for `FrameAllocator` in `Mapper::map_to` ([204](https://github.com/rust-osdev/x86_64/pull/204))
 
 # 0.12.3 – 2020-10-31
 

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -53,7 +53,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let p4 = &mut self.level_4_table;
         let p3 = self.page_table_walker.create_next_table(
@@ -81,7 +81,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let p4 = &mut self.level_4_table;
         let p3 = self.page_table_walker.create_next_table(
@@ -114,7 +114,7 @@ impl<'a, P: PhysToVirt> MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let p4 = &mut self.level_4_table;
         let p3 = self.page_table_walker.create_next_table(
@@ -153,7 +153,7 @@ impl<'a, P: PhysToVirt> Mapper<Size1GiB> for MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
     }
@@ -261,7 +261,7 @@ impl<'a, P: PhysToVirt> Mapper<Size2MiB> for MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
@@ -389,7 +389,7 @@ impl<'a, P: PhysToVirt> Mapper<Size4KiB> for MappedPageTable<'a, P> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }
@@ -643,7 +643,7 @@ impl<P: PhysToVirt> PageTableWalker<P> {
         allocator: &mut A,
     ) -> Result<&'b mut PageTable, PageTableCreateError>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let created;
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -170,7 +170,7 @@ pub trait Mapper<S: PageSize> {
     ) -> Result<MapperFlush<S>, MapToError<S>>
     where
         Self: Sized,
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let parent_table_flags = flags
             & (PageTableFlags::PRESENT
@@ -260,7 +260,7 @@ pub trait Mapper<S: PageSize> {
     ) -> Result<MapperFlush<S>, MapToError<S>>
     where
         Self: Sized,
-        A: FrameAllocator<Size4KiB>;
+        A: FrameAllocator<Size4KiB> + ?Sized;
 
     /// Removes a mapping from the page table and returns the frame that used to be mapped.
     ///
@@ -348,7 +348,7 @@ pub trait Mapper<S: PageSize> {
     ) -> Result<MapperFlush<S>, MapToError<S>>
     where
         Self: Sized,
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
         S: PageSize,
         Self: Mapper<S>,
     {

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -70,7 +70,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.inner
             .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
@@ -137,7 +137,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.inner
             .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
@@ -204,7 +204,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.inner
             .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -108,7 +108,7 @@ impl<'a> RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<&'b mut PageTable, MapToError<S>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         /// This inner function is used to limit the scope of `unsafe`.
         ///
@@ -120,7 +120,7 @@ impl<'a> RecursivePageTable<'a> {
             allocator: &mut A,
         ) -> Result<&'b mut PageTable, MapToError<S>>
         where
-            A: FrameAllocator<Size4KiB>,
+            A: FrameAllocator<Size4KiB> + ?Sized,
         {
             use crate::structures::paging::PageTableFlags as Flags;
 
@@ -165,7 +165,7 @@ impl<'a> RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         use crate::structures::paging::PageTableFlags as Flags;
         let p4 = &mut self.p4;
@@ -199,7 +199,7 @@ impl<'a> RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         use crate::structures::paging::PageTableFlags as Flags;
         let p4 = &mut self.p4;
@@ -243,7 +243,7 @@ impl<'a> RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         let p4 = &mut self.p4;
 
@@ -297,7 +297,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
     }
@@ -419,7 +419,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
@@ -576,7 +576,7 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         allocator: &mut A,
     ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
     where
-        A: FrameAllocator<Size4KiB>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }


### PR DESCRIPTION
This makes it possible to use the method with trait objects.

Resolves https://github.com/rust-osdev/acpi/issues/78