### PR TITLE
add set_general_handler macro

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1378,7 +1378,7 @@ mod test {
         }
         set_general_handler!(&mut idt, general_handler, 32..64);
         for i in 1..256 {
-            if i == 0 || i == 14 || (i >= 32 && i < 64) {
+            if i == 0 || i == 14 || (32..64).contains(&i) {
                 assert!(entry_present(&idt, i), "{}", i);
             } else {
                 assert!(!entry_present(&idt, i));
@@ -1386,7 +1386,7 @@ mod test {
         }
         set_general_handler!(&mut idt, general_handler);
         for i in 0..256 {
-            if i == 15 || i == 31 || (i >= 21 && i <= 28) {
+            if i == 15 || i == 31 || (21..=28).contains(&i) {
                 // reserved entries should not be set
                 assert!(!entry_present(&idt, i));
             } else {

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1321,12 +1321,13 @@ mod test {
             15 => &idt.reserved_1.options,
             17 => &idt.alignment_check.options,
             18 => &idt.machine_check.options,
-            i @ 21..=29 => &idt.reserved_2[i - 21].options,
+            i @ 21..=28 => &idt.reserved_2[i - 21].options,
+            29 => &idt.vmm_communication_exception.options,
             30 => &idt.security_exception.options,
             31 => &idt.reserved_3.options,
             other => &idt[other].options,
         };
-        options.bits.get_bit(15)
+        options.0.get_bit(15)
     }
 
     #[test]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1276,6 +1276,15 @@ macro_rules! set_general_handler_entry {
         }
         $idt.machine_check.set_handler_fn(handler);
     }};
+    ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 0, 1) => {
+        extern "x86-interrupt" fn handler(
+            frame: $crate::structures::idt::InterruptStackFrame,
+            error_code: u64,
+        ) {
+            $handler(frame, $idx.into(), Some(error_code));
+        }
+        $idt.vmm_communication_exception.set_handler_fn(handler);
+    };
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 1, 0) => {{
         extern "x86-interrupt" fn handler(
             frame: $crate::structures::idt::InterruptStackFrame,
@@ -1286,8 +1295,9 @@ macro_rules! set_general_handler_entry {
         $idt.security_exception.set_handler_fn(handler);
     }};
 
-    // reserved
+    // reserved_1
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 0, 1, 1, 1, 1) => {};
+    // reserved_2
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 0, 1, 0, 1) => {};
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 0, 1, 1, 0) => {};
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 0, 1, 1, 1) => {};
@@ -1296,8 +1306,7 @@ macro_rules! set_general_handler_entry {
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 0, 1, 0) => {};
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 0, 1, 1) => {};
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 0, 0) => {};
-    ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 0, 1) => {};
-    ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 1, 0) => {};
+    // reserved_3
     ($idt:expr, $handler:ident, $idx:ident, 0, 0, 0, 1, 1, 1, 1, 1) => {};
 
     // set entries with `HandlerFunc` signature
@@ -1377,7 +1386,7 @@ mod test {
         }
         set_general_handler!(&mut idt, general_handler);
         for i in 0..256 {
-            if i == 15 || i == 31 || (i >= 21 && i <= 29) {
+            if i == 15 || i == 31 || (i >= 21 && i <= 28) {
                 // reserved entries should not be set
                 assert!(!entry_present(&idt, i));
             } else {

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1123,6 +1123,7 @@ pub enum ExceptionVector {
     Security = 0x1E,
 }
 
+#[cfg(all(feature = "instructions", feature = "abi_x86_interrupt"))]
 #[macro_export]
 /// Set a general handler in an [`InterruptDescriptorTable`].
 /// ```
@@ -1175,6 +1176,7 @@ macro_rules! set_general_handler {
     }};
 }
 
+#[cfg(all(feature = "instructions", feature = "abi_x86_interrupt"))]
 #[macro_export]
 #[doc(hidden)]
 /// We can't loop in macros, but we can use recursion.
@@ -1196,6 +1198,7 @@ macro_rules! set_general_handler_recursive_bits {
     };
 }
 
+#[cfg(all(feature = "instructions", feature = "abi_x86_interrupt"))]
 #[macro_export]
 #[doc(hidden)]
 macro_rules! set_general_handler_entry {
@@ -1337,6 +1340,7 @@ mod test {
         assert_eq!(size_of::<InterruptDescriptorTable>(), 256 * 16);
     }
 
+    #[cfg(all(feature = "instructions", feature = "abi_x86_interrupt"))]
     #[test]
     fn default_handlers() {
         fn general_handler(

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1166,7 +1166,7 @@ macro_rules! set_general_handler {
         {
             fn set_general_handler(
                 idt: &mut $crate::structures::idt::InterruptDescriptorTable,
-                range: impl ::core::ops::RangeBounds<usize>,
+                range: impl ::core::ops::RangeBounds<u8>,
             ) {
                 $crate::set_general_handler_recursive_bits!(idt, GENERAL_HANDLER, range);
             }
@@ -1183,10 +1183,9 @@ macro_rules! set_general_handler_recursive_bits {
     // if we have 8 all bits, construct the index from the bits, check if the entry is in range and invoke the macro that sets the handler
     ($idt:expr, $handler:ident, $range:expr, $bit7:tt, $bit6:tt, $bit5:tt, $bit4:tt, $bit3:tt, $bit2:tt, $bit1:tt, $bit0:tt) => {{
         const IDX: u8 = $bit0 | ($bit1 << 1) | ($bit2 << 2) | ($bit3 << 3) | ($bit4 << 4) | ($bit5 << 5) | ($bit6 << 6) | ($bit7 << 7);
-        let idx = IDX as usize;
 
         #[allow(unreachable_code)]
-        if $range.contains(&idx) {
+        if $range.contains(&IDX) {
             $crate::set_general_handler_entry!($idt, $handler, IDX, $bit7, $bit6, $bit5, $bit4, $bit3, $bit2, $bit1, $bit0);
         }
     }};

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1350,6 +1350,9 @@ mod test {
     }
 
     #[cfg(all(feature = "instructions", feature = "abi_x86_interrupt"))]
+    // there seems to be a bug in LLVM that causes rustc to crash on windows when compiling this test:
+    // https://github.com/rust-osdev/x86_64/pull/285#issuecomment-962642984
+    #[cfg(not(windows))]
     #[test]
     fn default_handlers() {
         fn general_handler(

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1141,12 +1141,21 @@ pub enum ExceptionVector {
 /// }
 ///
 /// // set only one entry
+/// # // there seems to be a bug in LLVM that causes rustc to crash on windows when compiling this test:
+/// # // https://github.com/rust-osdev/x86_64/pull/285#issuecomment-962642984
+/// # #[cfg(not(windows))]
 /// set_general_handler!(&mut idt, my_general_handler, 14);
 ///
 /// // set a range of entries
+/// # // there seems to be a bug in LLVM that causes rustc to crash on windows when compiling this test:
+/// # // https://github.com/rust-osdev/x86_64/pull/285#issuecomment-962642984
+/// # #[cfg(not(windows))]
 /// set_general_handler!(&mut idt, my_general_handler, 32..64);
 ///
 /// // set all entries
+/// # // there seems to be a bug in LLVM that causes rustc to crash on windows when compiling this test:
+/// # // https://github.com/rust-osdev/x86_64/pull/285#issuecomment-962642984
+/// # #[cfg(not(windows))]
 /// set_general_handler!(&mut idt, my_general_handler);
 /// ```
 macro_rules! set_general_handler {


### PR DESCRIPTION
This pr adds the `set_general_handler!` macro to set a general handler in an idt using only macro_rules. It's an alternative to #168 and all of the tests are taken from it.

As already mentioned in https://github.com/rust-osdev/x86_64/issues/167#issuecomment-654946675 there are no loops in macro_rules macros, so I used recursion instead:
https://github.com/Freax13/x86_64/blob/8252697d6ef5b567ff6a8110656f9a50e00df051/src/structures/idt.rs#L936-L956

I believe this to be a relatively short and concise solution. The only major drawback with this approach is that we can't do the range checks a compile time, so the macro always has to expand to setting all 256 interrupts even if some of those will be skipped at runtime. The upside of this approach is that the range doesn't necessarily need to be known at compile time (`set_general_handler!` takes `$range` as an expression). 

Closes #167 