### PR TITLE
Support mapping ranges

### DIFF
--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -163,6 +163,15 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
             None
         }
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        if !self.is_empty() {
+            ((self.end.start_address() - self.start.start_address()) / S::SIZE) as usize
+        } else {
+            0
+        }
+    }
 }
 
 impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -645,7 +645,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size1GiB>,
         deallocator: &mut D,
@@ -850,7 +850,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size2MiB>,
         deallocator: &mut D,
@@ -1068,7 +1068,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size4KiB>,
         deallocator: &mut D,

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -4,6 +4,7 @@ use crate::structures::paging::{
     mapper::*,
     page::{AddressNotAligned, Page, Size1GiB, Size2MiB, Size4KiB},
     page_table::{FrameError, PageTable, PageTableEntry, PageTableFlags},
+    PageTableIndex,
 };
 
 /// A Mapper implementation that relies on a PhysAddr to VirtAddr conversion function.
@@ -140,6 +141,418 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
 
         Ok(MapperFlush::new(page))
     }
+
+    #[inline]
+    fn next_table_fn_create_next_table<'b, A>(
+        (flags, allocator): &mut (PageTableFlags, &mut A),
+        entry: &'b mut PageTableEntry,
+        walker: &PageTableWalker<P>,
+    ) -> Result<&'b mut PageTable, PageTableCreateError>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        walker
+            .create_next_table(entry, *flags, *allocator)
+            .map_err(Into::into)
+    }
+
+    #[inline]
+    fn next_table_fn_next_table_mut<'b, T>(
+        _: &mut T,
+        entry: &'b mut PageTableEntry,
+        walker: &PageTableWalker<P>,
+    ) -> Result<&'b mut PageTable, PageTableWalkError> {
+        walker.next_table_mut(entry)
+    }
+
+    fn modify_range_1gib<ModifyFn, ModifyInfo, Err, NextTableFn, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: NextTableFn,
+    ) -> Result<MapperFlushRange<Size1GiB>, (Err, MapperFlushRange<Size1GiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size1GiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFn: for<'b> Fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            &PageTableWalker<P>,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let p4 = &mut self.level_4_table;
+        let page_table_walker = &mut self.page_table_walker;
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices_1gib(p4_index, PageTableIndex::new(0));
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices_1gib(p4_index, PageTableIndex::new(511));
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3 = next_table(&mut info, &mut p4[p4_index], page_table_walker)
+                    .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index().into();
+                let mut end_p3_index = p4_end.p3_index().into();
+
+                if p4_end != pages.end {
+                    end_p3_index += 1;
+                }
+
+                (start_p3_index..end_p3_index)
+                    .map(PageTableIndex::new)
+                    .map(move |p3_index| Page::from_page_table_indices_1gib(p4_index, p3_index))
+                    .try_for_each(|page| {
+                        let entry = &mut p3[page.p3_index()];
+                        modify(entry, page, &mut info).map_err(|e| (e, page))
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_to_range_1gib<F, A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        F: Fn(Page<Size1GiB>, &mut A) -> Option<PhysFrame<Size1GiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_1gib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
+
+    fn modify_range_2mib<ModifyFn, ModifyInfo, Err, NextTableFn, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: NextTableFn,
+    ) -> Result<MapperFlushRange<Size2MiB>, (Err, MapperFlushRange<Size2MiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size2MiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFn: for<'b> Fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            &PageTableWalker<P>,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let p4 = &mut self.level_4_table;
+        let page_table_walker = &mut self.page_table_walker;
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices_2mib(
+                    p4_index,
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                );
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices_2mib(
+                    p4_index,
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                );
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3 = next_table(&mut info, &mut p4[p4_index], page_table_walker)
+                    .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index();
+                let end_p3_index = p4_end.p3_index();
+
+                (start_p3_index.into()..=end_p3_index.into())
+                    .map(PageTableIndex::new)
+                    .try_for_each(|p3_index| {
+                        let p3_start = Page::from_page_table_indices_2mib(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(0),
+                        );
+                        let p3_start = p3_start.max(p4_start);
+                        let p3_end = Page::from_page_table_indices_2mib(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(511),
+                        );
+                        let p3_end = p3_end.min(p4_end);
+
+                        if p3_start == p3_end {
+                            return Ok(());
+                        }
+
+                        let p2 = next_table(&mut info, &mut p3[p3_index], page_table_walker)
+                            .map_err(|e| (e.into(), p3_start))?;
+
+                        let start_p2_index = p3_start.p2_index().into();
+                        let mut end_p2_index = p3_end.p2_index().into();
+
+                        if p3_end != pages.end {
+                            end_p2_index += 1;
+                        }
+
+                        (start_p2_index..end_p2_index)
+                            .map(PageTableIndex::new)
+                            .map(move |p2_index| {
+                                Page::from_page_table_indices_2mib(p4_index, p3_index, p2_index)
+                            })
+                            .try_for_each(|page| {
+                                let entry = &mut p2[page.p2_index()];
+                                modify(entry, page, &mut info).map_err(|e| (e, page))
+                            })
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_range_2mib<F, A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        F: Fn(Page<Size2MiB>, &mut A) -> Option<PhysFrame<Size2MiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_2mib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
+
+    fn modify_range_4kib<ModifyFn, ModifyInfo, Err, NextTableFn, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: NextTableFn,
+    ) -> Result<MapperFlushRange<Size4KiB>, (Err, MapperFlushRange<Size4KiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size4KiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFn: for<'b> Fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            &PageTableWalker<P>,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let p4 = &mut self.level_4_table;
+        let page_table_walker = &mut self.page_table_walker;
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices(
+                    p4_index,
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                );
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices(
+                    p4_index,
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                );
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3 = next_table(&mut info, &mut p4[p4_index], page_table_walker)
+                    .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index();
+                let end_p3_index = p4_end.p3_index();
+
+                (start_p3_index.into()..=end_p3_index.into())
+                    .map(PageTableIndex::new)
+                    .try_for_each(|p3_index| {
+                        let p3_start = Page::from_page_table_indices(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(0),
+                            PageTableIndex::new(0),
+                        );
+                        let p3_start = p3_start.max(p4_start);
+                        let p3_end = Page::from_page_table_indices(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(511),
+                            PageTableIndex::new(511),
+                        );
+                        let p3_end = p3_end.min(p4_end);
+
+                        if p3_start == p3_end {
+                            return Ok(());
+                        }
+
+                        let p2 = next_table(&mut info, &mut p3[p3_index], page_table_walker)
+                            .map_err(|e| (e.into(), p3_start))?;
+
+                        let start_p2_index = p3_start.p2_index();
+                        let end_p2_index = p3_end.p2_index();
+
+                        (start_p2_index.into()..=end_p2_index.into())
+                            .map(PageTableIndex::new)
+                            .try_for_each(|p2_index| {
+                                let p2_start = Page::from_page_table_indices(
+                                    p4_index,
+                                    p3_index,
+                                    p2_index,
+                                    PageTableIndex::new(0),
+                                );
+                                let p2_start = p2_start.max(p4_start);
+                                let p2_end = Page::from_page_table_indices(
+                                    p4_index,
+                                    p3_index,
+                                    p2_index,
+                                    PageTableIndex::new(511),
+                                );
+                                let p2_end = p2_end.min(p4_end);
+
+                                if p2_start == p2_end {
+                                    return Ok(());
+                                }
+
+                                let p1 =
+                                    next_table(&mut info, &mut p2[p2_index], page_table_walker)
+                                        .map_err(|e| (e.into(), p2_start))?;
+
+                                let start_p1_index = p2_start.p1_index().into();
+                                let mut end_p1_index = p2_end.p1_index().into();
+
+                                if p2_end != pages.end {
+                                    end_p1_index += 1;
+                                }
+
+                                (start_p1_index..end_p1_index)
+                                    .map(PageTableIndex::new)
+                                    .map(move |p1_index| {
+                                        Page::from_page_table_indices(
+                                            p4_index, p3_index, p2_index, p1_index,
+                                        )
+                                    })
+                                    .try_for_each(|page| {
+                                        let entry = &mut p1[page.p1_index()];
+                                        modify(entry, page, &mut info).map_err(|e| (e, page))
+                                    })
+                            })
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_to_range_4kib<F, A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        F: Fn(Page<Size4KiB>, &mut A) -> Option<PhysFrame<Size4KiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_4kib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
 }
 
 impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
@@ -156,6 +569,53 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        frames: PhysFrameRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_to_range_1gib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size1GiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size1GiB> + ?Sized,
+    {
+        self.map_to_range_1gib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
     }
 
     fn unmap(
@@ -184,6 +644,32 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size1GiB>, (UnmapError, MapperFlushRange<Size1GiB>)>
+    where
+        D: FrameDeallocator<Size1GiB>,
+    {
+        self.modify_range_1gib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = PhysFrame::from_start_address(entry.addr())
+                    .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(entry.addr()))?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
@@ -200,6 +686,27 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
         p3[page.p3_index()].set_flags(flags | PageTableFlags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size1GiB>, (FlagUpdateError, MapperFlushRange<Size1GiB>)> {
+        self.modify_range_1gib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(
@@ -266,6 +773,53 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
         self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
 
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        frames: PhysFrameRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_range_2mib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size2MiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size2MiB> + ?Sized,
+    {
+        self.map_range_2mib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
@@ -295,6 +849,32 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size2MiB>, (UnmapError, MapperFlushRange<Size2MiB>)>
+    where
+        D: FrameDeallocator<Size2MiB>,
+    {
+        self.modify_range_2mib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = PhysFrame::from_start_address(entry.addr())
+                    .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(entry.addr()))?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
@@ -315,6 +895,27 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
         p2[page.p2_index()].set_flags(flags | PageTableFlags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size2MiB>, (FlagUpdateError, MapperFlushRange<Size2MiB>)> {
+        self.modify_range_2mib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(
@@ -394,6 +995,52 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
         self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }
 
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        frames: PhysFrameRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_to_range_4kib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size4KiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.map_to_range_4kib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
@@ -420,6 +1067,34 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size4KiB>, (UnmapError, MapperFlushRange<Size4KiB>)>
+    where
+        D: FrameDeallocator<Size4KiB>,
+    {
+        self.modify_range_4kib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = entry.frame().map_err(|err| match err {
+                    FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+                    FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
+                })?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     unsafe fn update_flags(
         &mut self,
         page: Page<Size4KiB>,
@@ -443,6 +1118,27 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
         p1[page.p1_index()].set_flags(flags);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size4KiB>, (FlagUpdateError, MapperFlushRange<Size4KiB>)> {
+        self.modify_range_4kib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -6,6 +6,8 @@ pub use self::offset_page_table::OffsetPageTable;
 #[cfg(feature = "instructions")]
 pub use self::recursive_page_table::{InvalidPageTable, RecursivePageTable};
 
+use core::convert::Infallible;
+
 use crate::structures::paging::{
     frame::PhysFrameRange, frame_alloc::FrameAllocator, page::PageRange,
     page_table::PageTableFlags, FrameDeallocator, Page, PageSize, PhysFrame, Size1GiB, Size2MiB,
@@ -736,6 +738,12 @@ pub enum UnmapError {
     InvalidFrameAddress(PhysAddr),
 }
 
+impl From<Infallible> for UnmapError {
+    fn from(i: Infallible) -> Self {
+        match i {}
+    }
+}
+
 /// An error indicating that an `update_flags` call failed.
 #[derive(Debug)]
 pub enum FlagUpdateError {
@@ -744,6 +752,12 @@ pub enum FlagUpdateError {
     /// An upper level page table entry has the `HUGE_PAGE` flag set, which means that the
     /// given page is part of a huge page and can't be freed individually.
     ParentEntryHugePage,
+}
+
+impl From<Infallible> for FlagUpdateError {
+    fn from(i: Infallible) -> Self {
+        match i {}
+    }
 }
 
 /// An error indicating that an `translate` call failed.

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -655,6 +655,15 @@ impl<S: PageSize> MapperFlushRange<S> {
         MapperFlushRange(pages)
     }
 
+    /// Create a new empty flush promise
+    #[inline]
+    fn empty() -> Self {
+        MapperFlushRange::new(PageRange {
+            start: Page::containing_address(VirtAddr::zero()),
+            end: Page::containing_address(VirtAddr::zero()),
+        })
+    }
+
     /// Flush the page from the TLB to ensure that the newest mapping is used.
     #[cfg(feature = "instructions")]
     #[inline]

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -425,6 +425,34 @@ pub trait Mapper<S: PageSize> {
             })
     }
 
+    /// Maps frames from the allocator to the given range of virtual pages.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`Mapper::map_range_with_table_flags`] internally, so
+    /// all safety requirements of it also apply for this function.
+    ///
+    /// ## Errors
+    ///
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the frames that were successfully mapped.
+    #[inline]
+    unsafe fn map_range<A>(
+        &mut self,
+        pages: PageRange<S>,
+        flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlushRange<S>, (MapToError<S>, MapperFlushRange<S>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<S> + ?Sized,
+    {
+        let parent_table_flags = flags
+            & (PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE);
+        self.map_range_with_table_flags(pages, flags, parent_table_flags, frame_allocator)
+    }
+
     /// Removes a mapping from the page table and returns the frame that used to be mapped.
     ///
     /// Note that no page tables or pages are deallocated.

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -7,8 +7,9 @@ pub use self::offset_page_table::OffsetPageTable;
 pub use self::recursive_page_table::{InvalidPageTable, RecursivePageTable};
 
 use crate::structures::paging::{
-    frame_alloc::FrameAllocator, page_table::PageTableFlags, Page, PageSize, PhysFrame, Size1GiB,
-    Size2MiB, Size4KiB,
+    frame::PhysFrameRange, frame_alloc::FrameAllocator, page::PageRange,
+    page_table::PageTableFlags, FrameDeallocator, Page, PageSize, PhysFrame, Size1GiB, Size2MiB,
+    Size4KiB,
 };
 use crate::{PhysAddr, VirtAddr};
 
@@ -193,6 +194,52 @@ pub trait Mapper<S: PageSize> {
         self.map_to_with_table_flags(page, frame, flags, parent_table_flags, frame_allocator)
     }
 
+    /// Maps the given range of frames to the range of virtual pages.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`Mapper::map_to`] internally, so
+    /// all safety requirements of it also apply for this function.
+    ///
+    /// ## Panics
+    ///
+    /// This function panics if the amount of pages does not equal the amount of frames.
+    ///
+    /// ## Errors
+    ///
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the frames that were successfully mapped.
+    #[inline]
+    unsafe fn map_to_range<A>(
+        &mut self,
+        pages: PageRange<S>,
+        frames: PhysFrameRange<S>,
+        flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlushRange<S>, (MapToError<S>, MapperFlushRange<S>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+
+        pages
+            .zip(frames)
+            .try_for_each(|(page, frame)| {
+                self.map_to(page, frame, flags, frame_allocator)
+                    .map(|_| ())
+                    .map_err(|e| {
+                        (
+                            e,
+                            MapperFlushRange::new(PageRange {
+                                start: pages.start,
+                                end: page,
+                            }),
+                        )
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+    }
+
     /// Creates a new mapping in the page table.
     ///
     /// This function might need additional physical frames to create new page tables. These
@@ -275,10 +322,146 @@ pub trait Mapper<S: PageSize> {
         Self: Sized,
         A: FrameAllocator<Size4KiB> + ?Sized;
 
+    /// Maps the given range of frames to the range of virtual pages.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`Mapper::map_to_with_table_flags`] internally, so
+    /// all safety requirements of it also apply for this function.
+    ///
+    /// ## Panics
+    ///
+    /// This function panics if the amount of pages does not equal the amount of frames.
+    ///
+    /// ## Errors
+    ///
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the frames that were successfully mapped.
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<S>,
+        frames: PhysFrameRange<S>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlushRange<S>, (MapToError<S>, MapperFlushRange<S>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+
+        pages
+            .zip(frames)
+            .try_for_each(|(page, frame)| {
+                self.map_to_with_table_flags(
+                    page,
+                    frame,
+                    flags,
+                    parent_table_flags,
+                    frame_allocator,
+                )
+                .map(|_| ())
+                .map_err(|e| {
+                    (
+                        e,
+                        MapperFlushRange::new(PageRange {
+                            start: pages.start,
+                            end: page,
+                        }),
+                    )
+                })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+    }
+
+    /// Maps frames from the allocator to the given range of virtual pages.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`Mapper::map_to_with_table_flags`] internally, so
+    /// all safety requirements of it also apply for this function.
+    ///
+    /// ## Errors
+    ///
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the frames that were successfully mapped.
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        mut pages: PageRange<S>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlushRange<S>, (MapToError<S>, MapperFlushRange<S>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<S> + ?Sized,
+    {
+        pages
+            .try_for_each(|page| {
+                let frame = frame_allocator
+                    .allocate_frame()
+                    .ok_or((MapToError::FrameAllocationFailed, page))?;
+
+                self.map_to_with_table_flags(
+                    page,
+                    frame,
+                    flags,
+                    parent_table_flags,
+                    frame_allocator,
+                )
+                .map(|_| ())
+                .map_err(|e| (e, page))
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
     /// Removes a mapping from the page table and returns the frame that used to be mapped.
     ///
     /// Note that no page tables or pages are deallocated.
     fn unmap(&mut self, page: Page<S>) -> Result<(PhysFrame<S>, MapperFlush<S>), UnmapError>;
+
+    /// Removes a range of mapping from the page table and deallocate the frames that used to be mapped.
+    ///
+    /// Note that no page tables or pages are deallocated.
+    ///
+    /// ## Errors
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the pages that were successfully unmapped.
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<S>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<S>, (UnmapError, MapperFlushRange<S>)>
+    where
+        D: FrameDeallocator<S>,
+    {
+        pages
+            .clone()
+            .try_for_each(|page| {
+                let (frame, _) = self.unmap(page).map_err(|e| {
+                    (
+                        e,
+                        MapperFlushRange::new(PageRange {
+                            start: pages.start,
+                            end: page,
+                        }),
+                    )
+                })?;
+                unsafe {
+                    // SAFETY: the page has been unmapped so the frame is unused
+                    deallocator.deallocate_frame(frame);
+                }
+                Ok(())
+            })
+            .map(|_| MapperFlushRange::new(pages))
+    }
 
     /// Updates the flags of an existing mapping.
     ///
@@ -294,6 +477,39 @@ pub trait Mapper<S: PageSize> {
         page: Page<S>,
         flags: PageTableFlags,
     ) -> Result<MapperFlush<S>, FlagUpdateError>;
+
+    /// Updates the flags of a range of existing mappings.
+    ///
+    /// ## Safety
+    ///
+    /// This method is unsafe because changing the flags of a mapping
+    /// might result in undefined behavior. For example, setting the
+    /// `GLOBAL` and `WRITABLE` flags for a page might result in the corruption
+    /// of values stored in that page from processes running in other address
+    /// spaces.
+    ///
+    /// ## Errors
+    /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the pages that were successfully updated.
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<S>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<S>, (FlagUpdateError, MapperFlushRange<S>)> {
+        pages
+            .clone()
+            .try_for_each(|page| {
+                self.update_flags(page, flags).map(|_| ()).map_err(|e| {
+                    (
+                        e,
+                        MapperFlushRange::new(PageRange {
+                            start: pages.start,
+                            end: page,
+                        }),
+                    )
+                })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+    }
 
     /// Set the flags of an existing page level 4 table entry
     ///
@@ -368,6 +584,31 @@ pub trait Mapper<S: PageSize> {
         let page = Page::containing_address(VirtAddr::new(frame.start_address().as_u64()));
         self.map_to(page, frame, flags, frame_allocator)
     }
+
+    /// Maps the given range of frames to the range of virtual pages with the same address.
+    ///
+    /// ## Safety
+    ///
+    /// This is a convencience function that invokes [`Mapper::map_to_range`] internally, so
+    /// all safety requirements of it also apply for this function.
+    #[inline]
+    unsafe fn identity_map_range<A>(
+        &mut self,
+        frames: PhysFrameRange<S>,
+        flags: PageTableFlags,
+        frame_allocator: &mut A,
+    ) -> Result<MapperFlushRange<S>, (MapToError<S>, MapperFlushRange<S>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+        S: PageSize,
+        Self: Mapper<S>,
+    {
+        let start = Page::containing_address(VirtAddr::new(frames.start.start_address().as_u64()));
+        let end = Page::containing_address(VirtAddr::new(frames.end.start_address().as_u64()));
+        let pages = PageRange { start, end };
+        self.map_to_range(pages, frames, flags, frame_allocator)
+    }
 }
 
 /// This type represents a page whose mapping has changed in the page table.
@@ -396,6 +637,41 @@ impl<S: PageSize> MapperFlush<S> {
     /// Don't flush the TLB and silence the “must be used” warning.
     #[inline]
     pub fn ignore(self) {}
+}
+
+/// This type represents a range of pages whose mappings have changed in the page table.
+///
+/// The old mappings might be still cached in the translation lookaside buffer (TLB), so they need
+/// to be flushed from the TLB before they're accessed. This type is returned from a function that
+/// changed the mappings of a range of pages to ensure that the TLB flush is not forgotten.
+#[derive(Debug)]
+#[must_use = "Page Table changes must be flushed or ignored."]
+pub struct MapperFlushRange<S: PageSize>(PageRange<S>);
+
+impl<S: PageSize> MapperFlushRange<S> {
+    /// Create a new flush promise
+    #[inline]
+    fn new(pages: PageRange<S>) -> Self {
+        MapperFlushRange(pages)
+    }
+
+    /// Flush the page from the TLB to ensure that the newest mapping is used.
+    #[cfg(feature = "instructions")]
+    #[inline]
+    pub fn flush(self) {
+        for page in self.0 {
+            crate::instructions::tlb::flush(page.start_address())
+        }
+    }
+
+    /// Don't flush the TLB and silence the “must be used” warning.
+    #[inline]
+    pub fn ignore(self) {}
+
+    /// Get the range of changed pages.
+    pub fn pages(&self) -> PageRange<S> {
+        self.0
+    }
 }
 
 /// This type represents a change of a page table requiring a complete TLB flush

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -436,7 +436,11 @@ pub trait Mapper<S: PageSize> {
     ///
     /// ## Errors
     /// If an error occurs half-way through a [`MapperFlushRange<S>`] is returned that contains the pages that were successfully unmapped.
-    fn unmap_range<D>(
+    ///
+    /// ## Safety
+    /// The caller has to guarantee that it's safe to deallocate frames:
+    /// All unmapped frames must only be only in this page table.
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<S>,
         deallocator: &mut D,

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -75,11 +75,60 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        frames: PhysFrameRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner.map_to_range_with_table_flags(
+            pages,
+            frames,
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size1GiB> + ?Sized,
+    {
+        self.inner
+            .map_range_with_table_flags(pages, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size1GiB>,
     ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
         self.inner.unmap(page)
+    }
+
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size1GiB>, (UnmapError, MapperFlushRange<Size1GiB>)>
+    where
+        D: FrameDeallocator<Size1GiB>,
+    {
+        self.inner.unmap_range(pages, deallocator)
     }
 
     #[inline]
@@ -142,11 +191,60 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        frames: PhysFrameRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner.map_to_range_with_table_flags(
+            pages,
+            frames,
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size2MiB> + ?Sized,
+    {
+        self.inner
+            .map_range_with_table_flags(pages, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
     ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
         self.inner.unmap(page)
+    }
+
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size2MiB>, (UnmapError, MapperFlushRange<Size2MiB>)>
+    where
+        D: FrameDeallocator<Size2MiB>,
+    {
+        self.inner.unmap_range(pages, deallocator)
     }
 
     #[inline]
@@ -209,11 +307,60 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        frames: PhysFrameRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner.map_to_range_with_table_flags(
+            pages,
+            frames,
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.inner
+            .map_range_with_table_flags(pages, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
     ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
         self.inner.unmap(page)
+    }
+
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size4KiB>, (UnmapError, MapperFlushRange<Size4KiB>)>
+    where
+        D: FrameDeallocator<Size4KiB>,
+    {
+        self.inner.unmap_range(pages, deallocator)
     }
 
     #[inline]

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -120,7 +120,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size1GiB>,
         deallocator: &mut D,
@@ -236,7 +236,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size2MiB>,
         deallocator: &mut D,
@@ -352,7 +352,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size4KiB>,
         deallocator: &mut D,

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -1,6 +1,6 @@
 //! Access the page tables through a recursively mapped level 4 table.
 
-use core::fmt;
+use core::{convert::Infallible, fmt};
 
 use super::*;
 use crate::registers::control::Cr3;
@@ -286,6 +286,442 @@ impl<'a> RecursivePageTable<'a> {
 
         Ok(MapperFlush::new(page))
     }
+
+    unsafe fn next_table_fn_create_next_table<'b, A, S>(
+        (insert_flags, allocator): &mut (PageTableFlags, &mut A),
+        entry: &'b mut PageTableEntry,
+        page: Page,
+    ) -> Result<&'b mut PageTable, MapToError<S>>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+        S: PageSize,
+    {
+        Self::create_next_table(entry, page, *insert_flags, *allocator)
+    }
+
+    unsafe fn next_table_fn_next_table_mut<'b, I>(
+        _: &mut I,
+        _: &'b mut PageTableEntry,
+        page: Page,
+    ) -> Result<&'b mut PageTable, Infallible> {
+        Ok(&mut *page.start_address().as_mut_ptr())
+    }
+
+    fn modify_range_1gib<ModifyFn, ModifyInfo, Err, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: for<'b> unsafe fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            Page,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+    ) -> Result<MapperFlushRange<Size1GiB>, (Err, MapperFlushRange<Size1GiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size1GiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let recursive_index = self.recursive_index;
+        let p4 = self.level_4_table();
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices_1gib(p4_index, PageTableIndex::new(0));
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices_1gib(p4_index, PageTableIndex::new(511));
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3_page = p3_page(p4_start, recursive_index);
+                let p3 = unsafe { next_table(&mut info, &mut p4[p4_index], p3_page) }
+                    .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index().into();
+                let mut end_p3_index = p4_end.p3_index().into();
+
+                if p4_end != pages.end {
+                    end_p3_index += 1;
+                }
+
+                (start_p3_index..end_p3_index)
+                    .map(PageTableIndex::new)
+                    .map(move |p3_index| Page::from_page_table_indices_1gib(p4_index, p3_index))
+                    .try_for_each(|page| {
+                        let entry = &mut p3[page.p3_index()];
+                        modify(entry, page, &mut info).map_err(|e| (e, page))
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_to_range_1gib<F, A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        F: Fn(Page<Size1GiB>, &mut A) -> Option<PhysFrame<Size1GiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_1gib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
+
+    fn modify_range_2mib<ModifyFn, ModifyInfo, Err, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: for<'b> unsafe fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            Page,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+    ) -> Result<MapperFlushRange<Size2MiB>, (Err, MapperFlushRange<Size2MiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size2MiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let recursive_index = self.recursive_index;
+        let p4 = self.level_4_table();
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices_2mib(
+                    p4_index,
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                );
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices_2mib(
+                    p4_index,
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                );
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3 = unsafe {
+                    next_table(
+                        &mut info,
+                        &mut p4[p4_index],
+                        p3_page(p4_start, recursive_index),
+                    )
+                }
+                .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index();
+                let end_p3_index = p4_end.p3_index();
+
+                (start_p3_index.into()..=end_p3_index.into())
+                    .map(PageTableIndex::new)
+                    .try_for_each(|p3_index| {
+                        let p3_start = Page::from_page_table_indices_2mib(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(0),
+                        );
+                        let p3_start = p3_start.max(p4_start);
+                        let p3_end = Page::from_page_table_indices_2mib(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(511),
+                        );
+                        let p3_end = p3_end.min(p4_end);
+
+                        if p3_start == p3_end {
+                            return Ok(());
+                        }
+
+                        let p2 = unsafe {
+                            next_table(
+                                &mut info,
+                                &mut p3[p3_index],
+                                p2_page(p3_start, recursive_index),
+                            )
+                        }
+                        .map_err(|e| (e.into(), p3_start))?;
+
+                        let start_p2_index = p3_start.p2_index().into();
+                        let mut end_p2_index = p3_end.p2_index().into();
+
+                        if p3_end != pages.end {
+                            end_p2_index += 1;
+                        }
+
+                        (start_p2_index..end_p2_index)
+                            .map(PageTableIndex::new)
+                            .map(move |p2_index| {
+                                Page::from_page_table_indices_2mib(p4_index, p3_index, p2_index)
+                            })
+                            .try_for_each(|page| {
+                                let entry = &mut p2[page.p2_index()];
+                                modify(entry, page, &mut info).map_err(|e| (e, page))
+                            })
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_range_2mib<F, A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        F: Fn(Page<Size2MiB>, &mut A) -> Option<PhysFrame<Size2MiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_2mib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
+
+    fn modify_range_4kib<ModifyFn, ModifyInfo, Err, NextTableFnErr>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        modify: ModifyFn,
+        mut info: ModifyInfo,
+        next_table: for<'b> unsafe fn(
+            &mut ModifyInfo,
+            &'b mut PageTableEntry,
+            Page,
+        ) -> Result<&'b mut PageTable, NextTableFnErr>,
+    ) -> Result<MapperFlushRange<Size4KiB>, (Err, MapperFlushRange<Size4KiB>)>
+    where
+        ModifyFn: Fn(&mut PageTableEntry, Page<Size4KiB>, &mut ModifyInfo) -> Result<(), Err>,
+        NextTableFnErr: Into<Err>,
+    {
+        if pages.is_empty() {
+            return Ok(MapperFlushRange::empty());
+        }
+
+        let recursive_index = self.recursive_index;
+        let p4 = self.level_4_table();
+
+        (pages.start.p4_index().into()..=pages.end.p4_index().into())
+            .map(PageTableIndex::new)
+            .try_for_each(|p4_index| {
+                let p4_start = Page::from_page_table_indices(
+                    p4_index,
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                    PageTableIndex::new(0),
+                );
+                let p4_start = p4_start.max(pages.start);
+                let p4_end = Page::from_page_table_indices(
+                    p4_index,
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                    PageTableIndex::new(511),
+                );
+                let p4_end = p4_end.min(pages.end);
+
+                if p4_start == p4_end {
+                    return Ok(());
+                }
+
+                let p3 = unsafe {
+                    next_table(
+                        &mut info,
+                        &mut p4[p4_index],
+                        p3_page(p4_start, recursive_index),
+                    )
+                }
+                .map_err(|e| (e.into(), p4_start))?;
+
+                let start_p3_index = p4_start.p3_index();
+                let end_p3_index = p4_end.p3_index();
+
+                (start_p3_index.into()..=end_p3_index.into())
+                    .map(PageTableIndex::new)
+                    .try_for_each(|p3_index| {
+                        let p3_start = Page::from_page_table_indices(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(0),
+                            PageTableIndex::new(0),
+                        );
+                        let p3_start = p3_start.max(p4_start);
+                        let p3_end = Page::from_page_table_indices(
+                            p4_index,
+                            p3_index,
+                            PageTableIndex::new(511),
+                            PageTableIndex::new(511),
+                        );
+                        let p3_end = p3_end.min(p4_end);
+
+                        if p3_start == p3_end {
+                            return Ok(());
+                        }
+
+                        let p2 = unsafe {
+                            next_table(
+                                &mut info,
+                                &mut p3[p3_index],
+                                p2_page(p3_start, recursive_index),
+                            )
+                        }
+                        .map_err(|e| (e.into(), p3_start))?;
+
+                        let start_p2_index = p3_start.p2_index();
+                        let end_p2_index = p3_end.p2_index();
+
+                        (start_p2_index.into()..=end_p2_index.into())
+                            .map(PageTableIndex::new)
+                            .try_for_each(|p2_index| {
+                                let p2_start = Page::from_page_table_indices(
+                                    p4_index,
+                                    p3_index,
+                                    p2_index,
+                                    PageTableIndex::new(0),
+                                );
+                                let p2_start = p2_start.max(p3_start);
+                                let p2_end = Page::from_page_table_indices(
+                                    p4_index,
+                                    p3_index,
+                                    p2_index,
+                                    PageTableIndex::new(511),
+                                );
+                                let p2_end = p2_end.min(p4_end);
+
+                                if p2_start == p2_end {
+                                    return Ok(());
+                                }
+
+                                let p1 = unsafe {
+                                    next_table(
+                                        &mut info,
+                                        &mut p2[p2_index],
+                                        p1_page(p2_start, recursive_index),
+                                    )
+                                }
+                                .map_err(|e| (e.into(), p2_start))?;
+
+                                let start_p1_index = p2_start.p1_index().into();
+                                let mut end_p1_index = p2_end.p1_index().into();
+
+                                if p2_end != pages.end {
+                                    end_p1_index += 1;
+                                }
+
+                                (start_p1_index..end_p1_index)
+                                    .map(PageTableIndex::new)
+                                    .map(move |p1_index| {
+                                        Page::from_page_table_indices(
+                                            p4_index, p3_index, p2_index, p1_index,
+                                        )
+                                    })
+                                    .try_for_each(|page| {
+                                        let entry = &mut p1[page.p1_index()];
+                                        modify(entry, page, &mut info).map_err(|e| (e, page))
+                                    })
+                            })
+                    })
+            })
+            .map(|_| MapperFlushRange::new(pages))
+            .map_err(|(e, page)| {
+                (
+                    e,
+                    MapperFlushRange::new(PageRange {
+                        start: pages.start,
+                        end: page,
+                    }),
+                )
+            })
+    }
+
+    #[inline]
+    fn map_to_range_4kib<F, A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        frames: F,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        F: Fn(Page<Size4KiB>, &mut A) -> Option<PhysFrame<Size4KiB>>,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.modify_range_4kib(
+            pages,
+            |entry, page, (_, allocator)| {
+                let frame = frames(page, allocator).ok_or(MapToError::FrameAllocationFailed)?;
+                if !entry.is_unused() {
+                    return Err(MapToError::PageAlreadyMapped(frame));
+                }
+                entry.set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+                Ok(())
+            },
+            (parent_table_flags, allocator),
+            Self::next_table_fn_create_next_table,
+        )
+    }
 }
 
 impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
@@ -302,6 +738,53 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
         self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
+    }
+
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        frames: PhysFrameRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_to_range_1gib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size1GiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size1GiB>, (MapToError<Size1GiB>, MapperFlushRange<Size1GiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size1GiB> + ?Sized,
+    {
+        self.map_to_range_1gib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
     }
 
     fn unmap(
@@ -334,6 +817,32 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size1GiB>, (UnmapError, MapperFlushRange<Size1GiB>)>
+    where
+        D: FrameDeallocator<Size1GiB>,
+    {
+        self.modify_range_1gib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = PhysFrame::from_start_address(entry.addr())
+                    .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(entry.addr()))?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
     #[allow(unused_unsafe)]
     unsafe fn update_flags(
@@ -356,6 +865,27 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         p3[page.p3_index()].set_flags(flags | Flags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size1GiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size1GiB>, (FlagUpdateError, MapperFlushRange<Size1GiB>)> {
+        self.modify_range_1gib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(
@@ -426,6 +956,53 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
     }
 
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        frames: PhysFrameRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_range_2mib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size2MiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size2MiB>, (MapToError<Size2MiB>, MapperFlushRange<Size2MiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + FrameAllocator<Size2MiB> + ?Sized,
+    {
+        self.map_range_2mib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
@@ -462,6 +1039,32 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size2MiB>, (UnmapError, MapperFlushRange<Size2MiB>)>
+    where
+        D: FrameDeallocator<Size2MiB>,
+    {
+        self.modify_range_2mib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = PhysFrame::from_start_address(entry.addr())
+                    .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(entry.addr()))?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
     #[allow(unused_unsafe)]
     unsafe fn update_flags(
@@ -491,6 +1094,27 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         p2[page.p2_index()].set_flags(flags | Flags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size2MiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size2MiB>, (FlagUpdateError, MapperFlushRange<Size2MiB>)> {
+        self.modify_range_2mib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(
@@ -583,6 +1207,52 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
     }
 
+    #[inline]
+    unsafe fn map_to_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        frames: PhysFrameRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        Self: Sized,
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        assert_eq!(pages.count(), frames.count());
+        self.map_to_range_4kib(
+            pages,
+            |page, _| {
+                let offset = pages.start - page;
+                Some(frames.start + (offset / Size4KiB::SIZE))
+            },
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
+    #[inline]
+    unsafe fn map_range_with_table_flags<A>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        flags: PageTableFlags,
+        parent_table_flags: PageTableFlags,
+        allocator: &mut A,
+    ) -> Result<MapperFlushRange<Size4KiB>, (MapToError<Size4KiB>, MapperFlushRange<Size4KiB>)>
+    where
+        A: FrameAllocator<Size4KiB> + ?Sized,
+    {
+        self.map_to_range_4kib(
+            pages,
+            |_, allocator| allocator.allocate_frame(),
+            flags,
+            parent_table_flags,
+            allocator,
+        )
+    }
+
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
@@ -620,6 +1290,34 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
+    #[inline]
+    fn unmap_range<D>(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        deallocator: &mut D,
+    ) -> Result<MapperFlushRange<Size4KiB>, (UnmapError, MapperFlushRange<Size4KiB>)>
+    where
+        D: FrameDeallocator<Size4KiB>,
+    {
+        self.modify_range_4kib(
+            pages,
+            |entry, _, deallocator| {
+                let frame = entry.frame().map_err(|err| match err {
+                    FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+                    FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
+                })?;
+                unsafe {
+                    deallocator.deallocate_frame(frame);
+                }
+
+                entry.set_unused();
+                Ok(())
+            },
+            deallocator,
+            Self::next_table_fn_next_table_mut,
+        )
+    }
+
     // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
     #[allow(unused_unsafe)]
     unsafe fn update_flags(
@@ -654,6 +1352,27 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         p1[page.p1_index()].set_flags(flags);
 
         Ok(MapperFlush::new(page))
+    }
+
+    #[inline]
+    unsafe fn update_flags_range(
+        &mut self,
+        pages: PageRange<Size4KiB>,
+        flags: PageTableFlags,
+    ) -> Result<MapperFlushRange<Size4KiB>, (FlagUpdateError, MapperFlushRange<Size4KiB>)> {
+        self.modify_range_4kib(
+            pages,
+            |entry, _, _| {
+                if entry.is_unused() {
+                    return Err(FlagUpdateError::PageNotMapped);
+                }
+
+                entry.set_flags(flags);
+                Ok(())
+            },
+            (),
+            Self::next_table_fn_next_table_mut,
+        )
     }
 
     unsafe fn set_flags_p4_entry(

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -818,7 +818,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size1GiB>,
         deallocator: &mut D,
@@ -1040,7 +1040,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size2MiB>,
         deallocator: &mut D,
@@ -1291,7 +1291,7 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
     }
 
     #[inline]
-    fn unmap_range<D>(
+    unsafe fn unmap_range<D>(
         &mut self,
         pages: PageRange<Size4KiB>,
         deallocator: &mut D,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -296,6 +296,15 @@ impl<S: PageSize> Iterator for PageRange<S> {
             None
         }
     }
+
+    #[inline]
+    fn count(self) -> usize {
+        if !self.is_empty() {
+            ((self.end.start_address() - self.start.start_address()) / S::SIZE) as usize
+        } else {
+            0
+        }
+    }
 }
 
 impl PageRange<Size2MiB> {


### PR DESCRIPTION
This pr adds various methods for modifying a range of pages:
- `Mapper::map_to_range`
- `Mapper::map_to_range_with_table_flags`
- `Mapper::map_range`
- `Mapper::map_range_with_table_flags`
- `Mapper::unmap_range`
- `Mapper::update_flags_range`
- `Mapper::identity_map_range`

All of those functions have a default implementation that just calls the non-ranged version for each page. `MappedPageTable`, `OffsetPageTable` and `RecursivePageTable` have specialized implementations that avoid looking up the P1-P3 tables multiple times which _should_ improve performance (I haven't run any benchmarks to verify this, the kernel I used to test the pr doesn't work with timers yet lol).

Closes #192

Sort of depends on #136: The default implementation for `Mapper::map_range_with_table_flags` should use `Mapper::map_with_table_flags` instead of `Mapper::map_to_with_table_flags` once #136 is merged.