### PR TITLE
Release version 0.12.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.12.3"
+version = "0.12.4"
 edition = "2018"
 
 [dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.12.4 – 2020-12-28
+
 - Fix bad conversion from llvm_asm! to asm! ([#218](https://github.com/rust-osdev/x86_64/pull/218))
 - GDT: Add `load_unchecked`, `from_raw_slice`, and `as_raw_slice` ([#210](https://github.com/rust-osdev/x86_64/pull/210))
 


### PR DESCRIPTION
Releases a new patch version with https://github.com/rust-osdev/x86_64/pull/210 and https://github.com/rust-osdev/x86_64/pull/218.

cc @tomaka @mental32﻿
