### PR TITLE
Rename `PhysToVirt` trait to `PageTableFrameMapping`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,7 @@
 
 - **Breaking:** Also return flags for `MapperAllSizes::translate()` ([#207](https://github.com/rust-osdev/x86_64/pull/207))
 - **Breaking:** Restructure the `TranslateResult` type and create separate `Translate` trait ([#211](https://github.com/rust-osdev/x86_64/pull/211))
+- **Breaking:** Rename `PhysToVirt` trait to `PageTableFrameMapping` ([#214](https://github.com/rust-osdev/x86_64/pull/214))
 - **Breaking:** Use custom error types instead of `()` ([#199](https://github.com/rust-osdev/x86_64/pull/199))
 - **Breaking:** Remove deprecated items
   - `UnusedPhysFrame`

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -1,6 +1,6 @@
 //! Abstractions for reading and modifying the mapping of pages.
 
-pub use self::mapped_page_table::{MappedPageTable, PhysToVirt};
+pub use self::mapped_page_table::{MappedPageTable, PageTableFrameMapping};
 #[cfg(target_pointer_width = "64")]
 pub use self::offset_page_table::OffsetPageTable;
 #[cfg(feature = "instructions")]

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -48,11 +48,9 @@ struct PhysOffset {
     offset: VirtAddr,
 }
 
-impl PhysToVirt for PhysOffset {
-    #[inline]
-    fn phys_to_virt(&self, frame: PhysFrame) -> *mut PageTable {
-        let phys = frame.start_address().as_u64();
-        let virt = self.offset + phys;
+unsafe impl PageTableFrameMapping for PhysOffset {
+    fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
+        let virt = self.offset + frame.start_address().as_u64();
         virt.as_mut_ptr()
     }
 }


### PR DESCRIPTION
The new trait and method names better describe their purpose. Since the implementer must make sure that the returned pointer is valid and accessible, the trait is now unsafe to implement. Because of this requirement we also need to remove the generic implementation of this trait for closures.

(See https://github.com/rust-osdev/x86_64/pull/213 for an alternative, but unsuccessful, attempt).