### PR TITLE
Change return type of `read_rip` to `VirtAddr`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,7 @@
   - `VirtAddr::new_unchecked`
   - `interrupts::enable_interrupts_and_hlt`
 - **Breaking:** Make `DescriptorTablePointer::base` a `VirtAddr` ([#215](https://github.com/rust-osdev/x86_64/pull/215))
+- **Breaking:** Change return type of `read_rip` to `VirtAddr` ([#216](https://github.com/rust-osdev/x86_64/pull/216))
 - Relaxe `Sized` requirement for `FrameAllocator` in `Mapper::map_to` ([204](https://github.com/rust-osdev/x86_64/pull/204))
 
 # 0.12.3 – 2020-10-31

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -2,6 +2,8 @@
 
 //! Special x86_64 instructions.
 
+use crate::VirtAddr;
+
 pub mod interrupts;
 pub mod port;
 pub mod random;
@@ -56,12 +58,12 @@ pub fn bochs_breakpoint() {
 /// instructions to execute.
 #[cfg(feature = "inline_asm")]
 #[inline(always)]
-pub fn read_rip() -> u64 {
+pub fn read_rip() -> VirtAddr {
     let rip: u64;
     unsafe {
         asm!(
             "lea {}, [rip]", out(reg) rip, options(nostack, nomem)
         );
     }
-    rip
+    VirtAddr::new(rip)
 }


### PR DESCRIPTION
This makes it clear that the return type is a virtual address.﻿
