### PR TITLE
feat(idt): add unsafe const `set_handler_{fn|addr}_unchecked` methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))]
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))]
 #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
+#![cfg_attr(feature = "const_fn", feature(const_raw_ptr_to_usize_cast))]
 #![cfg_attr(feature = "inline_asm", feature(asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![warn(missing_docs)]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -9,7 +9,10 @@
 
 //! Provides types for the Interrupt Descriptor Table and its entries.
 
-use crate::{structures::{DescriptorTablePointer, gdt::SegmentSelector}, PrivilegeLevel, VirtAddr};
+use crate::{
+    structures::{gdt::SegmentSelector, DescriptorTablePointer},
+    PrivilegeLevel, VirtAddr,
+};
 use bit_field::BitField;
 use bitflags::bitflags;
 use core::fmt;


### PR DESCRIPTION
Allows users of `structures::idt::InterruptDescriptorTable` to set their handler functions in const, if you wanted to do something like this before you would've had to resort to constructing the table yourself and transmuting it into the crate provided IDT struct (which is error prone.)