### PR TITLE
enable `unsafe_block_in_unsafe_fn` lint

### DIFF
--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -11,11 +11,15 @@ impl PortRead for u8 {
         #[cfg(feature = "inline_asm")]
         {
             let value: u8;
-            asm!("in al, dx", out("al") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            unsafe {
+                asm!("in al, dx", out("al") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            }
             value
         }
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_read_from_port_u8(port)
+        unsafe {
+            crate::asm::x86_64_asm_read_from_port_u8(port)
+        }
     }
 }
 
@@ -25,11 +29,15 @@ impl PortRead for u16 {
         #[cfg(feature = "inline_asm")]
         {
             let value: u16;
-            asm!("in ax, dx", out("ax") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            unsafe {
+                asm!("in ax, dx", out("ax") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            }
             value
         }
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_read_from_port_u16(port)
+        unsafe {
+            crate::asm::x86_64_asm_read_from_port_u16(port)
+        }
     }
 }
 
@@ -39,11 +47,15 @@ impl PortRead for u32 {
         #[cfg(feature = "inline_asm")]
         {
             let value: u32;
-            asm!("in eax, dx", out("eax") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            unsafe {
+                asm!("in eax, dx", out("eax") value, in("dx") port, options(nomem, nostack, preserves_flags));
+            }
             value
         }
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_read_from_port_u32(port)
+        unsafe {
+            crate::asm::x86_64_asm_read_from_port_u32(port)
+        }
     }
 }
 
@@ -51,10 +63,14 @@ impl PortWrite for u8 {
     #[inline]
     unsafe fn write_to_port(port: u16, value: u8) {
         #[cfg(feature = "inline_asm")]
-        asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack, preserves_flags));
+        unsafe {
+            asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack, preserves_flags));
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_write_to_port_u8(port, value);
+        unsafe {
+            crate::asm::x86_64_asm_write_to_port_u8(port, value);
+        }
     }
 }
 
@@ -62,10 +78,14 @@ impl PortWrite for u16 {
     #[inline]
     unsafe fn write_to_port(port: u16, value: u16) {
         #[cfg(feature = "inline_asm")]
-        asm!("out dx, ax", in("dx") port, in("ax") value, options(nomem, nostack, preserves_flags));
+        unsafe {
+            asm!("out dx, ax", in("dx") port, in("ax") value, options(nomem, nostack, preserves_flags));
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_write_to_port_u16(port, value);
+        unsafe {
+            crate::asm::x86_64_asm_write_to_port_u16(port, value);
+        }
     }
 }
 
@@ -73,10 +93,14 @@ impl PortWrite for u32 {
     #[inline]
     unsafe fn write_to_port(port: u16, value: u32) {
         #[cfg(feature = "inline_asm")]
-        asm!("out dx, eax", in("dx") port, in("eax") value, options(nomem, nostack, preserves_flags));
+        unsafe {
+            asm!("out dx, eax", in("dx") port, in("eax") value, options(nomem, nostack, preserves_flags));
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_write_to_port_u32(port, value);
+        unsafe {
+            crate::asm::x86_64_asm_write_to_port_u32(port, value);
+        }
     }
 }
 
@@ -162,7 +186,7 @@ impl<T: PortRead, A: PortReadAccess> PortGeneric<T, A> {
     /// safety.
     #[inline]
     pub unsafe fn read(&mut self) -> T {
-        T::read_from_port(self.port)
+        unsafe { T::read_from_port(self.port) }
     }
 }
 
@@ -175,7 +199,7 @@ impl<T: PortWrite, A: PortWriteAccess> PortGeneric<T, A> {
     /// safety.
     #[inline]
     pub unsafe fn write(&mut self, value: T) {
-        T::write_to_port(self.port, value)
+        unsafe { T::write_to_port(self.port, value) }
     }
 }
 

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -31,10 +31,14 @@ macro_rules! segment_impl {
 
             unsafe fn set_reg(sel: SegmentSelector) {
                 #[cfg(feature = "inline_asm")]
-                asm!(concat!("mov ", $name, ", {0:x}"), in(reg) sel.0, options(nostack, preserves_flags));
+                unsafe {
+                    asm!(concat!("mov ", $name, ", {0:x}"), in(reg) sel.0, options(nostack, preserves_flags));
+                }
 
                 #[cfg(not(feature = "inline_asm"))]
-                crate::asm::$asm_load(sel.0);
+                unsafe{
+                    crate::asm::$asm_load(sel.0);
+                }
             }
         }
     };
@@ -59,10 +63,14 @@ macro_rules! segment64_impl {
 
             unsafe fn write_base(base: VirtAddr) {
                 #[cfg(feature = "inline_asm")]
-                asm!(concat!("wr", $name, "base {}"), in(reg) base.as_u64(), options(nostack, preserves_flags));
+                unsafe{
+                    asm!(concat!("wr", $name, "base {}"), in(reg) base.as_u64(), options(nostack, preserves_flags));
+                }
 
                 #[cfg(not(feature = "inline_asm"))]
-                crate::asm::$asm_wr(base.as_u64());
+                unsafe{
+                    crate::asm::$asm_wr(base.as_u64());
+                }
             }
         }
     };
@@ -81,19 +89,23 @@ impl Segment for CS {
     /// for 64-bit far calls/jumps in long-mode, AMD does not.
     unsafe fn set_reg(sel: SegmentSelector) {
         #[cfg(feature = "inline_asm")]
-        asm!(
-            "push {sel}",
-            "lea {tmp}, [1f + rip]",
-            "push {tmp}",
-            "retfq",
-            "1:",
-            sel = in(reg) u64::from(sel.0),
-            tmp = lateout(reg) _,
-            options(preserves_flags),
-        );
+        unsafe {
+            asm!(
+                "push {sel}",
+                "lea {tmp}, [1f + rip]",
+                "push {tmp}",
+                "retfq",
+                "1:",
+                sel = in(reg) u64::from(sel.0),
+                tmp = lateout(reg) _,
+                options(preserves_flags),
+            );
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_set_cs(u64::from(sel.0));
+        unsafe {
+            crate::asm::x86_64_asm_set_cs(u64::from(sel.0));
+        }
     }
 }
 
@@ -114,10 +126,14 @@ impl GS {
     /// swap operation cannot lead to undefined behavior.
     pub unsafe fn swap() {
         #[cfg(feature = "inline_asm")]
-        asm!("swapgs", options(nostack, preserves_flags));
+        unsafe {
+            asm!("swapgs", options(nostack, preserves_flags));
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_swapgs();
+        unsafe {
+            crate::asm::x86_64_asm_swapgs();
+        }
     }
 }
 
@@ -126,49 +142,49 @@ impl GS {
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn set_cs(sel: SegmentSelector) {
-    CS::set_reg(sel)
+    unsafe { CS::set_reg(sel) }
 }
 /// Alias for [`SS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `SS::set_reg()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_ss(sel: SegmentSelector) {
-    SS::set_reg(sel)
+    unsafe { SS::set_reg(sel) }
 }
 /// Alias for [`DS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `DS::set_reg()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_ds(sel: SegmentSelector) {
-    DS::set_reg(sel)
+    unsafe { DS::set_reg(sel) }
 }
 /// Alias for [`ES::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `ES::set_reg()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_es(sel: SegmentSelector) {
-    ES::set_reg(sel)
+    unsafe { ES::set_reg(sel) }
 }
 /// Alias for [`FS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `FS::set_reg()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_fs(sel: SegmentSelector) {
-    FS::set_reg(sel)
+    unsafe { FS::set_reg(sel) }
 }
 /// Alias for [`GS::set_reg()`]
 #[deprecated(since = "0.14.4", note = "use `GS::set_reg()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn load_gs(sel: SegmentSelector) {
-    GS::set_reg(sel)
+    unsafe { GS::set_reg(sel) }
 }
 /// Alias for [`GS::swap()`]
 #[deprecated(since = "0.14.4", note = "use `GS::swap()` instead")]
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn swap_gs() {
-    GS::swap()
+    unsafe { GS::swap() }
 }
 /// Alias for [`CS::get_reg()`]
 #[deprecated(since = "0.14.4", note = "use `CS::get_reg()` instead")]
@@ -184,7 +200,7 @@ pub fn cs() -> SegmentSelector {
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn wrfsbase(val: u64) {
-    FS::write_base(VirtAddr::new(val))
+    unsafe { FS::write_base(VirtAddr::new(val)) }
 }
 /// Alias for [`FS::read_base()`]
 #[deprecated(since = "0.14.4", note = "use `FS::read_base()` instead")]
@@ -200,7 +216,7 @@ pub unsafe fn rdfsbase() -> u64 {
 #[allow(clippy::missing_safety_doc)]
 #[inline]
 pub unsafe fn wrgsbase(val: u64) {
-    GS::write_base(VirtAddr::new(val))
+    unsafe { GS::write_base(VirtAddr::new(val)) }
 }
 /// Alias for [`GS::read_base()`]
 #[deprecated(since = "0.14.4", note = "use `GS::read_base()` instead")]

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -19,10 +19,14 @@ pub use crate::structures::DescriptorTablePointer;
 #[inline]
 pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
     #[cfg(feature = "inline_asm")]
-    asm!("lgdt [{}]", in(reg) gdt, options(readonly, nostack, preserves_flags));
+    unsafe {
+        asm!("lgdt [{}]", in(reg) gdt, options(readonly, nostack, preserves_flags));
+    }
 
     #[cfg(not(feature = "inline_asm"))]
-    crate::asm::x86_64_asm_lgdt(gdt as *const _);
+    unsafe {
+        crate::asm::x86_64_asm_lgdt(gdt as *const _);
+    }
 }
 
 /// Load an IDT.
@@ -39,10 +43,14 @@ pub unsafe fn lgdt(gdt: &DescriptorTablePointer) {
 #[inline]
 pub unsafe fn lidt(idt: &DescriptorTablePointer) {
     #[cfg(feature = "inline_asm")]
-    asm!("lidt [{}]", in(reg) idt, options(readonly, nostack, preserves_flags));
+    unsafe {
+        asm!("lidt [{}]", in(reg) idt, options(readonly, nostack, preserves_flags));
+    }
 
     #[cfg(not(feature = "inline_asm"))]
-    crate::asm::x86_64_asm_lidt(idt as *const _);
+    unsafe {
+        crate::asm::x86_64_asm_lidt(idt as *const _);
+    }
 }
 
 /// Get the address of the current GDT.
@@ -89,8 +97,12 @@ pub fn sidt() -> DescriptorTablePointer {
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     #[cfg(feature = "inline_asm")]
-    asm!("ltr {0:x}", in(reg) sel.0, options(nomem, nostack, preserves_flags));
+    unsafe {
+        asm!("ltr {0:x}", in(reg) sel.0, options(nomem, nostack, preserves_flags));
+    }
 
     #[cfg(not(feature = "inline_asm"))]
-    crate::asm::x86_64_asm_ltr(sel.0);
+    unsafe {
+        crate::asm::x86_64_asm_ltr(sel.0);
+    }
 }

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -97,8 +97,12 @@ pub unsafe fn flush_pcid(command: InvPicdCommand) {
     }
 
     #[cfg(feature = "inline_asm")]
-    asm!("invpcid {0}, [{1}]", in(reg) kind, in(reg) &desc, options(nostack, preserves_flags));
+    unsafe {
+        asm!("invpcid {0}, [{1}]", in(reg) kind, in(reg) &desc, options(nostack, preserves_flags));
+    }
 
     #[cfg(not(feature = "inline_asm"))]
-    crate::asm::x86_64_asm_invpcid(kind, &desc as *const _ as u64);
+    unsafe {
+        crate::asm::x86_64_asm_invpcid(kind, &desc as *const _ as u64);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};
 

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -200,7 +200,9 @@ mod x86_64 {
             let reserved = old_value & !(Cr0Flags::all().bits());
             let new_value = reserved | flags.bits();
 
-            Self::write_raw(new_value);
+            unsafe {
+                Self::write_raw(new_value);
+            }
         }
 
         /// Write raw CR0 flags.
@@ -214,10 +216,14 @@ mod x86_64 {
         #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
-            asm!("mov cr0, {}", in(reg) value, options(nostack, preserves_flags));
+            unsafe {
+                asm!("mov cr0, {}", in(reg) value, options(nostack, preserves_flags));
+            }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_write_cr0(value);
+            unsafe {
+                crate::asm::x86_64_asm_write_cr0(value);
+            }
         }
 
         /// Updates CR0 flags.
@@ -235,7 +241,9 @@ mod x86_64 {
         {
             let mut flags = Self::read();
             f(&mut flags);
-            Self::write(flags);
+            unsafe {
+                Self::write(flags);
+            }
         }
     }
 
@@ -303,7 +311,9 @@ mod x86_64 {
         /// changing the page mapping.
         #[inline]
         pub unsafe fn write(frame: PhysFrame, flags: Cr3Flags) {
-            Cr3::write_raw(frame, flags.bits() as u16);
+            unsafe {
+                Cr3::write_raw(frame, flags.bits() as u16);
+            }
         }
 
         /// Write a new P4 table address into the CR3 register.
@@ -315,7 +325,9 @@ mod x86_64 {
         /// [`Cr4Flags::PCID`] must be set before calling this method.
         #[inline]
         pub unsafe fn write_pcid(frame: PhysFrame, pcid: Pcid) {
-            Cr3::write_raw(frame, pcid.value());
+            unsafe {
+                Cr3::write_raw(frame, pcid.value());
+            }
         }
 
         /// Write a new P4 table address into the CR3 register.
@@ -330,10 +342,14 @@ mod x86_64 {
             let value = addr.as_u64() | val as u64;
 
             #[cfg(feature = "inline_asm")]
-            asm!("mov cr3, {}", in(reg) value, options(nostack, preserves_flags));
+            unsafe {
+                asm!("mov cr3, {}", in(reg) value, options(nostack, preserves_flags));
+            }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_write_cr3(value)
+            unsafe {
+                crate::asm::x86_64_asm_write_cr3(value)
+            }
         }
     }
 
@@ -376,7 +392,9 @@ mod x86_64 {
             let reserved = old_value & !(Cr4Flags::all().bits());
             let new_value = reserved | flags.bits();
 
-            Self::write_raw(new_value);
+            unsafe {
+                Self::write_raw(new_value);
+            }
         }
 
         /// Write raw CR4 flags.
@@ -391,10 +409,14 @@ mod x86_64 {
         #[inline]
         pub unsafe fn write_raw(value: u64) {
             #[cfg(feature = "inline_asm")]
-            asm!("mov cr4, {}", in(reg) value, options(nostack, preserves_flags));
+            unsafe {
+                asm!("mov cr4, {}", in(reg) value, options(nostack, preserves_flags));
+            }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_write_cr4(value);
+            unsafe {
+                crate::asm::x86_64_asm_write_cr4(value);
+            }
         }
 
         /// Updates CR4 flags.
@@ -413,7 +435,9 @@ mod x86_64 {
         {
             let mut flags = Self::read();
             f(&mut flags);
-            Self::write(flags);
+            unsafe {
+                Self::write(flags);
+            }
         }
     }
 }

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -140,17 +140,21 @@ mod x86_64 {
             #[cfg(feature = "inline_asm")]
             {
                 let (high, low): (u32, u32);
-                asm!(
-                    "rdmsr",
-                    in("ecx") self.0,
-                    out("eax") low, out("edx") high,
-                    options(nomem, nostack, preserves_flags),
-                );
+                unsafe {
+                    asm!(
+                        "rdmsr",
+                        in("ecx") self.0,
+                        out("eax") low, out("edx") high,
+                        options(nomem, nostack, preserves_flags),
+                    );
+                }
                 ((high as u64) << 32) | (low as u64)
             }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_rdmsr(self.0)
+            unsafe {
+                crate::asm::x86_64_asm_rdmsr(self.0)
+            }
         }
 
         /// Write 64 bits to msr register.
@@ -165,15 +169,19 @@ mod x86_64 {
             let high = (value >> 32) as u32;
 
             #[cfg(feature = "inline_asm")]
-            asm!(
-                "wrmsr",
-                in("ecx") self.0,
-                in("eax") low, in("edx") high,
-                options(nostack, preserves_flags),
-            );
+            unsafe {
+                asm!(
+                    "wrmsr",
+                    in("ecx") self.0,
+                    in("eax") low, in("edx") high,
+                    options(nostack, preserves_flags),
+                );
+            }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_wrmsr(self.0, low, high);
+            unsafe {
+                crate::asm::x86_64_asm_wrmsr(self.0, low, high);
+            }
         }
     }
 
@@ -204,7 +212,9 @@ mod x86_64 {
             let reserved = old_value & !(EferFlags::all().bits());
             let new_value = reserved | flags.bits();
 
-            Self::write_raw(new_value);
+            unsafe {
+                Self::write_raw(new_value);
+            }
         }
 
         /// Write the EFER flags.
@@ -218,7 +228,9 @@ mod x86_64 {
         #[inline]
         pub unsafe fn write_raw(flags: u64) {
             let mut msr = Self::MSR;
-            msr.write(flags);
+            unsafe {
+                msr.write(flags);
+            }
         }
 
         /// Update EFER flags.
@@ -236,7 +248,9 @@ mod x86_64 {
         {
             let mut flags = Self::read();
             f(&mut flags);
-            Self::write(flags);
+            unsafe {
+                Self::write(flags);
+            }
         }
     }
 
@@ -361,7 +375,9 @@ mod x86_64 {
             msr_value.set_bits(48..64, sysret.into());
             msr_value.set_bits(32..48, syscall.into());
             let mut msr = Self::MSR;
-            msr.write(msr_value);
+            unsafe {
+                msr.write(msr_value);
+            }
         }
 
         /// Write the Ring 0 and Ring 3 segment bases.

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -104,7 +104,9 @@ mod x86_64 {
         let reserved = old_value & !(RFlags::all().bits());
         let new_value = reserved | flags.bits();
 
-        write_raw(new_value);
+        unsafe {
+            write_raw(new_value);
+        }
     }
 
     /// Writes the RFLAGS register.
@@ -122,10 +124,14 @@ mod x86_64 {
         // HACK: we mark this function as preserves_flags to prevent Rust from restoring
         // saved flags after the "popf" below. See above note on safety.
         #[cfg(feature = "inline_asm")]
-        asm!("push {}; popfq", in(reg) val, options(nomem, preserves_flags));
+        unsafe {
+            asm!("push {}; popfq", in(reg) val, options(nomem, preserves_flags));
+        }
 
         #[cfg(not(feature = "inline_asm"))]
-        crate::asm::x86_64_asm_write_rflags(val);
+        unsafe {
+            crate::asm::x86_64_asm_write_rflags(val);
+        }
     }
 
     #[cfg(test)]

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -123,7 +123,9 @@ mod x86_64 {
                 );
             }
 
-            Self::write_raw(new_value);
+            unsafe {
+                Self::write_raw(new_value);
+            }
         }
 
         /// Write raw XCR0 flags.
@@ -140,15 +142,19 @@ mod x86_64 {
             let high = (value >> 32) as u32;
 
             #[cfg(feature = "inline_asm")]
-            asm!(
-                "xsetbv",
-                in("ecx") 0,
-                in("rax") low, in("rdx") high,
-                options(nomem, nostack, preserves_flags),
-            );
+            unsafe {
+                asm!(
+                    "xsetbv",
+                    in("ecx") 0,
+                    in("rax") low, in("rdx") high,
+                    options(nomem, nostack, preserves_flags),
+                );
+            }
 
             #[cfg(not(feature = "inline_asm"))]
-            crate::asm::x86_64_asm_xsetbv(0, low, high);
+            unsafe {
+                crate::asm::x86_64_asm_xsetbv(0, low, high);
+            }
         }
     }
 }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -151,7 +151,9 @@ impl GlobalDescriptorTable {
     #[inline]
     pub unsafe fn load_unsafe(&self) {
         use crate::instructions::tables::lgdt;
-        lgdt(&self.pointer());
+        unsafe {
+            lgdt(&self.pointer());
+        }
     }
 
     const_fn! {

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -472,7 +472,9 @@ impl InterruptDescriptorTable {
     #[inline]
     pub unsafe fn load_unsafe(&self) {
         use crate::instructions::tables::lidt;
-        lidt(&self.pointer());
+        unsafe {
+            lidt(&self.pointer());
+        }
     }
 
     /// Creates the descriptor pointer for this table. This pointer can only be

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -192,7 +192,9 @@ pub trait Mapper<S: PageSize> {
                 | PageTableFlags::WRITABLE
                 | PageTableFlags::USER_ACCESSIBLE);
 
-        self.map_to_with_table_flags(page, frame, flags, parent_table_flags, frame_allocator)
+        unsafe {
+            self.map_to_with_table_flags(page, frame, flags, parent_table_flags, frame_allocator)
+        }
     }
 
     /// Creates a new mapping in the page table.
@@ -368,7 +370,7 @@ pub trait Mapper<S: PageSize> {
         Self: Mapper<S>,
     {
         let page = Page::containing_address(VirtAddr::new(frame.start_address().as_u64()));
-        self.map_to(page, frame, flags, frame_allocator)
+        unsafe { self.map_to(page, frame, flags, frame_allocator) }
     }
 }
 

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -34,7 +34,7 @@ impl<'a> OffsetPageTable<'a> {
             offset: phys_offset,
         };
         Self {
-            inner: MappedPageTable::new(level_4_table, phys_offset),
+            inner: unsafe { MappedPageTable::new(level_4_table, phys_offset) },
         }
     }
 
@@ -71,8 +71,10 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     where
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
-        self.inner
-            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        unsafe {
+            self.inner
+                .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        }
     }
 
     #[inline]
@@ -89,7 +91,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         page: Page<Size1GiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlush<Size1GiB>, FlagUpdateError> {
-        self.inner.update_flags(page, flags)
+        unsafe { self.inner.update_flags(page, flags) }
     }
 
     #[inline]
@@ -98,7 +100,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         page: Page<Size1GiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p4_entry(page, flags)
+        unsafe { self.inner.set_flags_p4_entry(page, flags) }
     }
 
     #[inline]
@@ -107,7 +109,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         page: Page<Size1GiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p3_entry(page, flags)
+        unsafe { self.inner.set_flags_p3_entry(page, flags) }
     }
 
     #[inline]
@@ -116,7 +118,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
         page: Page<Size1GiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p2_entry(page, flags)
+        unsafe { self.inner.set_flags_p2_entry(page, flags) }
     }
 
     #[inline]
@@ -138,8 +140,10 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     where
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
-        self.inner
-            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        unsafe {
+            self.inner
+                .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        }
     }
 
     #[inline]
@@ -156,7 +160,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         page: Page<Size2MiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlush<Size2MiB>, FlagUpdateError> {
-        self.inner.update_flags(page, flags)
+        unsafe { self.inner.update_flags(page, flags) }
     }
 
     #[inline]
@@ -165,7 +169,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         page: Page<Size2MiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p4_entry(page, flags)
+        unsafe { self.inner.set_flags_p4_entry(page, flags) }
     }
 
     #[inline]
@@ -174,7 +178,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         page: Page<Size2MiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p3_entry(page, flags)
+        unsafe { self.inner.set_flags_p3_entry(page, flags) }
     }
 
     #[inline]
@@ -183,7 +187,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
         page: Page<Size2MiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p2_entry(page, flags)
+        unsafe { self.inner.set_flags_p2_entry(page, flags) }
     }
 
     #[inline]
@@ -205,8 +209,10 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     where
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
-        self.inner
-            .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        unsafe {
+            self.inner
+                .map_to_with_table_flags(page, frame, flags, parent_table_flags, allocator)
+        }
     }
 
     #[inline]
@@ -223,7 +229,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         page: Page<Size4KiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlush<Size4KiB>, FlagUpdateError> {
-        self.inner.update_flags(page, flags)
+        unsafe { self.inner.update_flags(page, flags) }
     }
 
     #[inline]
@@ -232,7 +238,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         page: Page<Size4KiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p4_entry(page, flags)
+        unsafe { self.inner.set_flags_p4_entry(page, flags) }
     }
 
     #[inline]
@@ -241,7 +247,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         page: Page<Size4KiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p3_entry(page, flags)
+        unsafe { self.inner.set_flags_p3_entry(page, flags) }
     }
 
     #[inline]
@@ -250,7 +256,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         page: Page<Size4KiB>,
         flags: PageTableFlags,
     ) -> Result<MapperFlushAll, FlagUpdateError> {
-        self.inner.set_flags_p2_entry(page, flags)
+        unsafe { self.inner.set_flags_p2_entry(page, flags) }
     }
 
     #[inline]
@@ -272,7 +278,7 @@ impl<'a> CleanUp for OffsetPageTable<'a> {
     where
         D: FrameDeallocator<Size4KiB>,
     {
-        self.inner.clean_up(frame_deallocator)
+        unsafe { self.inner.clean_up(frame_deallocator) }
     }
 
     #[inline]
@@ -283,6 +289,6 @@ impl<'a> CleanUp for OffsetPageTable<'a> {
     ) where
         D: FrameDeallocator<Size4KiB>,
     {
-        self.inner.clean_up_addr_range(range, frame_deallocator)
+        unsafe { self.inner.clean_up_addr_range(range, frame_deallocator) }
     }
 }

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -334,8 +334,6 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
-    #[allow(unused_unsafe)]
     unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
@@ -462,8 +460,6 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
-    #[allow(unused_unsafe)]
     unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
@@ -620,8 +616,6 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
         Ok((frame, MapperFlush::new(page)))
     }
 
-    // allow unused_unsafe until https://github.com/rust-lang/rfcs/pull/2585 lands
-    #[allow(unused_unsafe)]
     unsafe fn update_flags(
         &mut self,
         page: Page<Size4KiB>,

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -521,7 +521,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
             return Err(FlagUpdateError::PageNotMapped);
         }
 
-        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &mut p3[page.p3_index()];
 
         if p3_entry.is_unused() {
@@ -684,7 +684,7 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
             return Err(FlagUpdateError::PageNotMapped);
         }
 
-        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &mut p3[page.p3_index()];
 
         if p3_entry.is_unused() {
@@ -707,13 +707,13 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
             return Err(FlagUpdateError::PageNotMapped);
         }
 
-        let p3 = &mut *(p3_ptr(page, self.recursive_index));
+        let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
 
         if p3[page.p3_index()].is_unused() {
             return Err(FlagUpdateError::PageNotMapped);
         }
 
-        let p2 = &mut *(p2_ptr(page, self.recursive_index));
+        let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
         let p2_entry = &mut p2[page.p2_index()];
 
         if p2_entry.is_unused() {
@@ -835,13 +835,15 @@ impl<'a> CleanUp for RecursivePageTable<'a> {
     where
         D: FrameDeallocator<Size4KiB>,
     {
-        self.clean_up_addr_range(
-            PageRangeInclusive {
-                start: Page::from_start_address(VirtAddr::new(0)).unwrap(),
-                end: Page::from_start_address(VirtAddr::new(0xffff_ffff_ffff_f000)).unwrap(),
-            },
-            frame_deallocator,
-        )
+        unsafe {
+            self.clean_up_addr_range(
+                PageRangeInclusive {
+                    start: Page::from_start_address(VirtAddr::new(0)).unwrap(),
+                    end: Page::from_start_address(VirtAddr::new(0xffff_ffff_ffff_f000)).unwrap(),
+                },
+                frame_deallocator,
+            )
+        }
     }
 
     unsafe fn clean_up_addr_range<D>(


### PR DESCRIPTION
This pr enables the `unsafe_block_in_unsafe_fn` lint.

Closes #221 