### PR TITLE
fix: build error on the latest nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,16 +50,6 @@ jobs:
         rustc -Vv
         cargo -Vv
 
-    - name: Cache binaries
-      id: cache-bin
-      uses: actions/cache@v1
-      with:
-        path: binaries
-        key: ${{ runner.OS }}-binaries
-    - name: Add binaries/bin to PATH
-      run: echo "$GITHUB_WORKSPACE/binaries/bin" >> $GITHUB_PATH
-      shell: bash
-
     - name: "Run cargo build"
       uses: actions-rs/cargo@v1
       with:
@@ -130,6 +120,35 @@ jobs:
       run: |
         cargo build --target i686-unknown-linux-gnu --no-default-features --features nightly
         cargo build --target thumbv7em-none-eabihf --no-default-features --features nightly
+
+  bootloader-test:
+    name: "Bootloader Integration Test"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [
+          ubuntu-latest,
+          macos-latest,
+          windows-latest
+        ]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v1
+
+    - name: Cache binaries
+      id: cache-bin
+      uses: actions/cache@v1
+      with:
+        path: binaries
+        key: ${{ runner.OS }}-binaries
+    - name: Add binaries/bin to PATH
+      run: echo "$GITHUB_WORKSPACE/binaries/bin" >> $GITHUB_PATH
+      shell: bash
 
     - name: "Install Rustup Components"
       run: rustup component add rust-src llvm-tools-preview

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -1,5 +1,8 @@
 //! Enabling and disabling interrupts
 
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
+
 /// Returns whether interrupts are enabled.
 #[inline]
 pub fn are_enabled() -> bool {

--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -9,6 +9,9 @@ pub mod segmentation;
 pub mod tables;
 pub mod tlb;
 
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
+
 /// Halts the CPU until the next interrupt arrives.
 #[inline]
 pub fn hlt() {

--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -1,5 +1,7 @@
 //! Access to I/O ports
 
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 use core::fmt;
 use core::marker::PhantomData;
 

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -6,6 +6,8 @@ use crate::{
     structures::gdt::SegmentSelector,
     VirtAddr,
 };
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 
 macro_rules! get_reg_impl {
     ($name:literal, $asm_get:ident) => {

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -2,6 +2,8 @@
 
 use crate::structures::gdt::SegmentSelector;
 use crate::VirtAddr;
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 
 pub use crate::structures::DescriptorTablePointer;
 

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -1,6 +1,8 @@
 //! Functions to flush the translation lookaside buffer (TLB).
 
 use crate::VirtAddr;
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 
 /// Invalidate the given address in the TLB using the `invlpg` instruction.
 #[inline]

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -2,8 +2,6 @@
 
 pub use super::model_specific::{Efer, EferFlags};
 use bitflags::bitflags;
-#[cfg(feature = "inline_asm")]
-use core::arch::asm;
 
 /// Various control flags modifying the basic operation of the CPU.
 #[derive(Debug)]
@@ -163,6 +161,8 @@ bitflags! {
 mod x86_64 {
     use super::*;
     use crate::{instructions::tlb::Pcid, structures::paging::PhysFrame, PhysAddr, VirtAddr};
+    #[cfg(feature = "inline_asm")]
+    use core::arch::asm;
 
     impl Cr0 {
         /// Read the current set of CR0 flags.

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -2,6 +2,8 @@
 
 pub use super::model_specific::{Efer, EferFlags};
 use bitflags::bitflags;
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 
 /// Various control flags modifying the basic operation of the CPU.
 #[derive(Debug)]

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -4,8 +4,6 @@ use bitflags::bitflags;
 // imports for intra doc links
 #[cfg(doc)]
 use crate::registers::segmentation::{FS, GS};
-#[cfg(feature = "inline_asm")]
-use core::arch::asm;
 
 /// A model specific register.
 #[derive(Debug)]
@@ -129,6 +127,8 @@ mod x86_64 {
         control::Cr4Flags,
         segmentation::{Segment, Segment64, CS, SS},
     };
+    #[cfg(feature = "inline_asm")]
+    use core::arch::asm;
 
     impl Msr {
         /// Read 64 bits msr register.

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -4,6 +4,8 @@ use bitflags::bitflags;
 // imports for intra doc links
 #[cfg(doc)]
 use crate::registers::segmentation::{FS, GS};
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
 
 /// A model specific register.
 #[derive(Debug)]

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -3,6 +3,9 @@
 #[cfg(feature = "instructions")]
 pub use self::x86_64::*;
 
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
+
 use bitflags::bitflags;
 
 bitflags! {

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -3,9 +3,6 @@
 #[cfg(feature = "instructions")]
 pub use self::x86_64::*;
 
-#[cfg(feature = "inline_asm")]
-use core::arch::asm;
-
 use bitflags::bitflags;
 
 bitflags! {
@@ -68,6 +65,8 @@ bitflags! {
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;
+    #[cfg(feature = "inline_asm")]
+    use core::arch::asm;
 
     /// Returns the current value of the RFLAGS register.
     ///

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -1,9 +1,6 @@
 //! Access to various extended system registers
 use bitflags::bitflags;
 
-#[cfg(feature = "inline_asm")]
-use core::arch::asm;
-
 /// Extended feature enable mask register
 #[derive(Debug)]
 pub struct XCr0;
@@ -57,6 +54,9 @@ bitflags! {
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;
+    #[cfg(feature = "inline_asm")]
+    use core::arch::asm;
+
     impl XCr0 {
         /// Read the current set of XCR0 flags.
         #[inline]

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -1,6 +1,9 @@
 //! Access to various extended system registers
 use bitflags::bitflags;
 
+#[cfg(feature = "inline_asm")]
+use core::arch::asm;
+
 /// Extended feature enable mask register
 #[derive(Debug)]
 pub struct XCr0;


### PR DESCRIPTION
`asm!` is excluded from Prelude.
