### PR TITLE
Change signature of PhysToVirt::phys_to_virt

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - **Breaking:** Also return flags for `MapperAllSizes::translate()` ([#207](https://github.com/rust-osdev/x86_64/pull/207))
 - **Breaking:** Restructure the `TranslateResult` type and create separate `Translate` trait ([#211](https://github.com/rust-osdev/x86_64/pull/211))
+- **Breaking:** Change signature of `PhysToVirt::phys_to_virt` ([#213](https://github.com/rust-osdev/x86_64/pull/213))
 - **Breaking:** Use custom error types instead of `()` ([#199](https://github.com/rust-osdev/x86_64/pull/199))
 - **Breaking:** Remove deprecated items
   - `UnusedPhysFrame`

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -48,12 +48,10 @@ struct PhysOffset {
     offset: VirtAddr,
 }
 
-impl PhysToVirt for PhysOffset {
+unsafe impl PhysToVirt for PhysOffset {
     #[inline]
-    fn phys_to_virt(&self, frame: PhysFrame) -> *mut PageTable {
-        let phys = frame.start_address().as_u64();
-        let virt = self.offset + phys;
-        virt.as_mut_ptr()
+    fn phys_to_virt(&self, phys_addr: PhysAddr) -> VirtAddr {
+        self.offset + phys_addr.as_u64()
     }
 }
 


### PR DESCRIPTION
Instead of translating `PhysFrame`s to `*mut PageTable` pointers as before, it now performs a more general `PhysAddr` to `VirtAddr` conversion. Since the implementer must make sure that the returned address is valid and accessible, the trait is now unsafe to implement. Because of this requirement we also need to remove the generic implementation of this trait for closures.

This is a **breaking change**.