### PR TITLE
docs: Update segment register references in GDT::load* method to non-deprecated methods

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -173,8 +173,8 @@ impl GlobalDescriptorTable {
     /// Loads the GDT in the CPU using the `lgdt` instruction. This does **not** alter any of the
     /// segment registers; you **must** (re)load them yourself using [the appropriate
     /// functions](crate::instructions::segmentation):
-    /// [load_ss](crate::instructions::segmentation::load_ss),
-    /// [set_cs](crate::instructions::segmentation::set_cs).
+    /// [SS::set_reg](crate::instructions::segmentation::SS::set_reg),
+    /// [CSS::set_reg](crate::instructions::segmentation::CSS::set_reg).
     #[cfg(feature = "instructions")]
     #[inline]
     pub fn load(&'static self) {
@@ -185,8 +185,8 @@ impl GlobalDescriptorTable {
     /// Loads the GDT in the CPU using the `lgdt` instruction. This does **not** alter any of the
     /// segment registers; you **must** (re)load them yourself using [the appropriate
     /// functions](crate::instructions::segmentation):
-    /// [load_ss](crate::instructions::segmentation::load_ss),
-    /// [set_cs](crate::instructions::segmentation::set_cs).
+    /// [SS::set_reg](crate::instructions::segmentation::SS::set_reg),
+    /// [CSS::set_reg](crate::instructions::segmentation::CSS::set_reg).
     ///
     /// # Safety
     ///


### PR DESCRIPTION
# General
This is a small change to the documentation of the `GDT::load` and `GDT::load_unsafe` methods to point the following deprecated methods at their new replacements:

- [load_ss](https://docs.rs/x86_64/0.14.4/x86_64/instructions/segmentation/fn.load_ss.html#) -> [SS::set_reg](https://docs.rs/x86_64/0.14.4/x86_64/instructions/segmentation/struct.SS.html#method.set_reg)
- [set_cs](https://docs.rs/x86_64/0.14.4/x86_64/instructions/segmentation/fn.set_cs.html) -> [CS::set_reg](https://docs.rs/x86_64/0.14.4/x86_64/instructions/segmentation/struct.CS.html#method.set_reg)