### PR TITLE
fix(idt): fix panic messages for `index` and #VC

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -555,8 +555,8 @@ impl Index<usize> for InterruptDescriptorTable {
             19 => &self.simd_floating_point,
             20 => &self.virtualization,
             i @ 32..=255 => &self.interrupts[i - 32],
-            i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
-            i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
+            i @ 15 | i @ 31 | i @ 21..=28 => panic!("entry {} is reserved", i),
+            i @ 8 | i @ 10..=14 | i @ 17 | i @ 29 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)
             }
             i @ 18 => panic!("entry {} is an diverging exception (must not return)", i),
@@ -586,8 +586,8 @@ impl IndexMut<usize> for InterruptDescriptorTable {
             19 => &mut self.simd_floating_point,
             20 => &mut self.virtualization,
             i @ 32..=255 => &mut self.interrupts[i - 32],
-            i @ 15 | i @ 31 | i @ 21..=29 => panic!("entry {} is reserved", i),
-            i @ 8 | i @ 10..=14 | i @ 17 | i @ 30 => {
+            i @ 15 | i @ 31 | i @ 21..=28 => panic!("entry {} is reserved", i),
+            i @ 8 | i @ 10..=14 | i @ 17 | i @ 29 | i @ 30 => {
                 panic!("entry {} is an exception with error code", i)
             }
             i @ 18 => panic!("entry {} is an diverging exception (must not return)", i),


### PR DESCRIPTION
Signed-off-by: Harald Hoyer <harald@profian.com>