### PR TITLE
fix `load_tss` and `GlobalDescriptorTable`

### DIFF
--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -81,6 +81,9 @@ pub fn sidt() -> DescriptorTablePointer {
 
 /// Load the task state register using the `ltr` instruction.
 ///
+/// Loading the task state register changes the type of the entry
+/// in the GDT from `Available 64-bit TSS` to `Busy 64-bit TSS`.
+///
 /// ## Safety
 ///
 /// This function is unsafe because the caller must ensure that the given
@@ -89,7 +92,7 @@ pub fn sidt() -> DescriptorTablePointer {
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("ltr {0:x}", in(reg) sel.0, options(nomem, nostack, preserves_flags));
+    asm!("ltr {0:x}", in(reg) sel.0, options(nostack, preserves_flags));
 
     #[cfg(not(feature = "inline_asm"))]
     crate::asm::x86_64_asm_ltr(sel.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,17 +118,17 @@ impl PrivilegeLevel {
 
 /// A wrapper that can be used to safely create one mutable reference `&'static mut T` from a static variable.
 ///
-/// `Singleton` is safe because it ensures that it only ever gives out one reference.
+/// `SingleUseCell` is safe because it ensures that it only ever gives out one reference.
 ///
-/// ``Singleton<T>` is a safe alternative to `static mut` or a static `UnsafeCell<T>`.
+/// ``SingleUseCell<T>` is a safe alternative to `static mut` or a static `UnsafeCell<T>`.
 #[derive(Debug)]
-pub struct Singleton<T> {
+pub struct SingleUseCell<T> {
     used: AtomicBool,
     value: UnsafeCell<T>,
 }
 
-impl<T> Singleton<T> {
-    /// Construct a new singleton.
+impl<T> SingleUseCell<T> {
+    /// Construct a new SingleUseCell.
     pub const fn new(value: T) -> Self {
         Self {
             used: AtomicBool::new(false),
@@ -141,9 +141,9 @@ impl<T> Singleton<T> {
     /// called and fail on all following calls.
     ///
     /// ```
-    /// use x86_64::Singleton;
+    /// use x86_64::SingleUseCell;
     ///
-    /// static FOO: Singleton<i32> = Singleton::new(0);
+    /// static FOO: SingleUseCell<i32> = SingleUseCell::new(0);
     ///
     /// // Call `try_get_mut` for the first time and get a reference.
     /// let first: &'static mut i32 = FOO.try_get_mut().unwrap();
@@ -165,9 +165,9 @@ impl<T> Singleton<T> {
     }
 }
 
-// SAFETY: Sharing a `Singleton<T>` between threads is safe regardless of whether `T` is `Sync`
+// SAFETY: Sharing a `SingleUseCell<T>` between threads is safe regardless of whether `T` is `Sync`
 // because we only expose the inner value once to one thread.
-unsafe impl<T> Sync for Singleton<T> {}
+unsafe impl<T> Sync for SingleUseCell<T> {}
 
-// SAFETY: It's safe to send a `Singleton<T>` to another thread if it's safe to send `T`.
-unsafe impl<T: Send> Send for Singleton<T> {}
+// SAFETY: It's safe to send a `SingleUseCell<T>` to another thread if it's safe to send `T`.
+unsafe impl<T: Send> Send for SingleUseCell<T> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,15 +153,14 @@ impl<T> Singleton<T> {
     /// assert_eq!(FOO.try_get_mut(), None);
     /// ```
     pub fn try_get_mut(&self) -> Option<&mut T> {
-        match self
-            .used
-            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
-        {
-            Ok(_) => Some(unsafe {
+        let already_used = self.used.swap(true, Ordering::AcqRel);
+        if already_used {
+            None
+        } else {
+            Some(unsafe {
                 // SAFETY: no reference has been given out yet and we won't give out another.
                 &mut *self.value.get()
-            }),
-            Err(_) => None,
+            })
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,8 +166,9 @@ impl<T> SingleUseCell<T> {
 }
 
 // SAFETY: Sharing a `SingleUseCell<T>` between threads is safe regardless of whether `T` is `Sync`
-// because we only expose the inner value once to one thread.
-unsafe impl<T> Sync for SingleUseCell<T> {}
+// because we only expose the inner value once to one thread. The `T: Send` bound makes sure that
+// sending a unique reference to another thread is safe.
+unsafe impl<T: Send> Sync for SingleUseCell<T> {}
 
 // SAFETY: It's safe to send a `SingleUseCell<T>` to another thread if it's safe to send `T`.
 unsafe impl<T: Send> Send for SingleUseCell<T> {}

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
 use x86_64::structures::tss::TaskStateSegment;
-use x86_64::{Singleton, VirtAddr};
+use x86_64::{SingleUseCell, VirtAddr};
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
@@ -18,12 +18,12 @@ lazy_static! {
         };
         tss
     };
-    static ref GDT: (Singleton<GlobalDescriptorTable>, Selectors) = {
+    static ref GDT: (SingleUseCell<GlobalDescriptorTable>, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
         let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
         let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
         (
-            Singleton::new(gdt),
+            SingleUseCell::new(gdt),
             Selectors {
                 code_selector,
                 tss_selector,
@@ -38,7 +38,7 @@ struct Selectors {
 }
 
 pub fn init() {
-    use x86_64::instructions::segmentation::{CS, Segment};
+    use x86_64::instructions::segmentation::{Segment, CS};
     use x86_64::instructions::tables::load_tss;
 
     GDT.0.try_get_mut().unwrap().load();


### PR DESCRIPTION
`ltr` atomically writes to memory when it changes the referenced tss entry's type to `Busy 64-bit TSS`. This means that the inline assembly in `load_tss` should not have the `nomem` option and that the `table` field in `GlobalDescriptorTable` must use a type that is interiorly mutable.

Unfortunately this is a breaking change because I changed the type of `GlobalDescriptorTable::table` to `[AtomicU64; 8]` and  `GlobalDescriptorTable::as_raw_slice` exposes this field to the public api. Returning `&[u64]` wouldn't be safe anyways because `[u64]` isn't interioly mutable.

Technically this means that the old code was probably UB, but my guess is it's unlikely that anyone was actually affected by this.

#322 initially brought up that `load_tss` changes the GDT. This pr does not fix #322, but #322  should be easy to fix in a follow up pr once this pr is merged. 