### PR TITLE
Fix build on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(feature = "const_fn", feature(const_panic))]
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))]
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))]
-#![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
 #![cfg_attr(feature = "inline_asm", feature(asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![warn(missing_docs)]


### PR DESCRIPTION
The feature `const_in_array_repeat_expressions` was removed on the latest Rust nightly, removing the feature fixes a hard compilation error on all crates that import `x86_64` in nightly.

```
error[E0557]: feature has been removed
 --> /home/kernel/.cargo/registry/src/github.com-1ecc6299db9ec823/x86_64-0.13.1/src/lib.rs:9:43
  |
9 | #![cfg_attr(feature = "const_fn", feature(const_in_array_repeat_expressions))]
  |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: removed due to causing promotable bugs

error: aborting due to previous error

For more information about this error, try `rustc --explain E0557`.
error: could not compile `x86_64`
```