### PR TITLE
Make align_up and align_down const

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -534,8 +534,12 @@ impl Sub<PhysAddr> for PhysAddr {
 /// Returns the greatest x with alignment `align` so that x <= addr. The alignment must be
 ///  a power of 2.
 #[inline]
-pub fn align_down(addr: u64, align: u64) -> u64 {
+pub const fn align_down(addr: u64, align: u64) -> u64 {
+    #[cfg(feature = "const_fn")]
     assert!(align.is_power_of_two(), "`align` must be a power of two");
+    #[cfg(not(feature = "const_fn"))]
+    [(); 1][!align.is_power_of_two() as usize];
+
     addr & !(align - 1)
 }
 
@@ -544,8 +548,12 @@ pub fn align_down(addr: u64, align: u64) -> u64 {
 /// Returns the smallest x with alignment `align` so that x >= addr. The alignment must be
 /// a power of 2.
 #[inline]
-pub fn align_up(addr: u64, align: u64) -> u64 {
+pub const fn align_up(addr: u64, align: u64) -> u64 {
+    #[cfg(feature = "const_fn")]
     assert!(align.is_power_of_two(), "`align` must be a power of two");
+    #[cfg(not(feature = "const_fn"))]
+    [(); 1][!align.is_power_of_two() as usize];
+
     let align_mask = align - 1;
     if addr & align_mask == 0 {
         addr // already aligned

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -531,8 +531,10 @@ impl Sub<PhysAddr> for PhysAddr {
 
 /// Align address downwards.
 ///
-/// Returns the greatest x with alignment `align` so that x <= addr. The alignment must be
-///  a power of 2.
+/// Returns the greatest `x` with alignment `align` so that `x <= addr`.
+///
+/// Panics if the alignment is not a power of two. Without the `const_fn`
+/// feature, the panic message will be "index out of bounds".
 #[inline]
 pub const fn align_down(addr: u64, align: u64) -> u64 {
     const_assert!(align.is_power_of_two(), "`align` must be a power of two");
@@ -541,8 +543,10 @@ pub const fn align_down(addr: u64, align: u64) -> u64 {
 
 /// Align address upwards.
 ///
-/// Returns the smallest x with alignment `align` so that x >= addr. The alignment must be
-/// a power of 2.
+/// Returns the smallest `x` with alignment `align` so that `x >= addr`.
+///
+/// Panics if the alignment is not a power of two. Without the `const_fn`
+/// feature, the panic message will be "index out of bounds".
 #[inline]
 pub const fn align_up(addr: u64, align: u64) -> u64 {
     const_assert!(align.is_power_of_two(), "`align` must be a power of two");

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -535,11 +535,7 @@ impl Sub<PhysAddr> for PhysAddr {
 ///  a power of 2.
 #[inline]
 pub const fn align_down(addr: u64, align: u64) -> u64 {
-    #[cfg(feature = "const_fn")]
-    assert!(align.is_power_of_two(), "`align` must be a power of two");
-    #[cfg(not(feature = "const_fn"))]
-    [(); 1][!align.is_power_of_two() as usize];
-
+    const_assert!(align.is_power_of_two(), "`align` must be a power of two");
     addr & !(align - 1)
 }
 
@@ -549,11 +545,7 @@ pub const fn align_down(addr: u64, align: u64) -> u64 {
 /// a power of 2.
 #[inline]
 pub const fn align_up(addr: u64, align: u64) -> u64 {
-    #[cfg(feature = "const_fn")]
-    assert!(align.is_power_of_two(), "`align` must be a power of two");
-    #[cfg(not(feature = "const_fn"))]
-    [(); 1][!align.is_power_of_two() as usize];
-
+    const_assert!(align.is_power_of_two(), "`align` must be a power of two");
     let align_mask = align - 1;
     if addr & align_mask == 0 {
         addr // already aligned

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,19 @@ macro_rules! const_fn {
     };
 }
 
+// Helper method for assert! in const fn. Uses out of bounds indexing if an
+// assertion fails and the "const_fn" feature is not enabled.
+#[cfg(feature = "const_fn")]
+macro_rules! const_assert {
+    ($cond:expr, $($arg:tt)+) => { assert!($cond, $($arg)*) };
+}
+#[cfg(not(feature = "const_fn"))]
+macro_rules! const_assert {
+    ($cond:expr, $($arg:tt)+) => {
+        [(); 1][!($cond as bool) as usize]
+    };
+}
+
 #[cfg(all(feature = "instructions", feature = "external_asm"))]
 pub(crate) mod asm;
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -117,13 +117,10 @@ impl GlobalDescriptorTable {
         let mut table = [0; 8];
         let mut idx = 0;
 
-        #[cfg(feature = "const_fn")]
-        assert!(
+        const_assert!(
             next_free <= 8,
             "initializing a GDT from a slice requires it to be **at most** 8 elements."
         );
-        #[cfg(not(feature = "const_fn"))]
-        [(); 1][!(next_free <= 8) as usize];
 
         while idx != next_free {
             table[idx] = slice[idx];

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -141,7 +141,8 @@ impl GlobalDescriptorTable {
     const_fn! {
         /// Adds the given segment descriptor to the GDT, returning the segment selector.
         ///
-        /// Panics if the GDT has no free entries left.
+        /// Panics if the GDT has no free entries left.  Without the `const_fn`
+        /// feature, the panic message will be "index out of bounds".
         #[inline]
         pub fn add_entry(&mut self, entry: Descriptor) -> SegmentSelector {
             let index = match entry {


### PR DESCRIPTION
We can't make the `{VirtAddr, PhysAddr}::{align_up, align_down, is_aligned}` methods const as they have a `U: Into<u64>` constraint.

We should consider removing this constraint for the next breaking change.