### PR TITLE
Fix bad conversion from llvm_asm! to asm!

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -48,7 +48,7 @@ pub fn nop() {
 #[inline]
 pub fn bochs_breakpoint() {
     unsafe {
-        asm!("xchgw bx, bx", options(nomem, nostack));
+        asm!("xchg bx, bx", options(nomem, nostack));
     }
 }
 


### PR DESCRIPTION
When updating `x86_64` from 0.11.x to 0.12.x, I've gotten the following compilation error:

```
error: invalid instruction mnemonic 'xchgw'
  --> /home/pierre/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.12.3/src/instructions/mod.rs:51:15
   |
51 |         asm!("xchgw bx, bx", options(nomem, nostack));
   |               ^
   |
note: instantiated into assembly here
  --> <inline asm>:2:2
   |
2  |     xchgw bx, bx
   |     ^^^^^
```

According to [this Bochs-related page](https://wiki.osdev.org/Bochs#Magic_Breakpoint), the instruction is indeed just `xchg`, while `xchgw` is the weird AT&T syntax equivalent.

My code compiles with this change, but I haven't tested if the Bochs breakpoint actually works.
