### PR TITLE
feat(idt): make it available in the stable Rust

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -604,6 +604,8 @@ impl<T> PartialEq for Entry<T> {
 }
 
 /// A handler function for an interrupt or an exception without error code.
+///
+/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
 /// This type is not usable without the `abi_x86_interrupt` feature.
@@ -612,6 +614,8 @@ pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
 pub struct HandlerFunc(());
 
 /// A handler function for an exception that pushes an error code.
+///
+/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64);
 /// This type is not usable without the `abi_x86_interrupt` feature.
@@ -620,6 +624,8 @@ pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame,
 pub struct HandlerFuncWithErrCode(());
 
 /// A page fault handler function that pushes a page fault error code.
+///
+/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type PageFaultHandlerFunc =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: PageFaultErrorCode);
@@ -629,6 +635,8 @@ pub type PageFaultHandlerFunc =
 pub struct PageFaultHandlerFunc(());
 
 /// A handler function that must not return, e.g. for a machine check exception.
+///
+/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -> !;
 /// This type is not usable without the `abi_x86_interrupt` feature.
@@ -637,6 +645,8 @@ pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -
 pub struct DivergingHandlerFunc(());
 
 /// A handler function with an error code that must not return, e.g. for a double fault exception.
+///
+/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFuncWithErrCode =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64) -> !;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -8,6 +8,18 @@
 // except according to those terms.
 
 //! Provides types for the Interrupt Descriptor Table and its entries.
+//!
+//! # For the users who use this module with the stable Rust
+//!
+//! The following types are not used and not constructable.
+//!
+//! - [`DivergingHandlerFunc`]
+//! - [`DivergingHandlerFuncWithErrCode`]
+//! - [`HandlerFunc`]
+//! - [`HandlerFuncWithErrCode`]
+//! - [`PageFaultHandlerFunc`]
+//!
+//! These types are defined for the compatibility with the Nightly Rust.
 
 use crate::{PrivilegeLevel, VirtAddr};
 use bit_field::BitField;
@@ -595,18 +607,12 @@ impl<T> PartialEq for Entry<T> {
 /// A handler function for an interrupt or an exception without error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
-/// This type is a dummy.
-///
-/// This type alias is not used for builds which do not use the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 pub type HandlerFunc = ();
 
 /// A handler function for an exception that pushes an error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64);
-/// This type is a dummy.
-///
-/// This type alias is not used for builds which do not use the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 pub type HandlerFuncWithErrCode = ();
 
@@ -614,18 +620,12 @@ pub type HandlerFuncWithErrCode = ();
 #[cfg(feature = "abi_x86_interrupt")]
 pub type PageFaultHandlerFunc =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: PageFaultErrorCode);
-/// This type is a dummy.
-///
-/// This type alias is not used for builds which do not use the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 pub type PageFaultHandlerFunc = ();
 
 /// A handler function that must not return, e.g. for a machine check exception.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -> !;
-/// This type is a dummy.
-///
-/// This type alias is not used for builds which do not use the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 pub type DivergingHandlerFunc = ();
 
@@ -633,9 +633,6 @@ pub type DivergingHandlerFunc = ();
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFuncWithErrCode =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64) -> !;
-/// This type is a dummy.
-///
-/// This type alias is not used for builds which do not use the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 pub type DivergingHandlerFuncWithErrCode = ();
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -664,7 +664,8 @@ impl<F> Entry<F> {
     ///
     /// # Safety
     ///
-    /// The caller must ensure that `addr` is the correct address to the handler function.
+    /// The caller must ensure that `addr` is the address of a valid interrupt handler function,
+    /// and the signature of such a function is correct for the entry type.
     #[cfg(feature = "instructions")]
     #[inline]
     pub unsafe fn set_handler_addr(&mut self, addr: VirtAddr) -> &mut EntryOptions {

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -10,7 +10,6 @@
 //! Provides types for the Interrupt Descriptor Table and its entries.
 //!
 //! # For the users who use this module with the stable Rust
-//!
 //! The following types are not used and not constructable.
 //!
 //! - [`DivergingHandlerFunc`]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -606,6 +606,7 @@ impl<T> PartialEq for Entry<T> {
 /// A handler function for an interrupt or an exception without error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
+/// This type is not usable without the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 #[derive(Copy, Clone, Debug)]
 pub struct HandlerFunc(());
@@ -613,6 +614,7 @@ pub struct HandlerFunc(());
 /// A handler function for an exception that pushes an error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64);
+/// This type is not usable without the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 #[derive(Copy, Clone, Debug)]
 pub struct HandlerFuncWithErrCode(());
@@ -621,6 +623,7 @@ pub struct HandlerFuncWithErrCode(());
 #[cfg(feature = "abi_x86_interrupt")]
 pub type PageFaultHandlerFunc =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: PageFaultErrorCode);
+/// This type is not usable without the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 #[derive(Copy, Clone, Debug)]
 pub struct PageFaultHandlerFunc(());
@@ -628,6 +631,7 @@ pub struct PageFaultHandlerFunc(());
 /// A handler function that must not return, e.g. for a machine check exception.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -> !;
+/// This type is not usable without the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 #[derive(Copy, Clone, Debug)]
 pub struct DivergingHandlerFunc(());
@@ -636,6 +640,7 @@ pub struct DivergingHandlerFunc(());
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFuncWithErrCode =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64) -> !;
+/// This type is not usable without the `abi_x86_interrupt` feature.
 #[cfg(not(feature = "abi_x86_interrupt"))]
 #[derive(Copy, Clone, Debug)]
 pub struct DivergingHandlerFuncWithErrCode(());

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -608,33 +608,38 @@ impl<T> PartialEq for Entry<T> {
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame);
 #[cfg(not(feature = "abi_x86_interrupt"))]
-pub type HandlerFunc = ();
+#[derive(Copy, Clone, Debug)]
+pub struct HandlerFunc(());
 
 /// A handler function for an exception that pushes an error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type HandlerFuncWithErrCode = extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64);
 #[cfg(not(feature = "abi_x86_interrupt"))]
-pub type HandlerFuncWithErrCode = ();
+#[derive(Copy, Clone, Debug)]
+pub struct HandlerFuncWithErrCode(());
 
 /// A page fault handler function that pushes a page fault error code.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type PageFaultHandlerFunc =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: PageFaultErrorCode);
 #[cfg(not(feature = "abi_x86_interrupt"))]
-pub type PageFaultHandlerFunc = ();
+#[derive(Copy, Clone, Debug)]
+pub struct PageFaultHandlerFunc(());
 
 /// A handler function that must not return, e.g. for a machine check exception.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFunc = extern "x86-interrupt" fn(InterruptStackFrame) -> !;
 #[cfg(not(feature = "abi_x86_interrupt"))]
-pub type DivergingHandlerFunc = ();
+#[derive(Copy, Clone, Debug)]
+pub struct DivergingHandlerFunc(());
 
 /// A handler function with an error code that must not return, e.g. for a double fault exception.
 #[cfg(feature = "abi_x86_interrupt")]
 pub type DivergingHandlerFuncWithErrCode =
     extern "x86-interrupt" fn(InterruptStackFrame, error_code: u64) -> !;
 #[cfg(not(feature = "abi_x86_interrupt"))]
-pub type DivergingHandlerFuncWithErrCode = ();
+#[derive(Copy, Clone, Debug)]
+pub struct DivergingHandlerFuncWithErrCode(());
 
 impl<F> Entry<F> {
     /// Creates a non-present IDT entry (but sets the must-be-one bits).

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -19,7 +19,7 @@
 //! - [`HandlerFuncWithErrCode`]
 //! - [`PageFaultHandlerFunc`]
 //!
-//! These types are defined for the compatibility with the Nightly Rust.
+//! These types are defined for the compatibility with the Nightly Rust build.
 
 use crate::{PrivilegeLevel, VirtAddr};
 use bit_field::BitField;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -9,7 +9,7 @@
 
 //! Provides types for the Interrupt Descriptor Table and its entries.
 //!
-//! # For the users who use this module with the stable Rust
+//! # For the builds without the `abi_x86_interrupt` feature
 //! The following types are opaque and non-constructable instead of function pointers.
 //!
 //! - [`DivergingHandlerFunc`]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -10,7 +10,7 @@
 //! Provides types for the Interrupt Descriptor Table and its entries.
 //!
 //! # For the users who use this module with the stable Rust
-//! The following types are not used and not constructable.
+//! The following types are opaque and non-constructable instead of function pointers.
 //!
 //! - [`DivergingHandlerFunc`]
 //! - [`DivergingHandlerFuncWithErrCode`]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -703,6 +703,9 @@ macro_rules! impl_set_handler_fn {
             ///
             /// The function returns a mutable reference to the entry's options that allows
             /// further customization.
+            ///
+            /// This method is only usable with the `abi_x86_interrupt` feature enabled. Without it, the
+            /// unsafe [`Entry::set_handler_addr`] method has to be used instead.
             #[inline]
             pub fn set_handler_fn(&mut self, handler: $h) -> &mut EntryOptions {
                 let handler = VirtAddr::new(handler as u64);

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -4,8 +4,6 @@ use crate::VirtAddr;
 
 pub mod gdt;
 
-// idt needs `feature(abi_x86_interrupt)`, which is not available on stable rust
-#[cfg(feature = "abi_x86_interrupt")]
 pub mod idt;
 
 pub mod paging;


### PR DESCRIPTION
This PR makes the `idt` module available for use in the stable Rust with the `instructions` feature.

Especially, this PR
- exposes `Entry::set_handler_addr` as an unsafe method. This is the only way for the users of this crate who build it with the stable Rust to set the addresses of the interrupt or exception handlers.
- defines the handler function types as `()` if the `abi_x86_interrupt` feature is not enabled. These types are only used with the `abi_x86_interrupt` feature.