### PR TITLE
paging: page ranges can be generated from `Range<u64>`

### DIFF
--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -4,7 +4,7 @@ use crate::structures::paging::PageTableIndex;
 use crate::VirtAddr;
 use core::fmt;
 use core::marker::PhantomData;
-use core::ops::{Add, AddAssign, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Range, Sub, SubAssign};
 
 /// Trait for abstracting over the three possible page sizes on x86_64, 4KiB, 2MiB, 1GiB.
 pub trait PageSize: Copy + Eq + PartialOrd + Ord {
@@ -268,6 +268,11 @@ impl<S: PageSize> Sub<Self> for Page<S> {
 }
 
 /// A range of pages with exclusive upper bound.
+///
+/// ```rust
+/// # use x86_64::structures::paging::{Size4KiB, page::PageRange};
+/// let _: PageRange<Size4KiB> = (0x1000..0x4000u64).into();
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct PageRange<S: PageSize = Size4KiB> {
@@ -275,6 +280,15 @@ pub struct PageRange<S: PageSize = Size4KiB> {
     pub start: Page<S>,
     /// The end of the range, exclusive.
     pub end: Page<S>,
+}
+
+impl<S: PageSize> From<Range<u64>> for PageRange<S> {
+    fn from(range: Range<u64>) -> Self {
+        let start = Page::containing_address(VirtAddr::new(range.start));
+        let end = Page::containing_address(VirtAddr::new(range.end));
+
+        Self { start, end }
+    }
 }
 
 impl<S: PageSize> PageRange<S> {
@@ -321,6 +335,11 @@ impl<S: PageSize> fmt::Debug for PageRange<S> {
 }
 
 /// A range of pages with inclusive upper bound.
+///
+/// ```rust
+/// # use x86_64::structures::paging::{Size4KiB, page::PageRangeInclusive};
+/// let _: PageRangeInclusive<Size4KiB> = (0x1000..0x4000u64).into();
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[repr(C)]
 pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
@@ -328,6 +347,15 @@ pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
     pub start: Page<S>,
     /// The end of the range, inclusive.
     pub end: Page<S>,
+}
+
+impl<S: PageSize> From<Range<u64>> for PageRangeInclusive<S> {
+    fn from(range: Range<u64>) -> Self {
+        let start = Page::containing_address(VirtAddr::new(range.start));
+        let end = Page::containing_address(VirtAddr::new(range.end));
+
+        Self { start, end }
+    }
 }
 
 impl<S: PageSize> PageRangeInclusive<S> {


### PR DESCRIPTION
I noticed that a fair amount of my paging/physframe logic repeated the pattern of constructing a `PageRange` | `PageRangeInclusive` from essentially a `Range<u64>` and I had a few macros around to deal with the boilerplate of doing this stuff, loosely resembling something like:

```rust
let page_range = {
    let start_addr = VirtAddr::new(range.start);
    let end_addr = VirtAddr::new(range.end);

    let start_page = Page::containing_address(start_addr);
    let end_page = Page::containing_address(end_addr);

    Page::range(start_page, end_page)
};
```

This PR adds `From<Range<u64>>` impls for the page range variants using the same logic as above.

[0]: https://os.phil-opp.com/heap-allocation/