### PR TITLE
Release version 0.14.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2018"
 
 [dependencies]

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,12 +2,15 @@
 
 # 0.14.5 – 2021-09-04
 
+- Add `ExceptionVector` enum and additional flags to `PageFaultErrorCode` ([#303](https://github.com/rust-osdev/x86_64/pull/303))
+- Add `clean_up` and `clean_up_with_filter` methods to deallocate unused page tables ([#264](https://github.com/rust-osdev/x86_64/pull/264))
 - Rename some XCr0 and CR4 flags (#[275](https://github.com/rust-osdev/x86_64/pull/275))
 - Expose `MapperFlush::new` and `MapperFlushAll::new` constructor functions ([#296](https://github.com/rust-osdev/x86_64/pull/296))
 - Use `#[cfg(doc)]` instead of docs.rs-specific cfg flag (#[287](https://github.com/rust-osdev/x86_64/pull/287))
 - Some documentation updates:
   - Update segment register references in `GDT::load*` method to non-deprecated methods ([#301](https://github.com/rust-osdev/x86_64/pull/301))
   - Remove a panic note ([#300](https://github.com/rust-osdev/x86_64/pull/300))
+- Update `bit_field` dependency ([#306](https://github.com/rust-osdev/x86_64/pull/306))
 
 # 0.14.4 – 2021-07-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.14.5 – 2021-09-04
+
 - Rename some XCr0 and CR4 flags (#[275](https://github.com/rust-osdev/x86_64/pull/275))
 - Expose `MapperFlush::new` and `MapperFlushAll::new` constructor functions ([#296](https://github.com/rust-osdev/x86_64/pull/296))
 - Use `#[cfg(doc)]` instead of docs.rs-specific cfg flag (#[287](https://github.com/rust-osdev/x86_64/pull/287))

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,12 @@
 # Unreleased
 
+- Rename some XCr0 and CR4 flags (#[275](https://github.com/rust-osdev/x86_64/pull/275))
+- Expose `MapperFlush::new` and `MapperFlushAll::new` constructor functions ([#296](https://github.com/rust-osdev/x86_64/pull/296))
+- Use `#[cfg(doc)]` instead of docs.rs-specific cfg flag (#[287](https://github.com/rust-osdev/x86_64/pull/287))
+- Some documentation updates:
+  - Update segment register references in `GDT::load*` method to non-deprecated methods ([#301](https://github.com/rust-osdev/x86_64/pull/301))
+  - Remove a panic note ([#300](https://github.com/rust-osdev/x86_64/pull/300))
+
 # 0.14.4 – 2021-07-19
 
 - Add `instructions::tables::sgdt` ([#279](https://github.com/rust-osdev/x86_64/pull/279))


### PR DESCRIPTION
Updates the changelog to include the recent changes and bumps the version to 0.14.5.

(The CI will take care of creating the git tag and pushing to crates.io after merging.)

This releases the following PRs: #275, #287, #296, #300, #301, #302, #264, #303, #306