### PR TITLE
Implement `core::iter::Step` trait for for `PhysFrame`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,15 @@ authors = [
 ]
 description = "Support for x86_64 specific instructions, registers, and structures."
 documentation = "https://docs.rs/x86_64"
-keywords = ["amd64", "x86", "x86_64", "no_std"]
-categories = ["no-std"]
+keywords = [
+    "amd64",
+    "x86",
+    "x86_64",
+    "no_std",
+]
+categories = [
+    "no-std",
+]
 license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
@@ -40,7 +47,7 @@ step_trait = []
 [package.metadata.release]
 no-dev-version = true
 pre-release-replacements = [
-    { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
+    { file="Changelog.md", search="# Unreleased", replace="# Unreleased\n\n# {{version}} – {{date}}", exactly=1 },
 ]
 pre-release-commit-message = "Bump version to {{version}}"
 disable-push = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,15 +9,8 @@ authors = [
 ]
 description = "Support for x86_64 specific instructions, registers, and structures."
 documentation = "https://docs.rs/x86_64"
-keywords = [
-    "amd64",
-    "x86",
-    "x86_64",
-    "no_std",
-]
-categories = [
-    "no-std",
-]
+keywords = ["amd64", "x86", "x86_64", "no_std"]
+categories = ["no-std"]
 license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
@@ -37,16 +30,17 @@ cc = { version = "1.0.37", optional = true }
 default = [ "nightly", "instructions" ]
 instructions = []
 external_asm = [ "cc" ]
-nightly = [ "inline_asm", "const_fn", "abi_x86_interrupt", "doc_cfg" ]
+nightly = [ "inline_asm", "const_fn", "abi_x86_interrupt", "doc_cfg", "step_trait" ]
 inline_asm = []
 abi_x86_interrupt = []
 const_fn = []
 doc_cfg = []
+step_trait = []
 
 [package.metadata.release]
 no-dev-version = true
 pre-release-replacements = [
-    { file="Changelog.md", search="# Unreleased", replace="# Unreleased\n\n# {{version}} – {{date}}", exactly=1 },
+    { file = "Changelog.md", search = "# Unreleased", replace = "# Unreleased\n\n# {{version}} – {{date}}", exactly = 1 },
 ]
 pre-release-commit-message = "Bump version to {{version}}"
 disable-push = true

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -529,6 +529,25 @@ impl Sub<PhysAddr> for PhysAddr {
     }
 }
 
+#[cfg(feature = "step_trait")]
+impl core::iter::Step for PhysAddr {
+    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+        if *start <= *end {
+            Some((*end - *start) as usize)
+        } else {
+            None
+        }
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        start.as_u64().checked_add(count as u64).map(PhysAddr::new)
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        start.as_u64().checked_sub(count as u64).map(PhysAddr::new)
+    }
+}
+
 /// Align address downwards.
 ///
 /// Returns the greatest `x` with alignment `align` so that `x <= addr`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 #![cfg_attr(feature = "inline_asm", feature(asm))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
-#![warn(missing_docs)]
+#![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![deny(missing_debug_implementations)]
 
 pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -135,37 +135,17 @@ impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
 #[cfg(feature = "step_trait")]
 impl<S: PageSize> core::iter::Step for PhysFrame<S> {
     fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        if *start <= *end {
-            Some((*end - *start) as usize)
-        } else {
-            None
-        }
+        PhysAddr::steps_between(&start.start_address, &end.start_address)
     }
 
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
-        use core::convert::TryFrom;
-
-        match u64::try_from(count) {
-            Ok(n) => start
-                .start_address()
-                .as_u64()
-                .checked_add(n * S::SIZE)
-                .and_then(|start_addr| Self::from_start_address(PhysAddr::new(start_addr)).ok()),
-            Err(_) => None, // if n is out of range, `unsigned_start + n`
-        }
+        PhysAddr::forward_checked(start.start_address, count)
+            .and_then(|start_addr| Self::from_start_address(start_addr).ok())
     }
 
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
-        use core::convert::TryFrom;
-
-        match u64::try_from(count) {
-            Ok(n) => start
-                .start_address()
-                .as_u64()
-                .checked_sub(n * S::SIZE)
-                .and_then(|start_addr| Self::from_start_address(PhysAddr::new(start_addr)).ok()),
-            Err(_) => None, // if n is out of range, `unsigned_start + n`
-        }
+        PhysAddr::backward_checked(start.start_address, count)
+            .and_then(|start_addr| Self::from_start_address(start_addr).ok())
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -146,10 +146,11 @@ impl<S: PageSize> core::iter::Step for PhysFrame<S> {
         use core::convert::TryFrom;
 
         match u64::try_from(count) {
-            Ok(n) => match start.start_address().as_u64().overflowing_add(n * S::SIZE) {
-                (_, true) => None,
-                (start_addr, false) => Self::from_start_address(PhysAddr::new(start_addr)).ok(),
-            },
+            Ok(n) => start
+                .start_address()
+                .as_u64()
+                .checked_add(n * S::SIZE)
+                .and_then(|start_addr| Self::from_start_address(PhysAddr::new(start_addr)).ok()),
             Err(_) => None, // if n is out of range, `unsigned_start + n`
         }
     }
@@ -158,10 +159,11 @@ impl<S: PageSize> core::iter::Step for PhysFrame<S> {
         use core::convert::TryFrom;
 
         match u64::try_from(count) {
-            Ok(n) => match start.start_address().as_u64().overflowing_sub(n * S::SIZE) {
-                (_, true) => None,
-                (start_addr, false) => Self::from_start_address(PhysAddr::new(start_addr)).ok(),
-            },
+            Ok(n) => start
+                .start_address()
+                .as_u64()
+                .checked_sub(n * S::SIZE)
+                .and_then(|start_addr| Self::from_start_address(PhysAddr::new(start_addr)).ok()),
             Err(_) => None, // if n is out of range, `unsigned_start + n`
         }
     }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -167,22 +167,6 @@ impl<S: PageSize> core::iter::Step for PhysFrame<S> {
             Err(_) => None, // if n is out of range, `unsigned_start + n`
         }
     }
-
-    fn forward(start: Self, count: usize) -> Self {
-        core::iter::Step::forward_checked(start, count).expect("overflow in `Step::forward`")
-    }
-
-    unsafe fn forward_unchecked(start: Self, count: usize) -> Self {
-        core::iter::Step::forward(start, count)
-    }
-
-    fn backward(start: Self, count: usize) -> Self {
-        core::iter::Step::backward_checked(start, count).expect("overflow in `Step::backward`")
-    }
-
-    unsafe fn backward_unchecked(start: Self, count: usize) -> Self {
-        core::iter::Step::backward(start, count)
-    }
 }
 
 /// An range of physical memory frames, exclusive the upper bound.


### PR DESCRIPTION
# General
This is an initial naive first pass at implementing `core::iter::Step` for `PhysFrame`. I initially had it align off the start address of a frame and look for overflows of the `u64` space from the start. But I can imagine it would be worth checking chat the end overflows as well and figured I'd post to get your feedback before deciding.

# Related Issues
#212 