### PR TITLE
GDT: Add `load_unchecked`, `from_raw_slice`, and `as_raw_slice`.

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -113,19 +113,13 @@ impl GlobalDescriptorTable {
     /// and that the value of `next_free` does not exceed the maximum size of the table.
     #[inline]
     pub const unsafe fn from_raw_parts(table: [u64; 8], next_free: usize) -> GlobalDescriptorTable {
-        GlobalDescriptorTable {
-            table,
-            next_free
-        }
+        GlobalDescriptorTable { table, next_free }
     }
 
     /// Breaks a GDT into its raw parts (table and a next_free counter.)
     #[inline]
     pub const fn into_raw_parts(&self) -> ([u64; 8], usize) {
-        let Self {
-            table,
-            next_free,
-        } = *self;
+        let Self { table, next_free } = *self;
 
         (table, next_free)
     }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -112,6 +112,7 @@ impl GlobalDescriptorTable {
     /// * The user must make sure that the entries are well formed
     /// * The provided slice **must not be larger than 8 items** (only up to the first 8 will be observed.)
     #[inline]
+    #[cfg(feature = "nightly")]
     pub const unsafe fn from_raw_parts(slice: &[u64]) -> GlobalDescriptorTable {
         assert!(
             slice.len() <= 8,

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -112,8 +112,8 @@ impl GlobalDescriptorTable {
     /// * The user must make sure that the entries are well formed
     /// * The provided slice **must not be larger than 8 items** (only up to the first 8 will be observed.)
     #[inline]
-    #[cfg(feature = "nightly")]
-    pub const unsafe fn from_raw_parts(slice: &[u64]) -> GlobalDescriptorTable {
+    #[cfg(feature = "const_fn")]
+    pub const unsafe fn from_raw_slice(slice: &[u64]) -> GlobalDescriptorTable {
         assert!(
             slice.len() <= 8,
             "initializing a GDT from a slice requires it to be **at most** 8 elements."
@@ -132,8 +132,10 @@ impl GlobalDescriptorTable {
     }
 
     /// Get a reference to the internal table.
+    ///
+    /// The resulting slice may contain system descriptors, which span two `u64`s.
     #[inline]
-    pub fn as_raw_parts(&self) -> &[u64] {
+    pub fn as_raw_slice(&self) -> &[u64] {
         &self.table[..self.next_free]
     }
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -113,7 +113,11 @@ impl GlobalDescriptorTable {
     /// * The provided slice **must not be larger than 8 items** (only up to the first 8 will be observed.)
     #[inline]
     pub const unsafe fn from_raw_parts(slice: &[u64]) -> GlobalDescriptorTable {
-        let next_free = if slice.len() >= 8 { 8 } else { slice.len() };
+        assert!(
+            slice.len() <= 8,
+            "initializing a GDT from a slice requires it to be **at most** 8 elements."
+        );
+        let next_free = slice.len();
 
         let mut table = [0; 8];
         let mut idx = 0;
@@ -126,12 +130,10 @@ impl GlobalDescriptorTable {
         GlobalDescriptorTable { table, next_free }
     }
 
-    /// Breaks a GDT into its raw parts (table and a next_free counter.)
+    /// Get a reference to the internal table.
     #[inline]
-    pub const fn into_raw_parts(&self) -> ([u64; 8], usize) {
-        let Self { table, next_free } = *self;
-
-        (table, next_free)
+    pub fn as_raw_parts(&self) -> &[u64] {
+        &self.table[..self.next_free]
     }
 
     const_fn! {


### PR DESCRIPTION
Currently the API for `structures::GlobalDescriptorTable` feels like it requires you to either:

* use a [lazy_static][2] or
* use a `static mut` to store your GDT (which is a [bad idea][0])

That's because there's no way to actually form your GDT entries without using `add_entry` which takes `&mut self`... which seems contradictory that `load` requires the GDT to be `&'static self`!

you can get around this using a lazy_static of course but what if I want to use [once_cell][1] instead? there's no nice way of going about this... that's why this PR inroduces `load_unchecked` which is the same as `load` without the `'static` requirement and marked `unsafe` (of course.)

Also I noticed that sometimes you just know ahead of time what you want your GDT to be initialized with which lead me to add the const unsafe `from_raw_parts` constructor and `into_raw_parts`.

[0]: https://github.com/rust-lang/rust/issues/53639
[1]: https://docs.rs/once_cell/1.5.2/once_cell/#lazy-initialized-global-data
[2]: https://crates.io/crates/lazy_static