### PR TITLE
implement `Index<u8>` for IDT instead of `Index<usize>`

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -458,25 +458,21 @@ impl InterruptDescriptorTable {
         }
     }
 
-    /// Returns a normalized and ranged check slice range from a RangeBounds trait object
+    /// Returns a normalized and ranged check slice range from a RangeBounds trait object.
     ///
-    /// Panics if range is outside the range of user interrupts (i.e. greater than 255) or if the entry is an
-    /// exception
-    fn condition_slice_bounds(&self, bounds: impl RangeBounds<usize>) -> (usize, usize) {
+    /// Panics if the entry is an exception.
+    fn condition_slice_bounds(&self, bounds: impl RangeBounds<u8>) -> (usize, usize) {
         let lower_idx = match bounds.start_bound() {
-            Included(start) => *start,
-            Excluded(start) => *start + 1,
+            Included(start) => (*start as usize),
+            Excluded(start) => (*start as usize) + 1,
             Unbounded => 0,
         };
         let upper_idx = match bounds.end_bound() {
-            Included(end) => *end + 1,
-            Excluded(end) => *end,
+            Included(end) => (*end as usize) + 1,
+            Excluded(end) => (*end as usize),
             Unbounded => 256,
         };
 
-        if lower_idx > 256 || upper_idx > 256 {
-            panic!("Index out of range [{}..{}]", lower_idx, upper_idx);
-        }
         if lower_idx < 32 {
             panic!("Cannot return slice from traps, faults, and exception handlers");
         }
@@ -485,20 +481,18 @@ impl InterruptDescriptorTable {
 
     /// Returns slice of IDT entries with the specified range.
     ///
-    /// Panics if range is outside the range of user interrupts (i.e. greater than 255) or if the entry is an
-    /// exception
+    /// Panics if the entry is an exception.
     #[inline]
-    pub fn slice(&self, bounds: impl RangeBounds<usize>) -> &[Entry<HandlerFunc>] {
+    pub fn slice(&self, bounds: impl RangeBounds<u8>) -> &[Entry<HandlerFunc>] {
         let (lower_idx, upper_idx) = self.condition_slice_bounds(bounds);
         &self.interrupts[(lower_idx - 32)..(upper_idx - 32)]
     }
 
     /// Returns a mutable slice of IDT entries with the specified range.
     ///
-    /// Panics if range is outside the range of user interrupts (i.e. greater than 255) or if the entry is an
-    /// exception
+    /// Panics if the entry is an exception.
     #[inline]
-    pub fn slice_mut(&mut self, bounds: impl RangeBounds<usize>) -> &mut [Entry<HandlerFunc>] {
+    pub fn slice_mut(&mut self, bounds: impl RangeBounds<u8>) -> &mut [Entry<HandlerFunc>] {
         let (lower_idx, upper_idx) = self.condition_slice_bounds(bounds);
         &mut self.interrupts[(lower_idx - 32)..(upper_idx - 32)]
     }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -466,13 +466,13 @@ impl InterruptDescriptorTable {
     /// Panics if the entry is an exception.
     fn condition_slice_bounds(&self, bounds: impl RangeBounds<u8>) -> (usize, usize) {
         let lower_idx = match bounds.start_bound() {
-            Included(start) => (*start as usize),
-            Excluded(start) => (*start as usize) + 1,
+            Included(start) => usize::from(*start),
+            Excluded(start) => usize::from(*start) + 1,
             Unbounded => 0,
         };
         let upper_idx = match bounds.end_bound() {
-            Included(end) => (*end as usize) + 1,
-            Excluded(end) => (*end as usize),
+            Included(end) => usize::from(*end) + 1,
+            Excluded(end) => usize::from(*end),
             Unbounded => 256,
         };
 
@@ -522,7 +522,7 @@ impl Index<u8> for InterruptDescriptorTable {
             16 => &self.x87_floating_point,
             19 => &self.simd_floating_point,
             20 => &self.virtualization,
-            i @ 32..=255 => &self.interrupts[(i - 32) as usize],
+            i @ 32..=255 => &self.interrupts[usize::from(i - 32)],
             i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
             i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)
@@ -551,7 +551,7 @@ impl IndexMut<u8> for InterruptDescriptorTable {
             16 => &mut self.x87_floating_point,
             19 => &mut self.simd_floating_point,
             20 => &mut self.virtualization,
-            i @ 32..=255 => &mut self.interrupts[(i - 32) as usize],
+            i @ 32..=255 => &mut self.interrupts[usize::from(i - 32)],
             i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
             i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -504,15 +504,14 @@ impl InterruptDescriptorTable {
     }
 }
 
-impl Index<usize> for InterruptDescriptorTable {
+impl Index<u8> for InterruptDescriptorTable {
     type Output = Entry<HandlerFunc>;
 
     /// Returns the IDT entry with the specified index.
     ///
-    /// Panics if index is outside the IDT (i.e. greater than 255) or if the entry is an
-    /// exception that pushes an error code (use the struct fields for accessing these entries).
+    /// Panics if the entry is an exception that pushes an error code (use the struct fields for accessing these entries).
     #[inline]
-    fn index(&self, index: usize) -> &Self::Output {
+    fn index(&self, index: u8) -> &Self::Output {
         match index {
             0 => &self.divide_error,
             1 => &self.debug,
@@ -526,24 +525,22 @@ impl Index<usize> for InterruptDescriptorTable {
             16 => &self.x87_floating_point,
             19 => &self.simd_floating_point,
             20 => &self.virtualization,
-            i @ 32..=255 => &self.interrupts[i - 32],
+            i @ 32..=255 => &self.interrupts[(i - 32) as usize],
             i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
             i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)
             }
             i @ 18 => panic!("entry {} is an diverging exception (must not return)", i),
-            i => panic!("no entry with index {}", i),
         }
     }
 }
 
-impl IndexMut<usize> for InterruptDescriptorTable {
+impl IndexMut<u8> for InterruptDescriptorTable {
     /// Returns a mutable reference to the IDT entry with the specified index.
     ///
-    /// Panics if index is outside the IDT (i.e. greater than 255) or if the entry is an
-    /// exception that pushes an error code (use the struct fields for accessing these entries).
+    /// Panics if the entry is an exception that pushes an error code (use the struct fields for accessing these entries).
     #[inline]
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+    fn index_mut(&mut self, index: u8) -> &mut Self::Output {
         match index {
             0 => &mut self.divide_error,
             1 => &mut self.debug,
@@ -557,13 +554,12 @@ impl IndexMut<usize> for InterruptDescriptorTable {
             16 => &mut self.x87_floating_point,
             19 => &mut self.simd_floating_point,
             20 => &mut self.virtualization,
-            i @ 32..=255 => &mut self.interrupts[i - 32],
+            i @ 32..=255 => &mut self.interrupts[(i - 32) as usize],
             i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
             i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)
             }
             i @ 18 => panic!("entry {} is an diverging exception (must not return)", i),
-            i => panic!("no entry with index {}", i),
         }
     }
 }


### PR DESCRIPTION
This pr changes the `Idx` type of `InterruptDescriptorTable`'s `Index` implementation from `usize` to `u8` as discussed in https://github.com/rust-osdev/x86_64/pull/285#discussion_r744148763. `u8` more accurately represents the index for an `InterruptDescriptorTable` which always has exactly 256 entries. This change also eliminates some out of bounds panics that were possible with `usize`.

There was some discussion following https://github.com/rust-osdev/x86_64/pull/95#issuecomment-557496537 on whether it would be possible to use [`SliceIndex`](https://doc.rust-lang.org/std/slice/trait.SliceIndex.html) now or in the future. Following this pr this is no longer useful because `SliceIndex` is based around only `usize` not `u8`. Since using `SliceIndex` is now out of question, there shouldn't be any objections to hard coding implementations based for  the range types in `core` and so this pr provides those implementations as well.