### PR TITLE
Make `DescriptorTablePointer::base` a `VirtAddr`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,7 @@
   - `ExceptionStackFrame`
   - `VirtAddr::new_unchecked`
   - `interrupts::enable_interrupts_and_hlt`
+- **Breaking:** Make `DescriptorTablePointer::base` a `VirtAddr` ([#215](https://github.com/rust-osdev/x86_64/pull/215))
 - Relaxe `Sized` requirement for `FrameAllocator` in `Mapper::map_to` ([204](https://github.com/rust-osdev/x86_64/pull/204))
 
 # 0.12.3 – 2020-10-31

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -1,7 +1,10 @@
 //! Types for the Global Descriptor Table and segment selectors.
 
-use crate::structures::{tss::TaskStateSegment, DescriptorTablePointer};
 use crate::PrivilegeLevel;
+use crate::{
+    structures::{tss::TaskStateSegment, DescriptorTablePointer},
+    VirtAddr,
+};
 use bit_field::BitField;
 use bitflags::bitflags;
 use core::fmt;
@@ -169,7 +172,7 @@ impl GlobalDescriptorTable {
     fn pointer(&self) -> DescriptorTablePointer {
         use core::mem::size_of;
         DescriptorTablePointer {
-            base: self.table.as_ptr() as u64,
+            base: VirtAddr::new(self.table.as_ptr() as u64),
             limit: (self.next_free * size_of::<u64>() - 1) as u16,
         }
     }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -440,7 +440,7 @@ impl InterruptDescriptorTable {
     fn pointer(&self) -> DescriptorTablePointer {
         use core::mem::size_of;
         DescriptorTablePointer {
-            base: self as *const _ as u64,
+            base: VirtAddr::new(self as *const _ as u64),
             limit: (size_of::<Self>() - 1) as u16,
         }
     }

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -1,5 +1,7 @@
 //! Representations of various x86 specific structures and descriptor tables.
 
+use crate::VirtAddr;
+
 pub mod gdt;
 
 // idt needs `feature(abi_x86_interrupt)`, which is not available on stable rust
@@ -18,5 +20,5 @@ pub struct DescriptorTablePointer {
     /// Size of the DT.
     pub limit: u16,
     /// Pointer to the memory region containing the DT.
-    pub base: u64,
+    pub base: VirtAddr,
 }


### PR DESCRIPTION
Makes it clear that segmentation is applied before paging.

Suggested in https://github.com/rust-osdev/x86_64/issues/193#issue-723081621.