### PR TITLE
Added x86 support

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,13 @@ fn main() {
     #[cfg(all(feature = "external_asm", windows))]
     compile_error!("\"external_asm\" feature is not available on windows toolchain!");
 
+    let _carch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     #[cfg(feature = "instructions")]
-    if std::env::var("CARGO_CFG_TARGET_ARCH").unwrap() != "x86_64" {
-        panic!("\"instructions\" feature is only available for x86_64 targets!");
+    if _carch != "x86_64" && _carch != "x86" {
+        panic!(
+            "\"instructions\" feature is only available for x86_64 targets! Current target is: {}",
+            _carch
+        );
     }
 
     #[cfg(all(

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -125,11 +125,47 @@ impl VirtAddr {
         self.as_u64() as *const T
     }
 
+    /// Converts the address to a raw 32bit pointer.
+    /// Panics if it fails
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    pub fn as_ptr<T>(self) -> *const T {
+        let ptr = self
+            .as_32b_ptr::<T>()
+            .expect("Converting 64bit pointer to 32bit failed. Pointer too large");
+        ptr as *const T
+    }
+
+    /// Converts the address to a raw 32bit pointer.
+    #[inline]
+    pub fn as_32b_ptr<T>(self) -> Result<*const T, core::num::TryFromIntError> {
+        use core::convert::TryFrom;
+        let u32_value = u32::try_from(self.as_u64())?;
+        Ok(u32_value as *const T)
+    }
+
     /// Converts the address to a mutable raw pointer.
     #[cfg(target_pointer_width = "64")]
     #[inline]
     pub fn as_mut_ptr<T>(self) -> *mut T {
         self.as_ptr::<T>() as *mut T
+    }
+
+    /// Converts the address to a mutable raw 32bit pointer.
+    /// Panics if it fails
+    #[cfg(target_pointer_width = "32")]
+    #[inline]
+    pub fn as_mut_ptr<T>(self) -> *mut T {
+        let ptr = self
+            .as_32b_ptr::<T>()
+            .expect("Converting 64bit pointer to 32bit failed. Pointer too large");
+        ptr as *mut T
+    }
+
+    /// Converts the address to a mutable raw 32bit pointer.
+    #[inline]
+    pub fn as_32b_mut_ptr<T>(self) -> Result<*mut T, core::num::TryFromIntError> {
+        Ok(self.as_32b_ptr::<T>()? as *mut T)
     }
 
     /// Convenience method for checking if a virtual address is null.

--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -88,10 +88,10 @@ _x86_64_asm_get_cs:
     mov %cs, %ax
     retq
 
-.global _x86_64_asm_invlpg
+.global _x86_asm_invlpg
 .p2align 4
 _x86_64_asm_invlpg:
-    invlpg (%rdi)
+    invlpg (%edi)
     retq
 
 .global _x86_64_asm_invpcid

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -139,104 +139,160 @@ extern "C" {
     pub(crate) fn x86_64_asm_ltr(sel: u16);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_invlpg"
     )]
-    pub(crate) fn x86_64_asm_invlpg(addr: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_invlpg"
+    )]
+    pub(crate) fn x86_64_asm_invlpg(addr: usize);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_invpcid"
     )]
-    pub(crate) fn x86_64_asm_invpcid(kind: u64, desc: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_invpcid"
+    )]
+    pub(crate) fn x86_64_asm_invpcid(kind: usize, desc: usize);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_read_cr0"
     )]
-    pub(crate) fn x86_64_asm_read_cr0() -> u64;
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_read_cr0"
+    )]
+    pub(crate) fn x86_64_asm_read_cr0() -> usize;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_write_cr0"
     )]
-    pub(crate) fn x86_64_asm_write_cr0(value: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_write_cr0"
+    )]
+    pub(crate) fn x86_64_asm_write_cr0(value: usize);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_read_cr2"
     )]
-    pub(crate) fn x86_64_asm_read_cr2() -> u64;
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_read_cr2"
+    )]
+    pub(crate) fn x86_64_asm_read_cr2() -> usize;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_read_cr3"
     )]
-    pub(crate) fn x86_64_asm_read_cr3() -> u64;
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_read_cr3"
+    )]
+    pub(crate) fn x86_64_asm_read_cr3() -> usize;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_write_cr3"
     )]
-    pub(crate) fn x86_64_asm_write_cr3(value: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_write_cr3"
+    )]
+    pub(crate) fn x86_64_asm_write_cr3(value: usize);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_read_cr4"
     )]
-    pub(crate) fn x86_64_asm_read_cr4() -> u64;
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_read_cr4"
+    )]
+    pub(crate) fn x86_64_asm_read_cr4() -> usize;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_write_cr4"
     )]
-    pub(crate) fn x86_64_asm_write_cr4(value: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_write_cr4"
+    )]
+    pub(crate) fn x86_64_asm_write_cr4(value: usize);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_rdmsr"
+    )]
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_rdmsr"
     )]
     pub(crate) fn x86_64_asm_rdmsr(msr: u32) -> u64;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_wrmsr"
+    )]
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_wrmsr"
     )]
     pub(crate) fn x86_64_asm_wrmsr(msr: u32, value: u64);
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_read_rflags"
     )]
-    pub(crate) fn x86_64_asm_read_rflags() -> u64;
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_read_rflags"
+    )]
+    pub(crate) fn x86_64_asm_read_rflags() -> usize;
 
     #[cfg_attr(
-        any(target_env = "gnu", target_env = "musl"),
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86_64"),
         link_name = "_x86_64_asm_write_rflags"
     )]
-    pub(crate) fn x86_64_asm_write_rflags(val: u64);
+    #[cfg_attr(
+        all(any(target_env = "gnu", target_env = "musl"), target_arch = "x86"),
+        link_name = "_x86_asm_write_rflags"
+    )]
+    pub(crate) fn x86_64_asm_write_rflags(val: usize);
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_rdfsbase"
     )]
+    #[cfg(target_arch = "x86_64")]
     pub(crate) fn x86_64_asm_rdfsbase() -> u64;
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_wrfsbase"
     )]
+    #[cfg(target_arch = "x86_64")]
     pub(crate) fn x86_64_asm_wrfsbase(val: u64);
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_rdgsbase"
     )]
+    #[cfg(target_arch = "x86_64")]
     pub(crate) fn x86_64_asm_rdgsbase() -> u64;
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_wrgsbase"
     )]
+    #[cfg(target_arch = "x86_64")]
     pub(crate) fn x86_64_asm_wrgsbase(val: u64);
 }

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -2,6 +2,7 @@
 
 //! Special x86_64 instructions.
 
+#[cfg(feature = "inline_asm")]
 use crate::VirtAddr;
 
 pub mod interrupts;
@@ -59,11 +60,12 @@ pub fn bochs_breakpoint() {
 #[cfg(feature = "inline_asm")]
 #[inline(always)]
 pub fn read_rip() -> VirtAddr {
-    let rip: u64;
+    use core::convert::TryInto;
+    let rip: usize;
     unsafe {
         asm!(
             "lea {}, [rip]", out(reg) rip, options(nostack, nomem)
         );
     }
-    VirtAddr::new(rip)
+    VirtAddr::new(rip.try_into().unwrap())
 }

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -24,7 +24,7 @@ pub unsafe fn set_cs(sel: SegmentSelector) {
             "push {tmp}",
             "retfq",
             "1:",
-            sel = in(reg) u64::from(sel.0),
+            sel = in(reg) usize::from(sel.0),
             tmp = lateout(reg) _,
         );
     }
@@ -145,6 +145,7 @@ pub fn cs() -> SegmentSelector {
     }
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Writes the FS segment base address
 ///
 /// ## Safety
@@ -171,6 +172,7 @@ pub unsafe fn wrfsbase(val: u64) {
     inner(val)
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Reads the FS segment base address
 ///
 /// ## Safety
@@ -195,6 +197,7 @@ pub unsafe fn rdfsbase() -> u64 {
     inner()
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Writes the GS segment base address
 ///
 /// ## Safety
@@ -220,6 +223,7 @@ pub unsafe fn wrgsbase(val: u64) {
     inner(val)
 }
 
+#[cfg(target_arch = "x86_64")]
 /// Reads the GS segment base address
 ///
 /// ## Safety

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -54,7 +54,9 @@ pub struct Cr3;
 bitflags! {
     /// Controls cache settings for the level 4 page table.
     pub struct Cr3Flags: usize {
-        /// Use a writethrough cache policy for the P4 table (else a writeback policy is used).
+        /// Use a writeback cache policy for the P4 table.
+        const PAGE_LEVEL_WRITEBACK = 0 << 3;
+        /// Use a writethrough cache policy for the P4 table.
         const PAGE_LEVEL_WRITETHROUGH = 1 << 3;
         /// Disable caching for the P4 table.
         const PAGE_LEVEL_CACHE_DISABLE = 1 << 4;

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -5,6 +5,7 @@ pub mod model_specific;
 pub mod rflags;
 
 #[cfg(feature = "instructions")]
+#[cfg(target_arch = "x86_64")]
 pub use crate::instructions::segmentation::{rdfsbase, rdgsbase, wrfsbase, wrgsbase};
 
 #[cfg(all(feature = "instructions", feature = "inline_asm"))]

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -386,7 +386,7 @@ mod x86_64 {
         /// to 0, the corresponding rFLAGS bit is not modified.
         #[inline]
         pub fn read() -> RFlags {
-            RFlags::from_bits(unsafe { Self::MSR.read() }).unwrap()
+            RFlags::from_bits(unsafe { Self::MSR.read().try_into().unwrap() }).unwrap()
         }
 
         /// Write to the SFMask register.
@@ -399,7 +399,7 @@ mod x86_64 {
         #[inline]
         pub fn write(value: RFlags) {
             let mut msr = Self::MSR;
-            unsafe { msr.write(value.bits()) };
+            unsafe { msr.write(value.bits().try_into().unwrap()) };
         }
     }
 }

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -7,7 +7,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// The RFLAGS register.
-    pub struct RFlags: u64 {
+    pub struct RFlags: usize {
         /// Processor feature identification flag.
         ///
         /// If this flag is modifiable, the CPU supports CPUID.
@@ -76,8 +76,8 @@ mod x86_64 {
 
     /// Returns the raw current value of the RFLAGS register.
     #[inline]
-    pub fn read_raw() -> u64 {
-        let r: u64;
+    pub fn read_raw() -> usize {
+        let r: usize;
         #[cfg(feature = "inline_asm")]
         unsafe {
             asm!("pushf; pop {}", out(reg) r)
@@ -118,7 +118,7 @@ mod x86_64 {
     /// the `DF` flag must be unset in all Rust code. Also, modifying `CF`, `PF`, or any other
     /// flags also used by Rust/LLVM can result in undefined behavior too.
     #[inline]
-    pub unsafe fn write_raw(val: u64) {
+    pub unsafe fn write_raw(val: usize) {
         #[cfg(feature = "inline_asm")]
         {
             // FIXME - There's probably a better way than saying we preserve the flags even though we actually don't

--- a/src/structures/paging/mapper/legacy_offset_page_table.rs
+++ b/src/structures/paging/mapper/legacy_offset_page_table.rs
@@ -1,0 +1,268 @@
+use crate::structures::paging::{
+    frame::PhysFrame, mapper::*, page_table::PageTable, Page, PageTableFlags,
+};
+
+/// A Mapper implementation that requires that the complete physically memory is mapped at some
+/// offset in the virtual address space.
+#[derive(Debug)]
+pub struct LegacyOffsetPageTable<'a> {
+    inner: MappedPageTable<'a, PhysOffset>,
+}
+
+impl<'a> LegacyOffsetPageTable<'a> {
+    /// Creates a new `LegacyOffsetPageTable` that uses the given offset for converting virtual
+    /// to physical addresses.
+    ///
+    /// The first 4Gb of physical memory must be mapped in the virtual address space starting at
+    /// address `phys_offset`. This means that for example physical address `0x5000` can be
+    /// accessed through virtual address `phys_offset + 0x5000`. This mapping is required because
+    /// the mapper needs to access page tables, which are not mapped into the virtual address
+    /// space by default.
+    ///
+    /// ## Safety
+    ///
+    /// This function is unsafe because the caller must guarantee that the passed `phys_offset`
+    /// is correct. Also, the passed `level_4_table` must point to the level 4 page table
+    /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
+    /// by writing to an illegal memory location.
+    #[inline]
+    pub unsafe fn new(level_4_table: &'a mut PageTable, phys_offset: VirtAddr) -> Self {
+        let phys_offset = PhysOffset {
+            offset: phys_offset,
+        };
+        Self {
+            inner: MappedPageTable::new(level_4_table, phys_offset),
+        }
+    }
+
+    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&mut self) -> &mut PageTable {
+        self.inner.level_4_table()
+    }
+}
+
+#[derive(Debug)]
+struct PhysOffset {
+    offset: VirtAddr,
+}
+
+unsafe impl PageTableFrameMapping for PhysOffset {
+    fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
+        let virt = self.offset + frame.start_address().as_u64();
+        if let Ok(res) = virt.as_32b_mut_ptr() {
+            return res;
+        } else {
+            panic!("Virtual addr {:#?} is out of 32bit range. Not reachable by legacy_offset_page_table.", virt);
+        }
+    }
+}
+
+// delegate all trait implementations to inner
+
+impl<'a> Mapper<Size1GiB> for LegacyOffsetPageTable<'a> {
+    #[inline]
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<Size1GiB>,
+        frame: PhysFrame<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
+    fn unmap(
+        &mut self,
+        page: Page<Size1GiB>,
+    ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    #[inline]
+    unsafe fn update_flags(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size1GiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
+    }
+
+    #[inline]
+    fn translate_page(&self, page: Page<Size1GiB>) -> Result<PhysFrame<Size1GiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> Mapper<Size2MiB> for LegacyOffsetPageTable<'a> {
+    #[inline]
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<Size2MiB>,
+        frame: PhysFrame<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
+    fn unmap(
+        &mut self,
+        page: Page<Size2MiB>,
+    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    #[inline]
+    unsafe fn update_flags(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size2MiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
+    }
+
+    #[inline]
+    fn translate_page(&self, page: Page<Size2MiB>) -> Result<PhysFrame<Size2MiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> Mapper<Size4KiB> for LegacyOffsetPageTable<'a> {
+    #[inline]
+    unsafe fn map_to_with_table_flags<A>(
+        &mut self,
+        page: Page<Size4KiB>,
+        frame: PhysFrame<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner
+            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
+    fn unmap(
+        &mut self,
+        page: Page<Size4KiB>,
+    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+        self.inner.unmap(page)
+    }
+
+    #[inline]
+    unsafe fn update_flags(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlush<Size4KiB>, FlagUpdateError> {
+        self.inner.update_flags(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p4_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p4_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p3_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p3_entry(page, flags)
+    }
+
+    #[inline]
+    unsafe fn set_flags_p2_entry(
+        &mut self,
+        page: Page<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushAll, FlagUpdateError> {
+        self.inner.set_flags_p2_entry(page, flags)
+    }
+
+    #[inline]
+    fn translate_page(&self, page: Page<Size4KiB>) -> Result<PhysFrame<Size4KiB>, TranslateError> {
+        self.inner.translate_page(page)
+    }
+}
+
+impl<'a> Translate for LegacyOffsetPageTable<'a> {
+    #[inline]
+    fn translate(&self, addr: VirtAddr) -> TranslateResult {
+        self.inner.translate(addr)
+    }
+}

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -5,6 +5,7 @@ pub use self::mapped_page_table::{MappedPageTable, PageTableFrameMapping};
 pub use self::offset_page_table::OffsetPageTable;
 #[cfg(feature = "instructions")]
 pub use self::recursive_page_table::{InvalidPageTable, RecursivePageTable};
+pub use self::legacy_offset_page_table::LegacyOffsetPageTable;
 
 use crate::structures::paging::{
     frame_alloc::FrameAllocator, page_table::PageTableFlags, Page, PageSize, PhysFrame, Size1GiB,
@@ -16,6 +17,8 @@ mod mapped_page_table;
 mod offset_page_table;
 #[cfg(feature = "instructions")]
 mod recursive_page_table;
+mod legacy_offset_page_table;
+
 
 /// An empty convencience trait that requires the `Mapper` trait for all page sizes.
 pub trait MapperAllSizes: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB> {}

--- a/src/structures/paging/mod.rs
+++ b/src/structures/paging/mod.rs
@@ -9,6 +9,8 @@ pub use self::mapper::MappedPageTable;
 #[cfg(target_pointer_width = "64")]
 #[doc(no_inline)]
 pub use self::mapper::OffsetPageTable;
+#[doc(no_inline)]
+pub use self::mapper::LegacyOffsetPageTable;
 #[cfg(feature = "instructions")]
 #[doc(no_inline)]
 pub use self::mapper::RecursivePageTable;

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -194,6 +194,7 @@ impl PageTable {
         }
     }
 
+    /// Creates an empty page table.
     #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new() -> Self {


### PR DESCRIPTION
Hello,

I added x86 support so that this crate compiles and works with the target i686. This is an important feature for bootloaders which need to switch to long mode by creating a page table mapping etc.

What did I change?
I changed most of the u64 data types to usize ones. I did not blindly replace them but checked if it actually makes sense. 

I also changed the pure asm function definitons by changing the link name of the function depending on your architecture: https://github.com/Luis-Hebendanz/x86_64/blob/master/src/asm/mod.rs#L251

What's missing?
The asm functions implementation and testing them. I'm having trouble testing this because all rust versions I know or have set up have the `inline_asm` feature.

The i686 build command builds fine, but I am wondering why. External asm functions like `_x86_64_asm_set_cs` should throw errors because of the use of 64bit registers.
```bash
cargo build --target i686-unknown-linux-musl --no-default-features --features external_asm,instructions
```

Setting up another Github action with the target set to i686.
