### PR TITLE
Implement more fmt traits for addr types

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -206,6 +206,34 @@ impl fmt::Debug for VirtAddr {
     }
 }
 
+impl fmt::Binary for VirtAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::LowerHex for VirtAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Octal for VirtAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::UpperHex for VirtAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Add<u64> for VirtAddr {
     type Output = Self;
     #[inline]

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -211,28 +211,28 @@ impl fmt::Debug for VirtAddr {
 impl fmt::Binary for VirtAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::Binary::fmt(&self.0, f)
     }
 }
 
 impl fmt::LowerHex for VirtAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
 impl fmt::Octal for VirtAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::Octal::fmt(&self.0, f)
     }
 }
 
 impl fmt::UpperHex for VirtAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::UpperHex::fmt(&self.0, f)
     }
 }
 
@@ -418,28 +418,28 @@ impl fmt::Debug for PhysAddr {
 impl fmt::Binary for PhysAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::Binary::fmt(&self.0, f)
     }
 }
 
 impl fmt::LowerHex for PhysAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::LowerHex::fmt(&self.0, f)
     }
 }
 
 impl fmt::Octal for PhysAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::Octal::fmt(&self.0, f)
     }
 }
 
 impl fmt::UpperHex for PhysAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
+        fmt::UpperHex::fmt(&self.0, f)
     }
 }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -202,7 +202,9 @@ impl VirtAddr {
 
 impl fmt::Debug for VirtAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "VirtAddr({:#x})", self.0)
+        f.debug_tuple("VirtAddr")
+            .field(&format_args!("{:#x}", self.0))
+            .finish()
     }
 }
 
@@ -407,7 +409,9 @@ impl PhysAddr {
 
 impl fmt::Debug for PhysAddr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "PhysAddr({:#x})", self.0)
+        f.debug_tuple("PhysAddr")
+            .field(&format_args!("{:#x}", self.0))
+            .finish()
     }
 }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -236,6 +236,13 @@ impl fmt::UpperHex for VirtAddr {
     }
 }
 
+impl fmt::Pointer for VirtAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&(self.0 as *const ()), f)
+    }
+}
+
 impl Add<u64> for VirtAddr {
     type Output = Self;
     #[inline]
@@ -440,6 +447,13 @@ impl fmt::UpperHex for PhysAddr {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::UpperHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Pointer for PhysAddr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Pointer::fmt(&(self.0 as *const ()), f)
     }
 }
 


### PR DESCRIPTION
Some minor improvements for debug traits for the address types:

* Adds `fmt::Binary`, `fmt::LowerHex`, `fmt::Octal`, `fmt::UpperHex` impls for `VirtAddr`
* Adds `fmt::Pointer` impls for `VirtAddr` and `PhysAddr`
* Use `fmt::Formatter::debug_tuple` in the `fmt::Debug` impls so formatting flags are respected