### PR TITLE
registers: MXCSR

### DIFF
--- a/src/asm/asm.s
+++ b/src/asm/asm.s
@@ -334,3 +334,19 @@ _x86_64_asm_xsetbv:
     movl  %esi, %eax    # Second param is the low 32-bits
     xsetbv              # Third param (high 32-bits) is already in %edx
     retq
+
+.global _x86_64_asm_write_mxcsr
+.p2align 4
+_x86_64_asm_write_mxcsr:
+    pushq %rdi
+    ldmxcsr (%rsp)
+    popq %rdi
+    retq
+
+.global _x86_64_asm_read_mxcsr
+.p2align 4
+_x86_64_asm_read_mxcsr:
+    pushq $0
+    stmxcsr (%rsp)
+    popq %rax
+    retq

--- a/src/asm/mod.rs
+++ b/src/asm/mod.rs
@@ -299,4 +299,16 @@ extern "sysv64" {
         link_name = "_x86_64_asm_xsetbv"
     )]
     pub(crate) fn x86_64_asm_xsetbv(xcr: u32, low: u32, high: u32);
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_read_mxcsr"
+    )]
+    pub(crate) fn x86_64_asm_read_mxcsr() -> u32;
+
+    #[cfg_attr(
+        any(target_env = "gnu", target_env = "musl"),
+        link_name = "_x86_64_asm_write_mxcsr"
+    )]
+    pub(crate) fn x86_64_asm_write_mxcsr(val: u32);
 }

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod control;
 pub mod model_specific;
+pub mod mxcsr;
 pub mod rflags;
 pub mod segmentation;
 pub mod xcontrol;

--- a/src/registers/mxcsr.rs
+++ b/src/registers/mxcsr.rs
@@ -1,0 +1,121 @@
+//! Functions to read and write MXCSR register.
+
+#[cfg(feature = "instructions")]
+pub use self::x86_64::*;
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// MXCSR register.
+    #[repr(transparent)]
+    pub struct MxCsr: u32 {
+        /// Invalid operation
+        const INVALID_OPERATION = 1 << 0;
+        /// Denormal
+        const DENORMAL = 1 << 1;
+        /// Divide-by-zero
+        const DIVIDE_BY_ZERO = 1 << 2;
+        /// Overflow
+        const OVERFLOW = 1 << 3;
+        /// Underflow
+        const UNDERFLOW = 1 << 4;
+        /// Precision
+        const PRECISION = 1 << 5;
+        /// Denormals are zeros
+        const DENORMALS_ARE_ZEROS = 1 << 6;
+        /// Invalid operation mask
+        const INVALID_OPERATION_MASK = 1 << 7;
+        /// Denormal mask
+        const DENORMAL_MASK = 1 << 8;
+        /// Divide-by-zero mask
+        const DIVIDE_BY_ZERO_MASK = 1 << 9;
+        /// Overflow mask
+        const OVERFLOW_MASK = 1 << 10;
+        /// Underflow mask
+        const UNDERFLOW_MASK = 1 << 11;
+        /// Precision mask
+        const PRECISION_MASK = 1 << 12;
+        /// Toward negative infinity
+        const ROUNDING_CONTROL_NEGATIVE = 1 << 13;
+        /// Toward positive infinity
+        const ROUNDING_CONTROL_POSITIVE = 1 << 14;
+        /// Toward zero (positive + negative)
+        const ROUNDING_CONTROL_ZERO = 3 << 13;
+        /// Flush to zero
+        const FLUSH_TO_ZERO = 1 << 15;
+    }
+}
+
+impl Default for MxCsr {
+    /// Return the default MXCSR value at reset, as documented in Intel SDM volume 2A.
+    #[inline]
+    fn default() -> Self {
+        MxCsr::INVALID_OPERATION_MASK
+            | MxCsr::DENORMAL_MASK
+            | MxCsr::DIVIDE_BY_ZERO_MASK
+            | MxCsr::OVERFLOW_MASK
+            | MxCsr::UNDERFLOW_MASK
+            | MxCsr::PRECISION_MASK
+    }
+}
+
+#[cfg(feature = "instructions")]
+mod x86_64 {
+    use super::*;
+    #[cfg(feature = "inline_asm")]
+    use core::arch::asm;
+
+    /// Read the value of MXCSR.
+    #[inline]
+    pub fn read() -> MxCsr {
+        #[cfg(feature = "inline_asm")]
+        {
+            let mut mxcsr: u32 = 0;
+            unsafe {
+                asm!("stmxcsr [{}]", in(reg) &mut mxcsr, options(nostack, preserves_flags));
+            }
+            MxCsr::from_bits_truncate(mxcsr)
+        }
+        #[cfg(not(feature = "inline_asm"))]
+        unsafe {
+            MxCsr::from_bits_truncate(crate::asm::x86_64_asm_read_mxcsr())
+        }
+    }
+
+    /// Write MXCSR.
+    #[inline]
+    pub fn write(mxcsr: MxCsr) {
+        #[cfg(feature = "inline_asm")]
+        unsafe {
+            asm!("ldmxcsr [{}]", in(reg) &mxcsr, options(nostack, readonly));
+        }
+        #[cfg(not(feature = "inline_asm"))]
+        unsafe {
+            crate::asm::x86_64_asm_write_mxcsr(mxcsr.bits());
+        }
+    }
+
+    #[cfg(test)]
+    mod test {
+        use crate::registers::mxcsr::*;
+
+        #[test]
+        fn mxcsr_default() {
+            let mxcsr = read();
+            assert_eq!(mxcsr, MxCsr::from_bits_truncate(0x1F80));
+        }
+
+        #[test]
+        fn mxcsr_read() {
+            let mxcsr = read();
+            assert_eq!(mxcsr, MxCsr::default());
+        }
+
+        #[test]
+        fn mxcsr_write() {
+            let mxcsr = read();
+            write(mxcsr);
+            assert_eq!(mxcsr, read());
+        }
+    }
+}


### PR DESCRIPTION
Add MxCsr register derived from MxCsr type in enarx/xsave.

Provide two unit tests:
- mxcsr_default(): Check that the constant matches the value read from
  the CPU when the process has not yet written anything else to it.
- mxcsr_write(): Check that the write operation does not corrupt values.

Closes: https://github.com/enarx/enarx/issues/1000
Signed-off-by: Jarkko Sakkinen <jarkko.sakkinen@iki.fi>