### PR TITLE
gdt: Fix off-by-one error in from_raw_slice()

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -123,7 +123,7 @@ impl GlobalDescriptorTable {
             "initializing a GDT from a slice requires it to be **at most** 8 elements."
         );
         #[cfg(not(feature = "const_fn"))]
-        table[next_free]; // Will fail if slice.len() > 8
+        [(); 1][!(next_free <= 8) as usize];
 
         while idx != next_free {
             table[idx] = slice[idx];


### PR DESCRIPTION
We use our poor-man's assert instead of trying to do math.

Fixes error pointed out by @toku-sa-n and @phil-opp here: https://github.com/rust-osdev/x86_64/pull/255#discussion_r632872856

Uses technique from: https://github.com/rust-osdev/x86_64/pull/264#discussion_r649024894

Signed-off-by: Joe Richey <joerichey@google.com>