### PR TITLE
Use new `const_fn_trait_bound` feature to fix build on latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_fn))] // Needed for generic access to associated consts
 #![cfg_attr(feature = "const_fn", feature(const_panic))]
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))]
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))]
+#![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))]
 #![cfg_attr(feature = "inline_asm", feature(asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![warn(missing_docs)]


### PR DESCRIPTION
Feature gate introduced in https://github.com/rust-lang/rust/pull/84310.

Unfortunately, unknown feature gates lead to errors so that this change errors on older nightlies. For this reason, I think we should at least wait until the common `rustfmt` component is fixed on nightly again because then everyone should be able to update. See https://rust-lang.github.io/rustup-components-history/ for component availability.

Fixes #252 