### PR TITLE
add an immutable getter for the level 4 page table

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -37,9 +37,14 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
         }
     }
 
+    /// Returns an immutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&self) -> &PageTable {
+        self.level_4_table
+    }
+
     /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
-    pub fn level_4_table(&mut self) -> &mut PageTable {
-        &mut self.level_4_table
+    pub fn level_4_table_mut(&mut self) -> &mut PageTable {
+        self.level_4_table
     }
 
     /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -37,9 +37,14 @@ impl<'a> OffsetPageTable<'a> {
         }
     }
 
-    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
-    pub fn level_4_table(&mut self) -> &mut PageTable {
+    /// Returns an immutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&self) -> &PageTable {
         self.inner.level_4_table()
+    }
+
+    /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table_mut(&mut self) -> &mut PageTable {
+        self.inner.level_4_table_mut()
     }
 }
 

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -83,9 +83,14 @@ impl<'a> RecursivePageTable<'a> {
         }
     }
 
+    /// Returns an immutable reference to the wrapped level 4 `PageTable` instance.
+    pub fn level_4_table(&self) -> &PageTable {
+        self.p4
+    }
+
     /// Returns a mutable reference to the wrapped level 4 `PageTable` instance.
-    pub fn level_4_table(&mut self) -> &mut PageTable {
-        &mut self.p4
+    pub fn level_4_table_mut(&mut self) -> &mut PageTable {
+        self.p4
     }
 
     /// Internal helper function to create the page table of the next level if needed.


### PR DESCRIPTION
This pr adds immutable getters for the level 4 page tables. It also appends the `_mut` suffix to the already existing getters.

Related to #325 