### PR TITLE
activate `feature(abi_x86_interrupt)`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))] // IDT new()
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))] // PageSize marker trait
 #![cfg_attr(feature = "inline_asm", feature(asm))]
+#![cfg_attr(feature = "inline_asm", feature(asm_const))] // software_interrupt
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_docs)]


### PR DESCRIPTION
CI is failing because yesterdays nightly release broke const operands in asm (see https://github.com/rust-lang/rust/pull/90348). They now require `#![feature(asm_const)]`. Luckily we only use those on the `next` branch, so the master branch and all releases on crates.io should be fine.

This pr activates the `asm_const` feature when `inline_asm` is enabled.