### PR TITLE
change `cpu_flags`'s type to `RFlags`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2018"
 
 [dependencies]
 bit_field = "0.9.0"
-bitflags = "1.0.4"
+bitflags = "1.3.2"
 volatile = "0.4.4"
 
 [build-dependencies]

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -6,7 +6,8 @@ pub use self::x86_64::*;
 use bitflags::bitflags;
 
 bitflags! {
-    /// The RFLAGS register.
+    /// The RFLAGS register. All bit patterns are valid representations for this type.
+    #[repr(transparent)]
     pub struct RFlags: u64 {
         /// Processor feature identification flag.
         ///

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -20,6 +20,7 @@
 //!
 //! These types are defined for the compatibility with the Nightly Rust build.
 
+use crate::registers::rflags::RFlags;
 use crate::{PrivilegeLevel, VirtAddr};
 use bit_field::BitField;
 use bitflags::bitflags;
@@ -938,7 +939,7 @@ pub struct InterruptStackFrameValue {
     pub code_segment: SegmentSelector,
     _reserved1: [u8; 6],
     /// The flags register before the interrupt handler was invoked.
-    pub cpu_flags: u64,
+    pub cpu_flags: RFlags,
     /// The stack pointer at the time of the interrupt.
     pub stack_pointer: VirtAddr,
     /// The stack segment descriptor at the time of the interrupt (often zero in 64-bit mode).
@@ -948,17 +949,10 @@ pub struct InterruptStackFrameValue {
 
 impl fmt::Debug for InterruptStackFrameValue {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        struct Hex(u64);
-        impl fmt::Debug for Hex {
-            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "{:#x}", self.0)
-            }
-        }
-
         let mut s = f.debug_struct("InterruptStackFrame");
         s.field("instruction_pointer", &self.instruction_pointer);
         s.field("code_segment", &self.code_segment);
-        s.field("cpu_flags", &Hex(self.cpu_flags));
+        s.field("cpu_flags", &self.cpu_flags);
         s.field("stack_pointer", &self.stack_pointer);
         s.field("stack_segment", &self.stack_segment);
         s.finish()


### PR DESCRIPTION
https://github.com/rust-osdev/x86_64/issues/262 mentions that we should use correct types for `InterruptStackFrameValue`. This pr changes `cpu_flags` from u64 to `RFlags`, adds `#[repr(transparent)]` to `RFlags` and upgrades the `bitflags` dependency to the latest version. This last change is needed because "unknown" bits weren't officially supported until version `1.2.0`, starting with `1.2.0` crate authors must define what bit representations are valid for a type. 