### PR TITLE
feat(paging): Also return flags for `MapperAllSizes::translate()`

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -537,18 +537,30 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Ok(page_table) => page_table,
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
-                let frame = PhysFrame::containing_address(p3[addr.p3_index()].addr());
+                let entry = &p3[addr.p3_index()];
+                let frame = PhysFrame::containing_address(entry.addr());
                 let offset = addr.as_u64() & 0o_777_777_7777;
-                return TranslateResult::Frame1GiB { frame, offset };
+                let flags = entry.flags();
+                return TranslateResult::Frame1GiB {
+                    frame,
+                    offset,
+                    flags,
+                };
             }
         };
         let p1 = match self.page_table_walker.next_table(&p2[addr.p2_index()]) {
             Ok(page_table) => page_table,
             Err(PageTableWalkError::NotMapped) => return TranslateResult::PageNotMapped,
             Err(PageTableWalkError::MappedToHugePage) => {
-                let frame = PhysFrame::containing_address(p2[addr.p2_index()].addr());
+                let entry = &p2[addr.p2_index()];
+                let frame = PhysFrame::containing_address(entry.addr());
                 let offset = addr.as_u64() & 0o_777_7777;
-                return TranslateResult::Frame2MiB { frame, offset };
+                let flags = entry.flags();
+                return TranslateResult::Frame2MiB {
+                    frame,
+                    offset,
+                    flags,
+                };
             }
         };
 
@@ -563,7 +575,12 @@ impl<'a, P: PhysToVirt> MapperAllSizes for MappedPageTable<'a, P> {
             Err(()) => return TranslateResult::InvalidFrameAddress(p1_entry.addr()),
         };
         let offset = u64::from(addr.page_offset());
-        TranslateResult::Frame4KiB { frame, offset }
+        let flags = p1_entry.flags();
+        TranslateResult::Frame4KiB {
+            frame,
+            offset,
+            flags,
+        }
     }
 }
 

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -39,9 +39,15 @@ pub trait MapperAllSizes: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB>
     fn translate_addr(&self, addr: VirtAddr) -> Option<PhysAddr> {
         match self.translate(addr) {
             TranslateResult::PageNotMapped | TranslateResult::InvalidFrameAddress(_) => None,
-            TranslateResult::Frame4KiB { frame, offset } => Some(frame.start_address() + offset),
-            TranslateResult::Frame2MiB { frame, offset } => Some(frame.start_address() + offset),
-            TranslateResult::Frame1GiB { frame, offset } => Some(frame.start_address() + offset),
+            TranslateResult::Frame4KiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
+            TranslateResult::Frame2MiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
+            TranslateResult::Frame1GiB { frame, offset, .. } => {
+                Some(frame.start_address() + offset)
+            }
         }
     }
 }
@@ -58,6 +64,8 @@ pub enum TranslateResult {
         frame: PhysFrame<Size4KiB>,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// The flags for the frame.
+        flags: PageTableFlags,
     },
     /// The page is mapped to a physical frame of size 2MiB.
     Frame2MiB {
@@ -65,6 +73,8 @@ pub enum TranslateResult {
         frame: PhysFrame<Size2MiB>,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// The flags for the frame.
+        flags: PageTableFlags,
     },
     /// The page is mapped to a physical frame of size 2MiB.
     Frame1GiB {
@@ -72,6 +82,8 @@ pub enum TranslateResult {
         frame: PhysFrame<Size1GiB>,
         /// The offset whithin the mapped frame.
         offset: u64,
+        /// The flags for the frame.
+        flags: PageTableFlags,
     },
     /// The given page is not mapped to a physical frame.
     PageNotMapped,


### PR DESCRIPTION
Extend `TranslateResult` returned by `MapperAllSizes::translate()` with
the page flags. This way, there is a method to get the flags for the
page of a `VirtAddr`.

_Edit(phil-opp)_: This is a **breaking change**.