### PR TITLE
Add a SelectorErrorCode to segment_not_present in IDT

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -940,7 +940,7 @@ pub struct SelectorErrorCode {
 }
 
 impl SelectorErrorCode {
-    ///  When set, the exception originated externally to the processor
+    ///  If this flag is set, it indicates that the exception originated externally to the processor
     pub fn external(&self) -> bool {
         self.flags.get_bit(0)
     }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -963,6 +963,11 @@ impl SelectorErrorCode {
     pub fn index(&self) -> u64 {
         self.flags.get_bits(3..16)
     }
+
+    /// If true, the #SS or #GP has returned zero as opposed to a SelectorErrorCode.
+    pub fn is_null(&self) -> bool {
+        self.flags == 0
+    }
 }
 
 impl fmt::Debug for SelectorErrorCode {

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -940,6 +940,22 @@ pub struct SelectorErrorCode {
 }
 
 impl SelectorErrorCode {
+    /// Create a SelectorErrorCode. Returns None is any of the reserved bits (16-64) are set.
+    pub const fn new(value: u64) -> Option<Self> {
+        if value > u16::MAX as u64 {
+            None
+        } else {
+            Some(Self { flags: value })
+        }
+    }
+
+    /// Create a new SelectorErrorCode dropping any reserved bits (16-64).
+    pub const fn new_truncate(value: u64) -> Self {
+        Self {
+            flags: (value as u16) as u64,
+        }
+    }
+
     ///  If this flag is set, it indicates that the exception originated externally to the processor
     pub fn external(&self) -> bool {
         self.flags.get_bit(0)

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -933,6 +933,7 @@ bitflags! {
 
 // https://wiki.osdev.org/Exceptions#Selector_Error_Code
 /// Describes a segment selector error code.
+#[derive(Clone, Copy)]
 #[repr(transparent)]
 pub struct SelectorErrorCode {
     flags: u64,

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -972,9 +972,11 @@ impl fmt::Debug for SelectorErrorCode {
     }
 }
 
-/// The descriptor tables.
+/// The possible descriptor table values.
+///
+/// Used by the [`SelectorErrorCode`] to represent where the exception occurred.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DescriptorTable {
+pub enum DescriptorTable {
     /// Global Descriptor Table.
     Gdt,
     /// Interrupt Descriptor Table.

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -634,18 +634,6 @@ pub type PageFaultHandlerFunc =
 #[derive(Copy, Clone, Debug)]
 pub struct PageFaultHandlerFunc(());
 
-/// A segment not present handler function that pushes a selector error code.
-///
-/// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
-#[cfg(feature = "abi_x86_interrupt")]
-pub type SegmentNotPresentHandlerFunc =
-    extern "x86-interrupt" fn(InterruptStackFrame, error_code: SelectorErrorCode);
-
-/// This type is not usable without the `abi_x86_interrupt` feature.
-#[cfg(not(feature = "abi_x86_interrupt"))]
-#[derive(Copy, Clone, Debug)]
-pub struct SegmentNotPresentHandlerFunc(());
-
 /// A handler function that must not return, e.g. for a machine check exception.
 ///
 /// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
@@ -745,7 +733,6 @@ macro_rules! impl_set_handler_fn {
 impl_set_handler_fn!(HandlerFunc);
 impl_set_handler_fn!(HandlerFuncWithErrCode);
 impl_set_handler_fn!(PageFaultHandlerFunc);
-impl_set_handler_fn!(SegmentNotPresentHandlerFunc);
 impl_set_handler_fn!(DivergingHandlerFunc);
 impl_set_handler_fn!(DivergingHandlerFuncWithErrCode);
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -236,7 +236,7 @@ pub struct InterruptDescriptorTable {
     /// that loaded the segment selector resulting in the `#NP`.
     ///
     /// The vector number of the `#NP` exception is 11.
-    pub segment_not_present: Entry<SegmentNotPresentHandlerFunc>,
+    pub segment_not_present: Entry<HandlerFuncWithErrCode>,
 
     /// An stack segment exception (`#SS`) can occur in the following situations:
     ///
@@ -634,7 +634,7 @@ pub type PageFaultHandlerFunc =
 #[derive(Copy, Clone, Debug)]
 pub struct PageFaultHandlerFunc(());
 
-/// A Page fault handler function that pushes a selector error code.
+/// A segment not present handler function that pushes a selector error code.
 ///
 /// This type alias is only usable with the `abi_x86_interrupt` feature enabled.
 #[cfg(feature = "abi_x86_interrupt")]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -933,7 +933,7 @@ bitflags! {
 
 // https://wiki.osdev.org/Exceptions#Selector_Error_Code
 /// Describes a segment selector error code.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct SelectorErrorCode {
     flags: u64,
@@ -991,7 +991,7 @@ impl fmt::Debug for SelectorErrorCode {
 /// The possible descriptor table values.
 ///
 /// Used by the [`SelectorErrorCode`] to represent where the exception occurred.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DescriptorTable {
     /// Global Descriptor Table.
     Gdt,

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -940,12 +940,12 @@ pub struct SelectorErrorCode {
 
 impl SelectorErrorCode {
     ///  When set, the exception originated externally to the processor
-    fn external(&self) -> bool {
+    pub fn external(&self) -> bool {
         self.flags.get_bit(0)
     }
 
     /// The descriptor table where the exception occurred.
-    fn descriptor_table(&self) -> DescriptorTable {
+    pub fn descriptor_table(&self) -> DescriptorTable {
         match self.flags.get_bits(1..3) {
             0b00 => DescriptorTable::Gdt,
             0b01 => DescriptorTable::Idt,
@@ -956,7 +956,7 @@ impl SelectorErrorCode {
     }
 
     /// The index of the descriptor table.
-    fn index(&self) -> u64 {
+    pub fn index(&self) -> u64 {
         self.flags.get_bits(3..16)
     }
 }


### PR DESCRIPTION
As documented here: https://wiki.osdev.org/Exceptions#Selector_Error_Code
Similar to the `PageFaultHandlerFunc` this adds a `SegmentNotPresentHandlerFunc`

The struct does need to be a repr(transparent) u64 otherwise a LLVM error occurs