### PR TITLE
replace software_interrupt! macro with generic function

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -148,15 +148,8 @@ pub fn int3() {
 }
 
 /// Generate a software interrupt by invoking the `int` instruction.
-///
-/// This currently needs to be a macro because the `int` argument needs to be an
-/// immediate. This macro will be replaced by a generic function when support for
-/// const generics is implemented in Rust.
 #[cfg(feature = "inline_asm")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "nightly", feature = "inline_asm"))))]
-#[macro_export]
-macro_rules! software_interrupt {
-    ($x:expr) => {{
-        asm!("int {id}", id = const $x, options(nomem, nostack));
-    }};
+pub unsafe fn software_interrupt<const X: u8>() {
+    asm!("int {id}", id = const X, options(nomem, nostack));
 }

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -150,6 +150,6 @@ pub fn int3() {
 /// Generate a software interrupt by invoking the `int` instruction.
 #[cfg(feature = "inline_asm")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "nightly", feature = "inline_asm"))))]
-pub unsafe fn software_interrupt<const X: u8>() {
-    asm!("int {id}", id = const X, options(nomem, nostack));
+pub unsafe fn software_interrupt<const NUM: u8>() {
+    asm!("int {num}", num = const NUM, options(nomem, nostack));
 }

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -148,6 +148,13 @@ pub fn int3() {
 }
 
 /// Generate a software interrupt by invoking the `int` instruction.
+///
+/// ## Safety
+///
+/// Invoking an arbitrary interrupt is unsafe. It can cause your system to
+/// crash if you invoke a double-fault (#8) or machine-check (#18) exception.
+/// It can also cause memory/register corruption depending on the interrupt
+/// implementation (if it expects values/pointers to be passed in registers).
 #[cfg(feature = "inline_asm")]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "nightly", feature = "inline_asm"))))]
 pub unsafe fn software_interrupt<const NUM: u8>() {


### PR DESCRIPTION
This pr replaces the `software_interrupt!` macro with a generic function.

This is a **breaking change**.
