### PR TITLE
Use marker types for Port read/write access

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,10 @@
 # Unreleased
 
-- The following methods no longer require the `nightly` feature to be `const fn`s`:
+- Make the following types aliases of the new `PortGeneric` type ([#248](https://github.com/rust-osdev/x86_64/pull/248)):
+  - `Port<T> = PortGeneric<T, ReadWriteAccess>`
+  - `PortReadOnly<T> = PortGeneric<T, ReadOnlyAccess>`
+  - `PortWriteOnly<T> = PortGeneric<T, WriteOnlyAccess>`
+- The following methods no longer require the `nightly` feature to be `const fn`s` ([#255](https://github.com/rust-osdev/x86_64/pull/255)):
   - `PageTable::new`
   - `GlobalDescriptorTable::from_raw_slice`
   - `MappedFrame::{start_address, size}`

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -19,10 +19,10 @@ pub enum QemuExitCode {
 }
 
 pub fn exit_qemu(exit_code: QemuExitCode) {
-    use x86_64::instructions::port::Port;
+    use x86_64::instructions::port::PortWriteOnly;
 
     unsafe {
-        let mut port = Port::new(0xf4);
+        let mut port = PortWriteOnly::new(0xf4);
         port.write(exit_code as u32);
     }
 }

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -39,7 +39,7 @@ pub extern "C" fn _start() -> ! {
         // Read the test value using PortReadOnly
         let read_only_test_value = crt_data_read_only_port.read() & 0xFF;
 
-        // Read the test value using PortReadWrite
+        // Read the test value using Port
         let read_write_test_value = crt_read_write_data_port.read() & 0xFF;
 
         if read_only_test_value != TEST_VALUE {
@@ -51,7 +51,7 @@ pub extern "C" fn _start() -> ! {
 
         if read_write_test_value != TEST_VALUE {
             panic!(
-                "PortReadWrite: {} does not match expected value {}",
+                "Port: {} does not match expected value {}",
                 read_write_test_value, TEST_VALUE
             );
         }


### PR DESCRIPTION
Changes the `Port` struct to use a type parameter and marker types for restricting read/write access instead of using entirely separate structs, reducing some code duplication and making it easier to be generic over access types.

I'm fairly confident this is a compatible change since the `A` parameter on `Port` defaults to `ReadWriteAccess` and `PortReadOnly` and `PortWriteOnly` still exist, albeit as type aliases now.

This conflicts with #247 a bit but it should be easy for me to deal with the conflicts.