### PR TITLE
Use const generics for different types of Ports

### DIFF
--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -130,33 +130,37 @@ impl PortWriteAccess for ReadWriteAccess {}
 ///
 /// The port reads or writes values of type `T` and has read/write access specified by `A`.
 ///
-/// By default, `A` is `ReadWriteAccess`, meaning that values can be read from or written to the
-/// port. Use `ReadOnlyAccess` or `WriteOnlyAccess` for `A` (or the type aliases `PortReadOnly` or
-/// `PortWriteOnly`) if you want to restrict access further.
+/// Use the provided marker types or aliases to get a port type with the access you need:
+/// * `PortGeneric<T, ReadWriteAccess>` -> `Port<T>`
+/// * `PortGeneric<T, ReadOnlyAccess>` -> `PortReadOnly<T>`
+/// * `PortGeneric<T, WriteOnlyAccess>` -> `PortWriteOnly<T>`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Port<T, A = ReadWriteAccess> {
+pub struct PortGeneric<T, A> {
     port: u16,
     phantom: PhantomData<(T, A)>,
 }
 
+/// A read-write I/O port.
+pub type Port<T> = PortGeneric<T, ReadWriteAccess>;
+
 /// A read-only I/O port.
-pub type PortReadOnly<T> = Port<T, ReadOnlyAccess>;
+pub type PortReadOnly<T> = PortGeneric<T, ReadOnlyAccess>;
 
 /// A write-only I/O port.
-pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
+pub type PortWriteOnly<T> = PortGeneric<T, WriteOnlyAccess>;
 
-impl<T, A> Port<T, A> {
+impl<T, A> PortGeneric<T, A> {
     /// Creates an I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> Port<T, A> {
-        Port {
+    pub const fn new(port: u16) -> PortGeneric<T, A> {
+        PortGeneric {
             port,
             phantom: PhantomData,
         }
     }
 }
 
-impl<T: PortRead, A: PortReadAccess> Port<T, A> {
+impl<T: PortRead, A: PortReadAccess> PortGeneric<T, A> {
     /// Reads from the port.
     ///
     /// ## Safety
@@ -169,7 +173,7 @@ impl<T: PortRead, A: PortReadAccess> Port<T, A> {
     }
 }
 
-impl<T: PortWrite, A: PortWriteAccess> Port<T, A> {
+impl<T: PortWrite, A: PortWriteAccess> PortGeneric<T, A> {
     /// Writes to the port.
     ///
     /// ## Safety

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -131,36 +131,36 @@ impl PortWriteAccess for ReadWriteAccess {}
 /// The port reads or writes values of type `T` and has read/write access specified by `A`.
 ///
 /// Use the provided marker types or aliases to get a port type with the access you need:
-/// * `PortGeneric<T, ReadWriteAccess>` -> `Port<T>`
-/// * `PortGeneric<T, ReadOnlyAccess>` -> `PortReadOnly<T>`
-/// * `PortGeneric<T, WriteOnlyAccess>` -> `PortWriteOnly<T>`
+/// * `Port<T, ReadWriteAccess>` -> `PortReadWrite<T>`
+/// * `Port<T, ReadOnlyAccess>` -> `PortReadOnly<T>`
+/// * `Port<T, WriteOnlyAccess>` -> `PortWriteOnly<T>`
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PortGeneric<T, A> {
+pub struct Port<T, A> {
     port: u16,
     phantom: PhantomData<(T, A)>,
 }
 
 /// A read-write I/O port.
-pub type Port<T> = PortGeneric<T, ReadWriteAccess>;
+pub type PortReadWrite<T> = Port<T, ReadWriteAccess>;
 
 /// A read-only I/O port.
-pub type PortReadOnly<T> = PortGeneric<T, ReadOnlyAccess>;
+pub type PortReadOnly<T> = Port<T, ReadOnlyAccess>;
 
 /// A write-only I/O port.
-pub type PortWriteOnly<T> = PortGeneric<T, WriteOnlyAccess>;
+pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
 
-impl<T, A> PortGeneric<T, A> {
+impl<T, A> Port<T, A> {
     /// Creates an I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> PortGeneric<T, A> {
-        PortGeneric {
+    pub const fn new(port: u16) -> Port<T, A> {
+        Port {
             port,
             phantom: PhantomData,
         }
     }
 }
 
-impl<T: PortRead, A: PortReadAccess> PortGeneric<T, A> {
+impl<T: PortRead, A: PortReadAccess> Port<T, A> {
     /// Reads from the port.
     ///
     /// ## Safety
@@ -173,7 +173,7 @@ impl<T: PortRead, A: PortReadAccess> PortGeneric<T, A> {
     }
 }
 
-impl<T: PortWrite, A: PortWriteAccess> PortGeneric<T, A> {
+impl<T: PortWrite, A: PortWriteAccess> Port<T, A> {
     /// Writes to the port.
     ///
     /// ## Safety

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -126,35 +126,35 @@ impl PortWriteAccess for ReadWriteAccess {}
 /// The port reads or writes values of type `T` and has read/write access specified by `A`.
 ///
 /// Use the provided marker types or aliases to get a port type with the access you need:
-/// * `Port<T, ReadWriteAccess>` -> `PortReadWrite<T>`
-/// * `Port<T, ReadOnlyAccess>` -> `PortReadOnly<T>`
-/// * `Port<T, WriteOnlyAccess>` -> `PortWriteOnly<T>`
-pub struct Port<T, A> {
+/// * `PortGeneric<T, ReadWriteAccess>` -> `Port<T>`
+/// * `PortGeneric<T, ReadOnlyAccess>` -> `PortReadOnly<T>`
+/// * `PortGeneric<T, WriteOnlyAccess>` -> `PortWriteOnly<T>`
+pub struct PortGeneric<T, A> {
     port: u16,
     phantom: PhantomData<(T, A)>,
 }
 
 /// A read-write I/O port.
-pub type PortReadWrite<T> = Port<T, ReadWriteAccess>;
+pub type Port<T> = PortGeneric<T, ReadWriteAccess>;
 
 /// A read-only I/O port.
-pub type PortReadOnly<T> = Port<T, ReadOnlyAccess>;
+pub type PortReadOnly<T> = PortGeneric<T, ReadOnlyAccess>;
 
 /// A write-only I/O port.
-pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
+pub type PortWriteOnly<T> = PortGeneric<T, WriteOnlyAccess>;
 
-impl<T, A> Port<T, A> {
+impl<T, A> PortGeneric<T, A> {
     /// Creates an I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> Port<T, A> {
-        Port {
+    pub const fn new(port: u16) -> PortGeneric<T, A> {
+        PortGeneric {
             port,
             phantom: PhantomData,
         }
     }
 }
 
-impl<T: PortRead, A: PortReadAccess> Port<T, A> {
+impl<T: PortRead, A: PortReadAccess> PortGeneric<T, A> {
     /// Reads from the port.
     ///
     /// ## Safety
@@ -167,7 +167,7 @@ impl<T: PortRead, A: PortReadAccess> Port<T, A> {
     }
 }
 
-impl<T: PortWrite, A: PortWriteAccess> Port<T, A> {
+impl<T: PortWrite, A: PortWriteAccess> PortGeneric<T, A> {
     /// Writes to the port.
     ///
     /// ## Safety
@@ -180,13 +180,15 @@ impl<T: PortWrite, A: PortWriteAccess> Port<T, A> {
     }
 }
 
-impl<T, A> fmt::Debug for Port<T, A> {
+impl<T, A> fmt::Debug for PortGeneric<T, A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Port").field("port", &self.port).finish()
+        f.debug_struct("PortGeneric")
+            .field("port", &self.port)
+            .finish()
     }
 }
 
-impl<T, A> Clone for Port<T, A> {
+impl<T, A> Clone for PortGeneric<T, A> {
     fn clone(&self) -> Self {
         Self {
             port: self.port,
@@ -195,10 +197,10 @@ impl<T, A> Clone for Port<T, A> {
     }
 }
 
-impl<T, A> PartialEq for Port<T, A> {
+impl<T, A> PartialEq for PortGeneric<T, A> {
     fn eq(&self, other: &Self) -> bool {
         self.port == other.port
     }
 }
 
-impl<T, A> Eq for Port<T, A> {}
+impl<T, A> Eq for PortGeneric<T, A> {}

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -148,7 +148,7 @@ pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
 impl<T, A> Port<T, A> {
     /// Creates an I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> Port<T> {
+    pub const fn new(port: u16) -> Port<T, A> {
         Port {
             port,
             phantom: PhantomData,

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -133,6 +133,11 @@ impl PortWriteAccess for ReadWriteAccess {}
 /// By default, `A` is `ReadWriteAccess`, meaning that values can be read from or written to the
 /// port. Use `ReadOnlyAccess` or `WriteOnlyAccess` for `A` (or the type aliases `PortReadOnly` or
 /// `PortWriteOnly`) if you want to restrict access further.
+///
+/// To create a new port, use the appropriate constructor for the access type you want:
+/// * `new` -> `ReadWriteAccess`
+/// * `new_read_only` -> `ReadOnlyAccess`
+/// * `new_write_only` -> `WriteOnlyAccess`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Port<T, A = ReadWriteAccess> {
     port: u16,
@@ -145,10 +150,32 @@ pub type PortReadOnly<T> = Port<T, ReadOnlyAccess>;
 /// A write-only I/O port.
 pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
 
-impl<T, A> Port<T, A> {
-    /// Creates an I/O port with the given port number.
+impl<T> Port<T> {
+    /// Creates a read-write I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> Port<T, A> {
+    pub const fn new(port: u16) -> Port<T> {
+        Port {
+            port,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> PortReadOnly<T> {
+    /// Creates a read-only I/O port with the given port number.
+    #[inline]
+    pub const fn new_read_only(port: u16) -> PortReadOnly<T> {
+        Port {
+            port,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<T> PortWriteOnly<T> {
+    /// Creates a write-only I/O port with the given port number.
+    #[inline]
+    pub const fn new_write_only(port: u16) -> PortWriteOnly<T> {
         Port {
             port,
             phantom: PhantomData,

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -103,25 +103,19 @@ pub trait PortWriteAccess {}
 
 /// An access marker type indicating that a port is only allowed to read values.
 #[derive(Debug)]
-pub struct ReadOnlyAccess {
-    _priv: (),
-}
+pub struct ReadOnlyAccess(());
 
 impl PortReadAccess for ReadOnlyAccess {}
 
 /// An access marker type indicating that a port is only allowed to write values.
 #[derive(Debug)]
-pub struct WriteOnlyAccess {
-    _priv: (),
-}
+pub struct WriteOnlyAccess(());
 
 impl PortWriteAccess for WriteOnlyAccess {}
 
 /// An access marker type indicating that a port is allowed to read or write values.
 #[derive(Debug)]
-pub struct ReadWriteAccess {
-    _priv: (),
-}
+pub struct ReadWriteAccess(());
 
 impl PortReadAccess for ReadWriteAccess {}
 

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -133,11 +133,6 @@ impl PortWriteAccess for ReadWriteAccess {}
 /// By default, `A` is `ReadWriteAccess`, meaning that values can be read from or written to the
 /// port. Use `ReadOnlyAccess` or `WriteOnlyAccess` for `A` (or the type aliases `PortReadOnly` or
 /// `PortWriteOnly`) if you want to restrict access further.
-///
-/// To create a new port, use the appropriate constructor for the access type you want:
-/// * `new` -> `ReadWriteAccess`
-/// * `new_read_only` -> `ReadOnlyAccess`
-/// * `new_write_only` -> `WriteOnlyAccess`
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Port<T, A = ReadWriteAccess> {
     port: u16,
@@ -150,32 +145,10 @@ pub type PortReadOnly<T> = Port<T, ReadOnlyAccess>;
 /// A write-only I/O port.
 pub type PortWriteOnly<T> = Port<T, WriteOnlyAccess>;
 
-impl<T> Port<T> {
-    /// Creates a read-write I/O port with the given port number.
+impl<T, A> Port<T, A> {
+    /// Creates an I/O port with the given port number.
     #[inline]
-    pub const fn new(port: u16) -> Port<T> {
-        Port {
-            port,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<T> PortReadOnly<T> {
-    /// Creates a read-only I/O port with the given port number.
-    #[inline]
-    pub const fn new_read_only(port: u16) -> PortReadOnly<T> {
-        Port {
-            port,
-            phantom: PhantomData,
-        }
-    }
-}
-
-impl<T> PortWriteOnly<T> {
-    /// Creates a write-only I/O port with the given port number.
-    #[inline]
-    pub const fn new_write_only(port: u16) -> PortWriteOnly<T> {
+    pub const fn new(port: u16) -> Port<T, A> {
         Port {
             port,
             phantom: PhantomData,

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -19,10 +19,10 @@ pub enum QemuExitCode {
 }
 
 pub fn exit_qemu(exit_code: QemuExitCode) {
-    use x86_64::instructions::port::Port;
+    use x86_64::instructions::port::PortReadWrite;
 
     unsafe {
-        let mut port = Port::new(0xf4);
+        let mut port = PortReadWrite::new(0xf4);
         port.write(exit_code as u32);
     }
 }

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -19,10 +19,10 @@ pub enum QemuExitCode {
 }
 
 pub fn exit_qemu(exit_code: QemuExitCode) {
-    use x86_64::instructions::port::PortReadWrite;
+    use x86_64::instructions::port::PortWriteOnly;
 
     unsafe {
-        let mut port = PortReadWrite::new(0xf4);
+        let mut port = PortWriteOnly::new(0xf4);
         port.write(exit_code as u32);
     }
 }

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -4,7 +4,7 @@
 
 use core::panic::PanicInfo;
 use testing::{exit_qemu, serial_print, serial_println, QemuExitCode};
-use x86_64::instructions::port::{PortReadOnly, PortReadWrite, PortWriteOnly};
+use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
 
 // This port tells the data port which index to read from
 const CRT_INDEX_PORT: u16 = 0x3D4;
@@ -26,7 +26,7 @@ pub extern "C" fn _start() -> ! {
     serial_print!("port_read_write... ");
 
     let mut crt_index_port = PortWriteOnly::<u8>::new(CRT_INDEX_PORT);
-    let mut crt_read_write_data_port = PortReadWrite::<u8>::new(CRT_DATA_PORT);
+    let mut crt_read_write_data_port = Port::<u8>::new(CRT_DATA_PORT);
     let mut crt_data_read_only_port = PortReadOnly::<u8>::new(CRT_DATA_PORT);
 
     unsafe {
@@ -39,7 +39,7 @@ pub extern "C" fn _start() -> ! {
         // Read the test value using PortReadOnly
         let read_only_test_value = crt_data_read_only_port.read() & 0xFF;
 
-        // Read the test value using PortReadWrite
+        // Read the test value using Port
         let read_write_test_value = crt_read_write_data_port.read() & 0xFF;
 
         if read_only_test_value != TEST_VALUE {
@@ -51,7 +51,7 @@ pub extern "C" fn _start() -> ! {
 
         if read_write_test_value != TEST_VALUE {
             panic!(
-                "PortReadWrite: {} does not match expected value {}",
+                "Port: {} does not match expected value {}",
                 read_write_test_value, TEST_VALUE
             );
         }

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -4,7 +4,7 @@
 
 use core::panic::PanicInfo;
 use testing::{exit_qemu, serial_print, serial_println, QemuExitCode};
-use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
+use x86_64::instructions::port::{PortReadOnly, PortReadWrite, PortWriteOnly};
 
 // This port tells the data port which index to read from
 const CRT_INDEX_PORT: u16 = 0x3D4;
@@ -26,7 +26,7 @@ pub extern "C" fn _start() -> ! {
     serial_print!("port_read_write... ");
 
     let mut crt_index_port = PortWriteOnly::<u8>::new(CRT_INDEX_PORT);
-    let mut crt_read_write_data_port = Port::<u8>::new(CRT_DATA_PORT);
+    let mut crt_read_write_data_port = PortReadWrite::<u8>::new(CRT_DATA_PORT);
     let mut crt_data_read_only_port = PortReadOnly::<u8>::new(CRT_DATA_PORT);
 
     unsafe {


### PR DESCRIPTION
Draft alternative implementation of #248 that uses const generics (stable in Rust 1.51)