### PR TITLE
Remove redundant alignment check

### DIFF
--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -24,7 +24,9 @@ impl<S: PageSize> PhysFrame<S> {
         if !address.is_aligned(S::SIZE) {
             return Err(AddressNotAligned);
         }
-        Ok(PhysFrame::containing_address(address))
+
+        // SAFETY: correct address alignment is checked above
+        Ok(unsafe { PhysFrame::from_start_address_unchecked(address) })
     }
 
     const_fn! {


### PR DESCRIPTION
This PR removes double alignment check - proper alignment to `S::Size` is asserted by this condition:

```rust
        if !address.is_aligned(S::SIZE) {
            return Err(AddressNotAligned);
        }
```