### PR TITLE
Add sidt support

### DIFF
--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -119,6 +119,12 @@ _x86_64_asm_lidt:
     lidt (%rdi)
     retq
 
+.global _x86_64_asm_sidt
+.p2align 4
+_x86_64_asm_sidt:
+    sidt (%rdi)
+    retq
+
 .global _x86_64_asm_write_rflags
 .p2align 4
 _x86_64_asm_write_rflags:

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -134,6 +134,12 @@ extern "C" {
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_sidt"
+    )]
+    pub(crate) fn x86_64_asm_sidt(idt: *mut crate::instructions::tables::DescriptorTablePointer);
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_ltr"
     )]
     pub(crate) fn x86_64_asm_ltr(sel: u16);


### PR DESCRIPTION
Adds a function for getting the current IDT descriptor value. Motivation is largely that being able to get this value can be handy while debugging IDT-related faults.
I'm not 100% on whether the function is safe, but from the instructions description is seems safe to call, as at worst it can fault but it won't touch memory not at the location passed.