### PR TITLE
remove `const_assert!` in favor of std's `assert!`

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -544,7 +544,7 @@ impl Sub<PhysAddr> for PhysAddr {
 /// feature, the panic message will be "index out of bounds".
 #[inline]
 pub const fn align_down(addr: u64, align: u64) -> u64 {
-    const_assert!(align.is_power_of_two(), "`align` must be a power of two");
+    assert!(align.is_power_of_two(), "`align` must be a power of two");
     addr & !(align - 1)
 }
 
@@ -556,7 +556,7 @@ pub const fn align_down(addr: u64, align: u64) -> u64 {
 /// feature, the panic message will be "index out of bounds".
 #[inline]
 pub const fn align_up(addr: u64, align: u64) -> u64 {
-    const_assert!(align.is_power_of_two(), "`align` must be a power of two");
+    assert!(align.is_power_of_two(), "`align` must be a power of two");
     let align_mask = align - 1;
     if addr & align_mask == 0 {
         addr // already aligned

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_panic))] // Better panic messages
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))] // IDT new()
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))] // PageSize marker trait
@@ -42,19 +41,6 @@ macro_rules! const_fn {
         $(#[$attr])*
         #[cfg(not(feature = "const_fn"))]
         $sv unsafe fn $($fn)*
-    };
-}
-
-// Helper method for assert! in const fn. Uses out of bounds indexing if an
-// assertion fails and the "const_fn" feature is not enabled.
-#[cfg(feature = "const_fn")]
-macro_rules! const_assert {
-    ($cond:expr, $($arg:tt)+) => { assert!($cond, $($arg)*) };
-}
-#[cfg(not(feature = "const_fn"))]
-macro_rules! const_assert {
-    ($cond:expr, $($arg:tt)+) => {
-        [(); 1][!($cond as bool) as usize]
     };
 }
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -72,7 +72,7 @@ impl GlobalDescriptorTable {
         let mut table = [0; 8];
         let mut idx = 0;
 
-        const_assert!(
+        assert!(
             next_free <= 8,
             "initializing a GDT from a slice requires it to be **at most** 8 elements."
         );


### PR DESCRIPTION
Rust 1.57 was just released and ["`panic!` in const contexts"](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html#panic-in-const-contexts) has finally been stabilized :tada:. This pr removes the hacky `const_assert!` macro that we previously used to conditionally abort the compilation in const contexts.