### PR TITLE
Use `#[cfg(doc)]` instead of docs.rs-specific cfg flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
       with:
         command: build
 
+    - name: "Run cargo doc"
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+
     - name: "Run cargo build for stable without instructions"
       uses: actions-rs/cargo@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,13 @@ jobs:
       with:
         command: doc
 
+    - name: "Run cargo doc for stable"
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-default-features --features external_asm,instructions
+      if: runner.os != 'Windows'
+
     - name: "Run cargo build for stable without instructions"
       uses: actions-rs/cargo@v1
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,6 @@ inline_asm = []
 abi_x86_interrupt = []
 const_fn = []
 
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "docsrs"]
-
 [package.metadata.release]
 no-dev-version = true
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,10 +37,11 @@ cc = { version = "1.0.37", optional = true }
 default = [ "nightly", "instructions" ]
 instructions = []
 external_asm = [ "cc" ]
-nightly = [ "inline_asm", "const_fn", "abi_x86_interrupt" ]
+nightly = [ "inline_asm", "const_fn", "abi_x86_interrupt", "doc_cfg" ]
 inline_asm = []
 abi_x86_interrupt = []
 const_fn = []
+doc_cfg = []
 
 [package.metadata.release]
 no-dev-version = true

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -153,7 +153,10 @@ pub fn int3() {
 /// immediate. This macro will be replaced by a generic function when support for
 /// const generics is implemented in Rust.
 #[cfg(feature = "inline_asm")]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "nightly", feature = "inline_asm"))))]
+#[cfg_attr(
+    feature = "doc_cfg",
+    doc(cfg(any(feature = "nightly", feature = "inline_asm")))
+)]
 #[macro_export]
 macro_rules! software_interrupt {
     ($x:expr) => {{

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -54,7 +54,10 @@ pub fn bochs_breakpoint() {
 /// Gets the current instruction pointer. Note that this is only approximate as it requires a few
 /// instructions to execute.
 #[cfg(feature = "inline_asm")]
-#[cfg_attr(docsrs, doc(cfg(any(feature = "nightly", feature = "inline_asm"))))]
+#[cfg_attr(
+    feature = "doc_cfg",
+    doc(cfg(any(feature = "nightly", feature = "inline_asm")))
+)]
 #[inline(always)]
 pub fn read_rip() -> crate::VirtAddr {
     let rip: u64;

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -1,6 +1,6 @@
 //! Provides functions to read and write segment registers.
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::{
     registers::control::Cr4Flags,
     structures::gdt::{Descriptor, GlobalDescriptorTable},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))] // PageSize marker trait
 #![cfg_attr(feature = "inline_asm", feature(asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
 

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -1,7 +1,7 @@
 //! Functions to read and write control registers.
 
 pub use super::model_specific::{Efer, EferFlags};
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::{registers::rflags::RFlags, structures::paging::PageTableFlags};
 
 use bitflags::bitflags;

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -1,6 +1,6 @@
 //! Functions to read and write model specific registers.
 
-#[cfg(docsrs)]
+#[cfg(doc)]
 use crate::{
     instructions::segmentation::{Segment64, FS, GS},
     registers::control::Cr4Flags,


### PR DESCRIPTION
The documentation can also be built locally using `cargo doc --open`. Doc links should be working there as well.