### PR TITLE
Add checked_add to VirtAddr and update frame_to_pointer

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -107,6 +107,20 @@ impl VirtAddr {
         self.0
     }
 
+    /// Preforms a checked add between two virtual addresses
+    ///
+    /// Panics if an integer overflow occurs
+    #[inline]
+    pub fn checked_add<U>(self, addr: U) -> VirtAddr
+    where
+        U: Into<u64>,
+    {
+        VirtAddr::new(
+            self.as_u64()
+                .checked_add(addr.into())
+                .expect("Integer overflow"),
+        )
+    }
     /// Creates a virtual address from the given pointer
     // cfg(target_pointer_width = "32") is only here for backwards
     // compatibility: Earlier versions of this crate did not have any `cfg()`

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -50,7 +50,7 @@ struct PhysOffset {
 
 unsafe impl PageTableFrameMapping for PhysOffset {
     fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
-        let virt = self.offset + frame.start_address().as_u64();
+        let virt = self.offset.checked_add(frame.start_address().as_u64());
         virt.as_mut_ptr()
     }
 }


### PR DESCRIPTION
This pr adds support for checked_adds between virtual addresses and uses it in the frame_to_pointer function for #290 .