### PR TITLE
Add common abstractions for x86 Segments 

### DIFF
--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -173,6 +173,36 @@ _x86_64_asm_load_gs:
     mov %di, %gs
     retq
 
+.global _x86_64_asm_get_ss
+.p2align 4
+_x86_64_asm_get_ss:
+    mov %ss, %ax
+    retq
+
+.global _x86_64_asm_get_ds
+.p2align 4
+_x86_64_asm_get_ds:
+    mov %ds, %ax
+    retq
+
+.global _x86_64_asm_get_es
+.p2align 4
+_x86_64_asm_get_es:
+    mov %es, %ax
+    retq
+
+.global _x86_64_asm_get_fs
+.p2align 4
+_x86_64_asm_get_fs:
+    mov %fs, %ax
+    retq
+
+.global _x86_64_asm_get_gs
+.p2align 4
+_x86_64_asm_get_gs:
+    mov %gs, %ax
+    retq
+
 .global _x86_64_asm_swapgs
 .p2align 4
 _x86_64_asm_swapgs:

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -116,6 +116,36 @@ extern "C" {
 
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_ss"
+    )]
+    pub(crate) fn x86_64_asm_get_ss() -> u16;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_ds"
+    )]
+    pub(crate) fn x86_64_asm_get_ds() -> u16;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_es"
+    )]
+    pub(crate) fn x86_64_asm_get_es() -> u16;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_fs"
+    )]
+    pub(crate) fn x86_64_asm_get_fs() -> u16;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_get_gs"
+    )]
+    pub(crate) fn x86_64_asm_get_gs() -> u16;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_swapgs"
     )]
     pub(crate) fn x86_64_asm_swapgs();

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -193,41 +193,49 @@ impl GS {
 }
 
 /// Alias for [`CS::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `CS::set_reg()` instead")]
 #[inline]
 pub unsafe fn set_cs(sel: SegmentSelector) {
     CS::set_reg(sel)
 }
 /// Alias for [`SS::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `SS::set_reg()` instead")]
 #[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
     SS::set_reg(sel)
 }
 /// Alias for [`DS::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `DS::set_reg()` instead")]
 #[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
     DS::set_reg(sel)
 }
 /// Alias for [`ES::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `ES::set_reg()` instead")]
 #[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
     ES::set_reg(sel)
 }
 /// Alias for [`FS::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `FS::set_reg()` instead")]
 #[inline]
 pub unsafe fn load_fs(sel: SegmentSelector) {
     FS::set_reg(sel)
 }
 /// Alias for [`GS::set_reg()`]
+#[deprecated(since = "0.14.4", note = "use `GS::set_reg()` instead")]
 #[inline]
 pub unsafe fn load_gs(sel: SegmentSelector) {
     GS::set_reg(sel)
 }
 /// Alias for [`GS::swap()`]
+#[deprecated(since = "0.14.4", note = "use `GS::swap()` instead")]
 #[inline]
 pub unsafe fn swap_gs() {
     GS::swap()
 }
 /// Alias for [`CS::get_reg()`]
+#[deprecated(since = "0.14.4", note = "use `CS::get_reg()` instead")]
 #[inline]
 pub fn cs() -> SegmentSelector {
     CS::get_reg()
@@ -235,11 +243,13 @@ pub fn cs() -> SegmentSelector {
 /// Alias for [`FS::write_base()`].
 ///
 /// Raises #GP if the provided address is non-canonical.
+#[deprecated(since = "0.14.4", note = "use `FS::write_base()` instead")]
 #[inline]
 pub unsafe fn wrfsbase(val: u64) {
     FS::write_base(VirtAddr::new(val))
 }
 /// Alias for [`FS::read_base()`]
+#[deprecated(since = "0.14.4", note = "use `FS::read_base()` instead")]
 #[inline]
 pub unsafe fn rdfsbase() -> u64 {
     FS::read_base().as_u64()
@@ -247,11 +257,13 @@ pub unsafe fn rdfsbase() -> u64 {
 /// Alias for [`GS::write_base()`].
 ///
 /// Raises #GP if the provided address is non-canonical.
+#[deprecated(since = "0.14.4", note = "use `GS::write_base()` instead")]
 #[inline]
 pub unsafe fn wrgsbase(val: u64) {
     GS::write_base(VirtAddr::new(val))
 }
 /// Alias for [`GS::read_base()`]
+#[deprecated(since = "0.14.4", note = "use `GS::read_base()` instead")]
 #[inline]
 pub unsafe fn rdgsbase() -> u64 {
     GS::read_base().as_u64()

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -1,7 +1,10 @@
 //! Provides functions to read and write segment registers.
 
 #[cfg(docsrs)]
-use crate::{registers::control::Cr4Flags, structures::gdt::GlobalDescriptorTable};
+use crate::{
+    registers::control::Cr4Flags,
+    structures::gdt::{Descriptor, GlobalDescriptorTable},
+};
 use crate::{
     registers::model_specific::{FsBase, GsBase, Msr},
     structures::gdt::SegmentSelector,
@@ -152,7 +155,11 @@ impl Segment for CS {
 /// Stack Segment
 ///
 /// Entirely unused in 64-bit mode; setting the segment register does nothing.
-/// However, this register is often set by the `syscall`/`sysret` and
+/// However, in ring 3, the SS register still has to point to a valid
+/// [`Descriptor`] (it cannot be zero). This means a user-mode read/write
+/// segment descriptor must be present in the GDT.
+///
+/// This register is also set by the `syscall`/`sysret` and
 /// `sysenter`/`sysexit` instructions (even on 64-bit transitions). This is to
 /// maintain symmetry with 32-bit transitions where setting SS actually will
 /// actually have an effect.

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -202,48 +202,56 @@ impl GS {
 
 /// Alias for [`CS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `CS::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn set_cs(sel: SegmentSelector) {
     CS::set_reg(sel)
 }
 /// Alias for [`SS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `SS::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
     SS::set_reg(sel)
 }
 /// Alias for [`DS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `DS::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
     DS::set_reg(sel)
 }
 /// Alias for [`ES::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `ES::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
     ES::set_reg(sel)
 }
 /// Alias for [`FS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `FS::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_fs(sel: SegmentSelector) {
     FS::set_reg(sel)
 }
 /// Alias for [`GS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `GS::set_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_gs(sel: SegmentSelector) {
     GS::set_reg(sel)
 }
 /// Alias for [`GS::swap()`]
 #[deprecated(since = "0.14.4", note = "use `GS::swap()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn swap_gs() {
     GS::swap()
 }
 /// Alias for [`CS::get_reg()`]
 #[deprecated(since = "0.14.4", note = "use `CS::get_reg()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub fn cs() -> SegmentSelector {
     CS::get_reg()
@@ -252,12 +260,14 @@ pub fn cs() -> SegmentSelector {
 ///
 /// Raises #GP if the provided address is non-canonical.
 #[deprecated(since = "0.14.4", note = "use `FS::write_base()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn wrfsbase(val: u64) {
     FS::write_base(VirtAddr::new(val))
 }
 /// Alias for [`FS::read_base()`]
 #[deprecated(since = "0.14.4", note = "use `FS::read_base()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn rdfsbase() -> u64 {
     FS::read_base().as_u64()
@@ -266,12 +276,14 @@ pub unsafe fn rdfsbase() -> u64 {
 ///
 /// Raises #GP if the provided address is non-canonical.
 #[deprecated(since = "0.14.4", note = "use `GS::write_base()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn wrgsbase(val: u64) {
     GS::write_base(VirtAddr::new(val))
 }
 /// Alias for [`GS::read_base()`]
 #[deprecated(since = "0.14.4", note = "use `GS::read_base()` instead")]
+#[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn rdgsbase() -> u64 {
     GS::read_base().as_u64()

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -151,21 +151,25 @@ impl Segment for CS {
 
 /// Stack Segment
 ///
-/// Entirely unused in 64-bit mode, setting the segment register does nothing.
+/// Entirely unused in 64-bit mode; setting the segment register does nothing.
+/// However, this register is often set by the `syscall`/`sysret` and
+/// `sysenter`/`sysexit` instructions (even on 64-bit transitions). This is to
+/// maintain symmetry with 32-bit transitions where setting SS actually will
+/// actually have an effect.
 #[derive(Debug)]
 pub struct SS;
 segment_impl!(SS, "ss", x86_64_asm_get_ss, x86_64_asm_load_ss);
 
 /// Data Segment
 ///
-/// Entirely unused in 64-bit mode, setting the segment register does nothing.
+/// Entirely unused in 64-bit mode; setting the segment register does nothing.
 #[derive(Debug)]
 pub struct DS;
 segment_impl!(DS, "ds", x86_64_asm_get_ds, x86_64_asm_load_ds);
 
 /// ES Segment
 ///
-/// Entirely unused in 64-bit mode, setting the segment register does nothing.
+/// Entirely unused in 64-bit mode; setting the segment register does nothing.
 #[derive(Debug)]
 pub struct ES;
 segment_impl!(ES, "es", x86_64_asm_get_es, x86_64_asm_load_es);

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -121,7 +121,7 @@ macro_rules! segment64_impl {
 ///
 /// The segment base and limit are unused in 64-bit mode. Only the L (long), D
 /// (default operation size), and DPL (descriptor privilege-level) fields of the
-/// descriptor are recognized. So chaning the segment register can be used to
+/// descriptor are recognized. So changing the segment register can be used to
 /// change privilege level or enable/disable long mode.
 #[derive(Debug)]
 pub struct CS;

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -266,7 +266,7 @@ pub fn cs() -> SegmentSelector {
 }
 /// Alias for [`FS::write_base()`].
 ///
-/// Raises #GP if the provided address is non-canonical.
+/// Panics if the provided address is non-canonical.
 #[deprecated(since = "0.14.4", note = "use `FS::write_base()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
@@ -282,7 +282,7 @@ pub unsafe fn rdfsbase() -> u64 {
 }
 /// Alias for [`GS::write_base()`].
 ///
-/// Raises #GP if the provided address is non-canonical.
+/// Panics if the provided address is non-canonical.
 #[deprecated(since = "0.14.4", note = "use `GS::write_base()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -128,10 +128,10 @@ pub struct CS;
 impl Segment for CS {
     get_reg_impl!("cs", x86_64_asm_get_cs);
 
+    /// Note this is special since we cannot directly move to [`CS`]. Instead we
+    /// push the new segment selector and return value on the stack and use
+    /// `retfq` to reload [`CS`] and continue at the end of our function.
     unsafe fn set_reg(sel: SegmentSelector) {
-        // Note this is special since we cannot directly move to cs. Instead we
-        // push the new segment selector and return value on the stack and use
-        // retfq to reload cs and continue at 1:.
         #[cfg(feature = "inline_asm")]
         asm!(
             "push {sel}",

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -6,6 +6,7 @@ pub mod rflags;
 pub mod xcontrol;
 
 #[cfg(feature = "instructions")]
+#[allow(deprecated)]
 pub use crate::instructions::segmentation::{rdfsbase, rdgsbase, wrfsbase, wrgsbase};
 
 #[cfg(all(feature = "instructions", feature = "inline_asm"))]

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -1,5 +1,11 @@
 //! Functions to read and write model specific registers.
 
+#[cfg(docsrs)]
+use crate::{
+    instructions::segmentation::{Segment64, FS, GS},
+    registers::control::Cr4Flags,
+};
+
 use bitflags::bitflags;
 
 /// A model specific register.
@@ -18,15 +24,19 @@ impl Msr {
 #[derive(Debug)]
 pub struct Efer;
 
-/// FS.Base Model Specific Register.
+/// [FS].Base Model Specific Register.
 #[derive(Debug)]
 pub struct FsBase;
 
-/// GS.Base Model Specific Register.
+/// [GS].Base Model Specific Register.
+///
+/// [`GS::swap`] swaps this register with [`KernelGsBase`].
 #[derive(Debug)]
 pub struct GsBase;
 
 /// KernelGsBase Model Specific Register.
+///
+/// [`GS::swap`] swaps this register with [`GsBase`].
 #[derive(Debug)]
 pub struct KernelGsBase;
 
@@ -223,12 +233,18 @@ mod x86_64 {
 
     impl FsBase {
         /// Read the current FsBase register.
+        ///
+        /// If [`CR4.FSGSBASE`][Cr4Flags::FSGSBASE] is set, the more efficient
+        /// [`FS::read_base`] can be used instead.
         #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the FS.Base register.
+        ///
+        /// If [`CR4.FSGSBASE`][Cr4Flags::FSGSBASE] is set, the more efficient
+        /// [`FS::write_base`] can be used instead.
         #[inline]
         pub fn write(address: VirtAddr) {
             let mut msr = Self::MSR;
@@ -238,12 +254,18 @@ mod x86_64 {
 
     impl GsBase {
         /// Read the current GsBase register.
+        ///
+        /// If [`CR4.FSGSBASE`][Cr4Flags::FSGSBASE] is set, the more efficient
+        /// [`GS::read_base`] can be used instead.
         #[inline]
         pub fn read() -> VirtAddr {
             VirtAddr::new(unsafe { Self::MSR.read() })
         }
 
         /// Write a given virtual address to the GS.Base register.
+        ///
+        /// If [`CR4.FSGSBASE`][Cr4Flags::FSGSBASE] is set, the more efficient
+        /// [`GS::write_base`] can be used instead.
         #[inline]
         pub fn write(address: VirtAddr) {
             let mut msr = Self::MSR;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -630,13 +630,13 @@ impl<F> Entry<F> {
     #[cfg(feature = "instructions")]
     #[inline]
     fn set_handler_addr(&mut self, addr: u64) -> &mut EntryOptions {
-        use crate::instructions::segmentation;
+        use crate::instructions::segmentation::{Segment, CS};
 
         self.pointer_low = addr as u16;
         self.pointer_middle = (addr >> 16) as u16;
         self.pointer_high = (addr >> 32) as u32;
 
-        self.gdt_selector = segmentation::cs().0;
+        self.gdt_selector = CS::get_reg().0;
 
         self.options.set_present(true);
         &mut self.options

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -38,12 +38,12 @@ struct Selectors {
 }
 
 pub fn init() {
-    use x86_64::instructions::segmentation::set_cs;
+    use x86_64::instructions::segmentation::{CS, Segment};
     use x86_64::instructions::tables::load_tss;
 
     GDT.0.load();
     unsafe {
-        set_cs(GDT.1.code_selector);
+        CS::set_reg(GDT.1.code_selector);
         load_tss(GDT.1.tss_selector);
     }
 }


### PR DESCRIPTION
When working on #257 I noticed it might be a good idea to have a common trait for the FS and GS segments, to make their use in things like wrapper structs easier. In fact, it makes sense to have a (different) common trait for all of the segments.

This change introduces the following traits:
  - `Segment`
    - allows reading/writing the segment register
    - implemented by `CS`, `DS`, `ES`, `SS`, `FS`, and `GS`
  - `Segment64`
    - allows reading/writing the segment base (using `VirtAddr` instead of `u64`)
    - associated `const` for the `Msr`
    - implemented by `FS` and `GS`
    - this trait will eventually also have the `read_u64`/`write_u64` methods from #257

Now that the code has a similar structure for all segments, we can use macros to implement the traits.

Also, this change adds some additional documentation about the segments and segment registers.

Outstanding questions:
  - I deprecated all the free functions (`rdfsbase()`/`wrgsbase()`/`set_ds()`/`set_cs()`/`cs()` etc...). Does this seem reasonable? We could also wait to deprecate them until `0.15` (with removal in `0.16` or later).
  - Right now both the `Segment` and `Segment64` traits just have static methods. Should I make these be normal methods? It doesn't really matter as the segment structs are singletons (`CS::get_reg()` vs `CS.get_reg()`). One advantage of normal methods is that the trait is then object safe, allowing users to use `&dyn Segment` and `&dyn Segment64`.