### PR TITLE
Derive common traits for number, range and enum types

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -17,7 +17,7 @@ use bit_field::BitField;
 /// On `x86_64`, only the 48 lower bits of a virtual address can be used. The top 16 bits need
 /// to be copies of bit 47, i.e. the most significant bit. Addresses that fulfil this criterium
 /// are called “canonical”. This type guarantees that it always represents a canonical address.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct VirtAddr(u64);
 
@@ -30,7 +30,7 @@ pub struct VirtAddr(u64);
 ///
 /// On `x86_64`, only the 52 lower bits of a physical address can be used. The top 12 bits need
 /// to be zero. This type guarantees that it always represents a valid physical address.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct PhysAddr(u64);
 

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -49,7 +49,7 @@ struct InvpcidDescriptor {
 
 /// Structure of a PCID. A PCID has to be <= 4096 for x86_64.
 #[repr(transparent)]
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Pcid(u16);
 
 impl Pcid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod registers;
 pub mod structures;
 
 /// Represents a protection ring level.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(u8)]
 pub enum PrivilegeLevel {
     /// Privilege-level 0 (most privilege): This level is used by critical system-software

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub mod registers;
 pub mod structures;
 
 /// Represents a protection ring level.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[repr(u8)]
 pub enum PrivilegeLevel {
     /// Privilege-level 0 (most privilege): This level is used by critical system-software

--- a/src/registers/segmentation.rs
+++ b/src/registers/segmentation.rs
@@ -62,7 +62,7 @@ pub trait Segment64: Segment {
 /// with some additional flags).
 ///
 /// See Intel 3a, Section 3.4.2 "Segment Selectors"
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct SegmentSelector(pub u16);
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1001,7 +1001,7 @@ impl fmt::Debug for SelectorErrorCode {
 /// The possible descriptor table values.
 ///
 /// Used by the [`SelectorErrorCode`] to indicate which table caused the error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DescriptorTable {
     /// Global Descriptor Table.
     Gdt,

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1001,7 +1001,7 @@ impl fmt::Debug for SelectorErrorCode {
 /// The possible descriptor table values.
 ///
 /// Used by the [`SelectorErrorCode`] to indicate which table caused the error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DescriptorTable {
     /// Global Descriptor Table.
     Gdt,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A physical memory frame.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PhysFrame<S: PageSize = Size4KiB> {
     pub(crate) start_address: PhysAddr, // TODO: remove when start_address() is const
@@ -133,7 +133,7 @@ impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
 }
 
 /// An range of physical memory frames, exclusive the upper bound.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PhysFrameRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
@@ -175,7 +175,7 @@ impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
 }
 
 /// An range of physical memory frames, inclusive the upper bound.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PhysFrameRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -133,7 +133,7 @@ impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
 }
 
 /// An range of physical memory frames, exclusive the upper bound.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct PhysFrameRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
@@ -175,7 +175,7 @@ impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
 }
 
 /// An range of physical memory frames, inclusive the upper bound.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct PhysFrameRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -53,7 +53,7 @@ impl PageSize for Size1GiB {
 }
 
 /// A virtual memory page.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct Page<S: PageSize = Size4KiB> {
     start_address: VirtAddr,
@@ -279,7 +279,7 @@ impl<S: PageSize> Sub<Self> for Page<S> {
 }
 
 /// A range of pages with exclusive upper bound.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PageRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
@@ -332,7 +332,7 @@ impl<S: PageSize> fmt::Debug for PageRange<S> {
 }
 
 /// A range of pages with inclusive upper bound.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -279,7 +279,7 @@ impl<S: PageSize> Sub<Self> for Page<S> {
 }
 
 /// A range of pages with exclusive upper bound.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct PageRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
@@ -332,7 +332,7 @@ impl<S: PageSize> fmt::Debug for PageRange<S> {
 }
 
 /// A range of pages with inclusive upper bound.
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C)]
 pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -268,7 +268,7 @@ impl fmt::Debug for PageTable {
 /// Can be used to select one of the 512 entries of a page table.
 ///
 /// Guaranteed to only ever contain 0..512.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PageTableIndex(u16);
 
 impl PageTableIndex {
@@ -319,7 +319,7 @@ impl From<PageTableIndex> for usize {
 /// This type is returned by the `VirtAddr::page_offset` method.
 ///
 /// Guaranteed to only ever contain 0..4096.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PageOffset(u16);
 
 impl PageOffset {

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -365,7 +365,7 @@ impl From<PageOffset> for usize {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// A value between 1 and 4.
 pub enum PageTableLevel {
     /// Represents the level for a page table.


### PR DESCRIPTION
Rust's api guidelines recommend [eagerly implementing common traits](https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits). There has already been some discussion #43 whether implementing all traits is always the best idea.

This pr add derives for `Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash` to some number and range types. These types are newtypes around integers and don't have any implementation details to hide, so adding these derives should be unobjectionable. This pr also adds the same derives to some enum types. 

Initially I only wanted to add theses derives to `Pcid`, but I noticed that other types were also missing some of them and decided to add them as well.