### PR TITLE
Fixes for `x86-interrupt` calling convention

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.13.5"
+version = "0.14.0"
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ edition = "2018"
 [dependencies]
 bit_field = "0.9.0"
 bitflags = "1.0.4"
+volatile = "0.4.4"
 
 [build-dependencies]
 cc = { version = "1.0.37", optional = true }

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.14.0 – 2021-04-11
+
 - **Breaking:** Take the interrupt stack frame by value (not by reference) [#242](https://github.com/rust-osdev/x86_64/pull/242)
 - **Breaking:** Change `InterruptStackFrame::as_mut` to return a `Volatile<_>` wrapper [#242](https://github.com/rust-osdev/x86_64/pull/242)
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- **Breaking:** Take the interrupt stack frame by value (not by reference) [#242](https://github.com/rust-osdev/x86_64/pull/242)
+- **Breaking:** Change `InterruptStackFrame::as_mut` to return a `Volatile<_>` wrapper [#242](https://github.com/rust-osdev/x86_64/pull/242)
+
 # 0.13.5 – 2021-04-01
 
 - Add support for `XCR0` register ([#239](https://github.com/rust-osdev/x86_64/pull/239))

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -572,18 +572,17 @@ pub struct Entry<F> {
 }
 
 /// A handler function for an interrupt or an exception without error code.
-pub type HandlerFunc = extern "x86-interrupt" fn(&mut InterruptStackFrame);
+pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
 /// A handler function for an exception that pushes an error code.
-pub type HandlerFuncWithErrCode =
-    extern "x86-interrupt" fn(&mut InterruptStackFrame, error_code: u64);
+pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64);
 /// A page fault handler function that pushes a page fault error code.
 pub type PageFaultHandlerFunc =
-    extern "x86-interrupt" fn(&mut InterruptStackFrame, error_code: PageFaultErrorCode);
+    extern "x86-interrupt" fn(InterruptStackFrame, error_code: PageFaultErrorCode);
 /// A handler function that must not return, e.g. for a machine check exception.
-pub type DivergingHandlerFunc = extern "x86-interrupt" fn(&mut InterruptStackFrame) -> !;
+pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -> !;
 /// A handler function with an error code that must not return, e.g. for a double fault exception.
 pub type DivergingHandlerFuncWithErrCode =
-    extern "x86-interrupt" fn(&mut InterruptStackFrame, error_code: u64) -> !;
+    extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64) -> !;
 
 impl<F> Entry<F> {
     /// Creates a non-present IDT entry (but sets the must-be-one bits).

--- a/testing/tests/breakpoint_exception.rs
+++ b/testing/tests/breakpoint_exception.rs
@@ -57,6 +57,6 @@ pub fn init_test_idt() {
     TEST_IDT.load();
 }
 
-extern "x86-interrupt" fn breakpoint_handler(_stack_frame: &mut InterruptStackFrame) {
+extern "x86-interrupt" fn breakpoint_handler(_stack_frame: InterruptStackFrame) {
     BREAKPOINT_HANDLER_CALLED.fetch_add(1, Ordering::SeqCst);
 }

--- a/testing/tests/double_fault_stack_overflow.rs
+++ b/testing/tests/double_fault_stack_overflow.rs
@@ -52,7 +52,7 @@ pub fn init_test_idt() {
 }
 
 extern "x86-interrupt" fn double_fault_handler(
-    _stack_frame: &mut InterruptStackFrame,
+    _stack_frame: InterruptStackFrame,
     _error_code: u64,
 ) -> ! {
     serial_println!("[ok]");


### PR DESCRIPTION
It looks like the `x86-interrupt` calling convention passes the `InterruptStackFrame` by value, not by reference: https://github.com/rust-lang/rust/issues/40180#issuecomment-814270159. Apparently, by-ref worked as well before Rust upgraded to LLVM 12, but it no longer works on the latest nightlies. This pull request fixes the IDT to require a by-value stack frame parameter.

Since modifying the interrupt stack frame [now requires a volatile write](https://github.com/rust-lang/rust/issues/40180#issuecomment-817207466), this PR changes the return type of the `InterruptStackFrame::as_mut` function to a `Volatile<_>` reference.

This is a **breaking change**.