### PR TITLE
Rename XCr0 and CR4 flags

### DIFF
--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -143,6 +143,9 @@ bitflags! {
         ///
         /// Also enables access to the PKRU register (via the `RDPKRU`/`WRPKRU`
         /// instructions) to set user-mode protection key access controls.
+        const PROTECTION_KEY_USER = 1 << 22;
+        /// Alias for [`PROTECTION_KEY_USER`](Cr4Flags::PROTECTION_KEY_USER)
+        #[deprecated(since = "0.14.5", note = "use `PROTECTION_KEY_USER` instead")]
         const PROTECTION_KEY = 1 << 22;
         /// Enables Control-flow Enforcement Technology (CET)
         ///

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -19,10 +19,13 @@ bitflags! {
         /// Enables using MXCSR and the XMM registers
         /// with `XSAVE`/`XRSTOR`.
         ///
-        /// Must be set if [`YMM`](XCr0Flags::YMM) is set.
-        const SSE = 1<<1;
-        /// Enables AVX instructions and using the upper halves of the YMM registers
+        /// Must be set if [`AVX`](XCr0Flags::AVX) is set.
+        const SSE = 1 << 1;
+        /// Enables AVX instructions and using the upper halves of the AVX registers
         /// with `XSAVE`/`XRSTOR`.
+        const AVX = 1 << 2;
+        /// Alias for [`AVX`](XCr0Flags::AVX)
+        #[deprecated(since = "0.14.5", note = "use `AVX` instead")]
         const YMM = 1<<2;
         /// Enables MPX instructions and using the BND0-BND3 bound registers
         /// with `XSAVE`/`XRSTOR` (Intel Only).
@@ -95,10 +98,10 @@ mod x86_64 {
             let new_value = reserved | flags.bits();
 
             assert!(flags.contains(XCr0Flags::X87), "The X87 flag must be set");
-            if flags.contains(XCr0Flags::YMM) {
+            if flags.contains(XCr0Flags::AVX) {
                 assert!(
                     flags.contains(XCr0Flags::SSE),
-                    "AVX/YMM cannot be enabled without enabling SSE"
+                    "AVX cannot be enabled without enabling SSE"
                 );
             }
             let mpx = XCr0Flags::BNDREG | XCr0Flags::BNDCSR;
@@ -111,8 +114,8 @@ mod x86_64 {
             let avx512 = XCr0Flags::OPMASK | XCr0Flags::ZMM_HI256 | XCr0Flags::HI16_ZMM;
             if flags.intersects(avx512) {
                 assert!(
-                    flags.contains(XCr0Flags::YMM),
-                    "AVX-512 cannot be enabled without enabling AVX/YMM"
+                    flags.contains(XCr0Flags::AVX),
+                    "AVX-512 cannot be enabled without enabling AVX"
                 );
                 assert!(
                     flags.contains(avx512),


### PR DESCRIPTION
Breaking changes from #272, part of #262 

NOTE: this was changed to only deprecate the new constant names, so it is no longer a breaking change.

@ethindp does this include all the breaking changes from your previous PR?