### PR TITLE
Remove `PortReadWrite` trait, which is no longer needed

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
   - `interrupts::enable_interrupts_and_hlt`
 - **Breaking:** Make `DescriptorTablePointer::base` a `VirtAddr` ([#215](https://github.com/rust-osdev/x86_64/pull/215))
 - **Breaking:** Change return type of `read_rip` to `VirtAddr` ([#216](https://github.com/rust-osdev/x86_64/pull/216))
+- **Breaking:** Remove `PortReadWrite` trait, which is no longer needed ([#217](https://github.com/rust-osdev/x86_64/pull/217))
 - Relaxe `Sized` requirement for `FrameAllocator` in `Mapper::map_to` ([204](https://github.com/rust-osdev/x86_64/pull/204))
 
 # 0.12.3 – 2020-10-31

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -2,7 +2,7 @@
 
 use core::marker::PhantomData;
 
-pub use crate::structures::port::{PortRead, PortReadWrite, PortWrite};
+pub use crate::structures::port::{PortRead, PortWrite};
 
 impl PortRead for u8 {
     #[cfg(feature = "inline_asm")]
@@ -94,10 +94,6 @@ impl PortWrite for u32 {
     }
 }
 
-impl PortReadWrite for u8 {}
-impl PortReadWrite for u16 {}
-impl PortReadWrite for u32 {}
-
 /// A read only I/O port.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PortReadOnly<T> {
@@ -178,7 +174,7 @@ impl<T> Port<T> {
     }
 }
 
-impl<T: PortReadWrite> Port<T> {
+impl<T: PortRead> Port<T> {
     /// Reads from the port.
     ///
     /// ## Safety
@@ -189,7 +185,9 @@ impl<T: PortReadWrite> Port<T> {
     pub unsafe fn read(&mut self) -> T {
         T::read_from_port(self.port)
     }
+}
 
+impl<T: PortWrite> Port<T> {
     /// Writes to the port.
     ///
     /// ## Safety

--- a/src/structures/port.rs
+++ b/src/structures/port.rs
@@ -27,9 +27,3 @@ pub trait PortWrite {
     /// safety.
     unsafe fn write_to_port(port: u16, value: Self);
 }
-
-/// A helper trait that implements the read/write port operations.
-///
-/// On x86, I/O ports operate on either `u8` (via `inb`/`outb`), `u16` (via `inw`/`outw`),
-/// or `u32` (via `inl`/`outl`). Therefore this trait is implemented for exactly these types.
-pub trait PortReadWrite: PortRead + PortWrite {}


### PR DESCRIPTION
No longer needed after https://github.com/rust-osdev/x86_64/pull/188﻿
