### PR TITLE
make `Cr2::read` return a result

### DIFF
--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -254,6 +254,10 @@ mod x86_64 {
 
     impl Cr2 {
         /// Read the current page fault linear address from the CR2 register.
+        ///
+        /// # Errors
+        ///
+        /// This method returns a [`VirtAddrNotValid`] error if the CR2 register contains a non-canonical address. Call [`Cr2::read_raw`] to handle such cases.
         #[inline]
         pub fn read() -> Result<VirtAddr, VirtAddrNotValid> {
             VirtAddr::try_new(Self::read_raw())

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -257,7 +257,8 @@ mod x86_64 {
         ///
         /// # Errors
         ///
-        /// This method returns a [`VirtAddrNotValid`] error if the CR2 register contains a non-canonical address. Call [`Cr2::read_raw`] to handle such cases.
+        /// This method returns a [`VirtAddrNotValid`] error if the CR2 register contains a
+        /// non-canonical address. Call [`Cr2::read_raw`] to handle such cases.
         #[inline]
         pub fn read() -> Result<VirtAddr, VirtAddrNotValid> {
             VirtAddr::try_new(Self::read_raw())

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -160,7 +160,10 @@ bitflags! {
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;
-    use crate::{instructions::tlb::Pcid, structures::paging::PhysFrame, PhysAddr, VirtAddr};
+    use crate::{
+        addr::VirtAddrNotValid, instructions::tlb::Pcid, structures::paging::PhysFrame, PhysAddr,
+        VirtAddr,
+    };
     #[cfg(feature = "inline_asm")]
     use core::arch::asm;
 
@@ -252,8 +255,8 @@ mod x86_64 {
     impl Cr2 {
         /// Read the current page fault linear address from the CR2 register.
         #[inline]
-        pub fn read() -> VirtAddr {
-            VirtAddr::new(Self::read_raw())
+        pub fn read() -> Result<VirtAddr, VirtAddrNotValid> {
+            VirtAddr::try_new(Self::read_raw())
         }
 
         /// Read the current page fault linear address from the CR2 register as a raw `u64`.


### PR DESCRIPTION
This pr adds `Cr2::read_raw` and makes `Cr2::read` return a result.

Closes #332 