### PR TITLE
Change software_interrupt to use min_const_generics

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -154,6 +154,12 @@ pub fn int3() {
 }
 
 /// Generate a software interrupt by invoking the `int` instruction.
+///
+/// ## Safety
+/// Invoking an arbitrary interrupt is unsafe. It can cause your system to
+/// crash if you invoke a double-fault (#8) or machine-check (#18) exception.
+/// It can also cause memory/register corruption depending on the interrupt
+/// implementation (if it expects values/pointers to be passed in registers).
 #[inline]
 #[cfg(feature = "inline_asm")]
 pub unsafe fn software_interrupt<const ID: u8>() {

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -154,23 +154,8 @@ pub fn int3() {
 }
 
 /// Generate a software interrupt by invoking the `int` instruction.
-///
-/// This currently needs to be a macro because the `int` argument needs to be an
-/// immediate. This macro will be replaced by a generic function when support for
-/// const generics is implemented in Rust.
+#[inline]
 #[cfg(feature = "inline_asm")]
-#[macro_export]
-macro_rules! software_interrupt {
-    ($x:expr) => {{
-        asm!("int {id}", id = const $x, options(nomem, nostack));
-    }};
-}
-
-/// Not implemented
-#[cfg(not(feature = "inline_asm"))]
-#[macro_export]
-macro_rules! software_interrupt {
-    ($x:expr) => {{
-        compile_error!("software_interrupt not implemented for non-nightly");
-    }};
+pub unsafe fn software_interrupt<const ID: u8>() {
+    asm!("int {}", const ID, options(nomem, nostack));
 }

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Philipp Oppermann <dev@phil-opp.com>"]
 edition = "2018"
 
 [[test]]
-name = "breakpoint_exception"
+name = "interrupt_handling"
 harness = false
 
 [[test]]

--- a/testing/tests/interrupt_handling.rs
+++ b/testing/tests/interrupt_handling.rs
@@ -7,7 +7,10 @@ use core::sync::atomic::{AtomicUsize, Ordering};
 use lazy_static::lazy_static;
 use testing::{exit_qemu, serial_print, serial_println, QemuExitCode};
 
+use x86_64::instructions::interrupts;
+
 static BREAKPOINT_HANDLER_CALLED: AtomicUsize = AtomicUsize::new(0);
+static INTERRUPT_HANDLER_CALLED: AtomicUsize = AtomicUsize::new(0);
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
@@ -16,13 +19,10 @@ pub extern "C" fn _start() -> ! {
     init_test_idt();
 
     // invoke a breakpoint exception
-    x86_64::instructions::interrupts::int3();
+    interrupts::int3();
 
     match BREAKPOINT_HANDLER_CALLED.load(Ordering::SeqCst) {
-        1 => {
-            serial_println!("[ok]");
-            exit_qemu(QemuExitCode::Success);
-        }
+        1 => {}
         0 => {
             serial_println!("[failed]");
             serial_println!("    Breakpoint handler was not called.");
@@ -35,6 +35,29 @@ pub extern "C" fn _start() -> ! {
         }
     }
 
+    serial_print!("interrupt 42... ");
+    unsafe { interrupts::software_interrupt::<42>() };
+    serial_print!("interrupt 77... ");
+    unsafe { interrupts::software_interrupt::<77>() };
+    serial_print!("interrupt 42... ");
+    unsafe { interrupts::software_interrupt::<42>() };
+
+    match INTERRUPT_HANDLER_CALLED.load(Ordering::SeqCst) {
+        3 => {}
+        0 => {
+            serial_println!("[failed]");
+            serial_println!("    Interrupt handler was not called.");
+            exit_qemu(QemuExitCode::Failed);
+        }
+        other => {
+            serial_println!("[failed]");
+            serial_println!("    Interrupt handler was called {} times", other);
+            exit_qemu(QemuExitCode::Failed);
+        }
+    }
+
+    serial_println!("[ok]");
+    exit_qemu(QemuExitCode::Success);
     loop {}
 }
 
@@ -49,6 +72,8 @@ lazy_static! {
     static ref TEST_IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
         idt.breakpoint.set_handler_fn(breakpoint_handler);
+        idt[42].set_handler_fn(interrupt_handler);
+        idt[77].set_handler_fn(interrupt_handler);
         idt
     };
 }
@@ -59,4 +84,8 @@ pub fn init_test_idt() {
 
 extern "x86-interrupt" fn breakpoint_handler(_stack_frame: &mut InterruptStackFrame) {
     BREAKPOINT_HANDLER_CALLED.fetch_add(1, Ordering::SeqCst);
+}
+
+extern "x86-interrupt" fn interrupt_handler(_stack_frame: &mut InterruptStackFrame) {
+    INTERRUPT_HANDLER_CALLED.fetch_add(1, Ordering::SeqCst);
 }


### PR DESCRIPTION
As this feature is stablized in the lastest nightly, no
feature flags need to be added.

Opening PR against the `next` branch as this is a breaking change.

Signed-off-by: Joe Richey <joerichey@google.com>