### PR TITLE
Add registers::debug

### DIFF
--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -7,8 +7,6 @@ use core::arch::asm;
 use core::convert::TryFrom;
 use core::ops::Range;
 
-use crate::VirtAddr;
-
 use bit_field::BitField;
 use bitflags::bitflags;
 
@@ -17,10 +15,10 @@ use bitflags::bitflags;
 /// Holds the address of a hardware breakpoint.
 pub trait DebugAddressRegister {
     /// Reads the current breakpoint address.
-    fn read() -> VirtAddr;
+    fn read() -> u64;
 
     /// Writes the provided breakpoint address.
-    fn write(addr: VirtAddr);
+    fn write(addr: u64);
 }
 
 macro_rules! debug_address_register {
@@ -34,18 +32,18 @@ macro_rules! debug_address_register {
         #[cfg(feature = "instructions")]
         impl DebugAddressRegister for $Dr {
             #[inline]
-            fn read() -> VirtAddr {
+            fn read() -> u64 {
                 let addr;
                 unsafe {
                     asm!(concat!("mov {}, ", $name), out(reg) addr, options(nomem, nostack, preserves_flags));
                 }
-                VirtAddr::new(addr)
+                addr
             }
 
             #[inline]
-            fn write(addr: VirtAddr) {
+            fn write(addr: u64) {
                 unsafe {
-                    asm!(concat!("mov ", $name, ", {}"), in(reg) addr.as_u64(), options(nomem, nostack, preserves_flags));
+                    asm!(concat!("mov ", $name, ", {}"), in(reg) addr, options(nomem, nostack, preserves_flags));
                 }
             }
         }

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -235,7 +235,7 @@ impl Dr7Flags {
 /// The condition for a hardware breakpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum HwBreakpointCondition {
+pub enum BreakpointCondition {
     /// Instruction execution
     InstructionExecution = 0b00,
 
@@ -249,7 +249,7 @@ pub enum HwBreakpointCondition {
     DataReadsWrites = 0b11,
 }
 
-impl HwBreakpointCondition {
+impl BreakpointCondition {
     /// Creates a new hardware breakpoint condition if `bits` is valid.
     pub const fn from_bits(bits: u64) -> Option<Self> {
         match bits {
@@ -270,7 +270,7 @@ impl HwBreakpointCondition {
 /// The size of a hardware breakpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
-pub enum HwBreakpointSize {
+pub enum BreakpointSize {
     /// 1 byte length
     Length1B = 0b00,
 
@@ -284,7 +284,7 @@ pub enum HwBreakpointSize {
     Length4B = 0b11,
 }
 
-impl HwBreakpointSize {
+impl BreakpointSize {
     /// Creates a new hardware breakpoint size if `size` is valid.
     pub const fn new(size: usize) -> Option<Self> {
         match size {
@@ -404,31 +404,27 @@ impl Dr7Value {
     }
 
     /// Returns the condition field of a debug address register.
-    pub fn condition(&self, n: DebugAddressRegisterNumber) -> HwBreakpointCondition {
-        let condition = self.bits.get_bits(HwBreakpointCondition::bit_range(n));
-        HwBreakpointCondition::from_bits(condition).expect("condition should be always valid")
+    pub fn condition(&self, n: DebugAddressRegisterNumber) -> BreakpointCondition {
+        let condition = self.bits.get_bits(BreakpointCondition::bit_range(n));
+        BreakpointCondition::from_bits(condition).expect("condition should be always valid")
     }
 
     /// Sets the condition field of a debug address register.
-    pub fn set_condition(
-        &mut self,
-        n: DebugAddressRegisterNumber,
-        condition: HwBreakpointCondition,
-    ) {
+    pub fn set_condition(&mut self, n: DebugAddressRegisterNumber, condition: BreakpointCondition) {
         self.bits
-            .set_bits(HwBreakpointCondition::bit_range(n), condition as u64);
+            .set_bits(BreakpointCondition::bit_range(n), condition as u64);
     }
 
     /// Returns the size field of a debug address register.
-    pub fn size(&self, n: DebugAddressRegisterNumber) -> HwBreakpointSize {
-        let size = self.bits.get_bits(HwBreakpointSize::bit_range(n));
-        HwBreakpointSize::from_bits(size).expect("condition should be always valid")
+    pub fn size(&self, n: DebugAddressRegisterNumber) -> BreakpointSize {
+        let size = self.bits.get_bits(BreakpointSize::bit_range(n));
+        BreakpointSize::from_bits(size).expect("condition should be always valid")
     }
 
     /// Sets the size field of a debug address register.
-    pub fn set_size(&mut self, n: DebugAddressRegisterNumber, size: HwBreakpointSize) {
+    pub fn set_size(&mut self, n: DebugAddressRegisterNumber, size: BreakpointSize) {
         self.bits
-            .set_bits(HwBreakpointSize::bit_range(n), size as u64);
+            .set_bits(BreakpointSize::bit_range(n), size as u64);
     }
 }
 

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -433,7 +433,6 @@ pub struct Dr7;
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;
-    use core::arch::asm;
 
     impl Dr6 {
         /// Read the current set of DR6 flags.

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -11,10 +11,15 @@ use bitflags::bitflags;
 ///
 /// Holds the address of a hardware breakpoint.
 pub trait DebugAddressRegister {
+    /// The corresponding [`DebugAddressRegisterNumber`].
+    const NUM: DebugAddressRegisterNumber;
+
     /// Reads the current breakpoint address.
+    #[cfg(feature = "instructions")]
     fn read() -> u64;
 
     /// Writes the provided breakpoint address.
+    #[cfg(feature = "instructions")]
     fn write(addr: u64);
 }
 
@@ -26,8 +31,10 @@ macro_rules! debug_address_register {
         #[derive(Debug)]
         pub struct $Dr;
 
-        #[cfg(feature = "instructions")]
         impl DebugAddressRegister for $Dr {
+            const NUM: DebugAddressRegisterNumber = DebugAddressRegisterNumber::$Dr;
+
+            #[cfg(feature = "instructions")]
             #[inline]
             fn read() -> u64 {
                 let addr;
@@ -37,6 +44,7 @@ macro_rules! debug_address_register {
                 addr
             }
 
+            #[cfg(feature = "instructions")]
             #[inline]
             fn write(addr: u64) {
                 unsafe {

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -37,7 +37,7 @@ macro_rules! debug_address_register {
             fn read() -> VirtAddr {
                 let addr;
                 unsafe {
-                    asm!(concat!("mov {}, ", $name), out(reg) addr, options(nostack, preserves_flags));
+                    asm!(concat!("mov {}, ", $name), out(reg) addr, options(nomem, nostack, preserves_flags));
                 }
                 VirtAddr::new(addr)
             }
@@ -45,7 +45,7 @@ macro_rules! debug_address_register {
             #[inline]
             fn write(addr: VirtAddr) {
                 unsafe {
-                    asm!(concat!("mov ", $name, ", {}"), in(reg) addr.as_u64(), options(nostack, preserves_flags));
+                    asm!(concat!("mov ", $name, ", {}"), in(reg) addr.as_u64(), options(nomem, nostack, preserves_flags));
                 }
             }
         }
@@ -472,7 +472,7 @@ mod x86_64 {
             let value;
 
             unsafe {
-                asm!("mov {}, dr6", out(reg) value, options(nostack, preserves_flags));
+                asm!("mov {}, dr6", out(reg) value, options(nomem, nostack, preserves_flags));
             }
 
             value
@@ -492,7 +492,7 @@ mod x86_64 {
             let value;
 
             unsafe {
-                asm!("mov {}, dr7", out(reg) value, options(nostack, preserves_flags));
+                asm!("mov {}, dr7", out(reg) value, options(nomem, nostack, preserves_flags));
             }
 
             value
@@ -514,7 +514,7 @@ mod x86_64 {
         #[inline]
         pub fn write_raw(value: u64) {
             unsafe {
-                asm!("mov dr7, {}", in(reg) value, options(nostack, preserves_flags));
+                asm!("mov dr7, {}", in(reg) value, options(nomem, nostack, preserves_flags));
             }
         }
     }

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -53,7 +53,6 @@ debug_address_register!(Dr2, "dr2");
 debug_address_register!(Dr3, "dr3");
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[repr(transparent)]
 /// A valid debug address register number.
 ///
 /// Must be between 0 and 3 (inclusive).

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -1,7 +1,5 @@
 //! Functions to read and write debug registers.
 
-#![deny(unsafe_op_in_unsafe_fn)]
-
 #[cfg(feature = "instructions")]
 use core::arch::asm;
 use core::convert::TryFrom;

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -418,7 +418,7 @@ impl Dr7Value {
     }
 
     /// Returns the condition field of a debug address register.
-    pub fn get_condition(&self, n: DebugAddressRegisterNumber) -> HwBreakpointCondition {
+    pub fn condition(&self, n: DebugAddressRegisterNumber) -> HwBreakpointCondition {
         let condition = self.bits.get_bits(HwBreakpointCondition::bit_range(n));
         HwBreakpointCondition::from_bits(condition).expect("condition should be always valid")
     }
@@ -434,7 +434,7 @@ impl Dr7Value {
     }
 
     /// Returns the size field of a debug address register.
-    pub fn get_size(&self, n: DebugAddressRegisterNumber) -> HwBreakpointSize {
+    pub fn size(&self, n: DebugAddressRegisterNumber) -> HwBreakpointSize {
         let size = self.bits.get_bits(HwBreakpointSize::bit_range(n));
         HwBreakpointSize::from_bits(size).expect("condition should be always valid")
     }

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -2,7 +2,6 @@
 
 #[cfg(feature = "instructions")]
 use core::arch::asm;
-use core::convert::TryFrom;
 use core::ops::Range;
 
 use bit_field::BitField;
@@ -81,24 +80,6 @@ impl DebugAddressRegisterNumber {
     /// Returns the number as a primitive type.
     pub const fn get(self) -> u8 {
         self.0
-    }
-}
-
-/// The error type returned when a checked integral type conversion fails.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct TryFromIntError(());
-
-impl From<core::num::TryFromIntError> for TryFromIntError {
-    fn from(_: core::num::TryFromIntError) -> Self {
-        Self(())
-    }
-}
-
-impl TryFrom<u8> for DebugAddressRegisterNumber {
-    type Error = TryFromIntError;
-
-    fn try_from(n: u8) -> Result<Self, Self::Error> {
-        Self::new(n).ok_or(TryFromIntError(()))
     }
 }
 
@@ -314,14 +295,6 @@ impl HwBreakpointSize {
     const fn bit_range(n: DebugAddressRegisterNumber) -> Range<usize> {
         let lsb = (18 + 4 * n.0) as usize;
         lsb..lsb + 2
-    }
-}
-
-impl TryFrom<usize> for HwBreakpointSize {
-    type Error = TryFromIntError;
-
-    fn try_from(size: usize) -> Result<Self, Self::Error> {
-        Self::new(size).ok_or(TryFromIntError(()))
     }
 }
 

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -56,29 +56,40 @@ debug_address_register!(Dr3, "dr3");
 /// A valid debug address register number.
 ///
 /// Must be between 0 and 3 (inclusive).
-pub struct DebugAddressRegisterNumber(u8);
+pub enum DebugAddressRegisterNumber {
+    /// The debug address register number of [`Dr0`] (0).
+    Dr0,
+
+    /// The debug address register number of [`Dr1`] (1).
+    Dr1,
+
+    /// The debug address register number of [`Dr2`] (2).
+    Dr2,
+
+    /// The debug address register number of [`Dr3`] (3).
+    Dr3,
+}
 
 impl DebugAddressRegisterNumber {
-    /// Creates a debug address register number without checking the value.
-    ///
-    /// # Safety
-    ///
-    /// The value must be between 0 and 3 (inclusive).
-    pub const unsafe fn new_unchecked(n: u8) -> Self {
-        Self(n)
-    }
-
     /// Creates a debug address register number if it is valid.
     pub const fn new(n: u8) -> Option<Self> {
         match n {
-            0..=3 => Some(Self(n)),
+            0 => Some(Self::Dr0),
+            1 => Some(Self::Dr1),
+            2 => Some(Self::Dr2),
+            3 => Some(Self::Dr3),
             _ => None,
         }
     }
 
     /// Returns the number as a primitive type.
     pub const fn get(self) -> u8 {
-        self.0
+        match self {
+            Self::Dr0 => 0,
+            Self::Dr1 => 1,
+            Self::Dr2 => 2,
+            Self::Dr3 => 3,
+        }
     }
 }
 
@@ -132,12 +143,11 @@ bitflags! {
 impl Dr6Flags {
     /// Returns the trap flag of the provided debug address register.
     pub fn trap(n: DebugAddressRegisterNumber) -> Self {
-        match n.0 {
-            0 => Self::TRAP0,
-            1 => Self::TRAP1,
-            2 => Self::TRAP2,
-            3 => Self::TRAP3,
-            _ => unreachable!(),
+        match n {
+            DebugAddressRegisterNumber::Dr0 => Self::TRAP0,
+            DebugAddressRegisterNumber::Dr1 => Self::TRAP1,
+            DebugAddressRegisterNumber::Dr2 => Self::TRAP2,
+            DebugAddressRegisterNumber::Dr3 => Self::TRAP3,
         }
     }
 }
@@ -195,23 +205,21 @@ bitflags! {
 impl Dr7Flags {
     /// Returns the local breakpoint enable flag of the provided debug address register.
     pub fn local_breakpoint_enable(n: DebugAddressRegisterNumber) -> Self {
-        match n.0 {
-            0 => Self::LOCAL_BREAKPOINT_0_ENABLE,
-            1 => Self::LOCAL_BREAKPOINT_1_ENABLE,
-            2 => Self::LOCAL_BREAKPOINT_2_ENABLE,
-            3 => Self::LOCAL_BREAKPOINT_3_ENABLE,
-            _ => unreachable!(),
+        match n {
+            DebugAddressRegisterNumber::Dr0 => Self::LOCAL_BREAKPOINT_0_ENABLE,
+            DebugAddressRegisterNumber::Dr1 => Self::LOCAL_BREAKPOINT_1_ENABLE,
+            DebugAddressRegisterNumber::Dr2 => Self::LOCAL_BREAKPOINT_2_ENABLE,
+            DebugAddressRegisterNumber::Dr3 => Self::LOCAL_BREAKPOINT_3_ENABLE,
         }
     }
 
     /// Returns the global breakpoint enable flag of the provided debug address register.
     pub fn global_breakpoint_enable(n: DebugAddressRegisterNumber) -> Self {
-        match n.0 {
-            0 => Self::GLOBAL_BREAKPOINT_0_ENABLE,
-            1 => Self::GLOBAL_BREAKPOINT_1_ENABLE,
-            2 => Self::GLOBAL_BREAKPOINT_2_ENABLE,
-            3 => Self::GLOBAL_BREAKPOINT_3_ENABLE,
-            _ => unreachable!(),
+        match n {
+            DebugAddressRegisterNumber::Dr0 => Self::GLOBAL_BREAKPOINT_0_ENABLE,
+            DebugAddressRegisterNumber::Dr1 => Self::GLOBAL_BREAKPOINT_1_ENABLE,
+            DebugAddressRegisterNumber::Dr2 => Self::GLOBAL_BREAKPOINT_2_ENABLE,
+            DebugAddressRegisterNumber::Dr3 => Self::GLOBAL_BREAKPOINT_3_ENABLE,
         }
     }
 }
@@ -246,7 +254,7 @@ impl HwBreakpointCondition {
     }
 
     const fn bit_range(n: DebugAddressRegisterNumber) -> Range<usize> {
-        let lsb = (16 + 4 * n.0) as usize;
+        let lsb = (16 + 4 * n.get()) as usize;
         lsb..lsb + 2
     }
 }
@@ -292,7 +300,7 @@ impl HwBreakpointSize {
     }
 
     const fn bit_range(n: DebugAddressRegisterNumber) -> Range<usize> {
-        let lsb = (18 + 4 * n.0) as usize;
+        let lsb = (18 + 4 * n.get()) as usize;
         lsb..lsb + 2
     }
 }

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -1,6 +1,7 @@
 //! Access to various system and model specific registers.
 
 pub mod control;
+pub mod debug;
 pub mod model_specific;
 pub mod mxcsr;
 pub mod rflags;


### PR DESCRIPTION
Fixes https://github.com/rust-osdev/x86_64/issues/284.

This adds `registers::debug`.

* `Dr0`-`Dr3` implement `DebugAddressRegister`.
* `Dr6Flags` can be read from `Dr6`.

For `Dr7` I added `Dr7Value` which contain `Dr7Flags` but has functions to modify the bits corresponding to the condition and size fields. Via `Dr7Value::flags_mut`, you can modify flags in place.