### PR TITLE
chore: specify `sysv64` for the calling convention of the external assembly functions

### DIFF
--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -1,5 +1,5 @@
 #[link(name = "x86_64_asm", kind = "static")]
-extern "C" {
+extern "sysv64" {
     #[cfg_attr(
         any(target_env = "gnu", target_env = "musl"),
         link_name = "_x86_64_asm_interrupt_enable"


### PR DESCRIPTION
This ensures that the arguments to the external assembly functions are passed by RDI, RSI, RDX, RCX, etc.