### PR TITLE
implement `core::iter::Step` for `VirtAddr` and `Page`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,10 @@ volatile = "0.4.4"
 [features]
 default = [ "nightly", "instructions" ]
 instructions = []
-nightly = [ "const_fn", "abi_x86_interrupt", "doc_cfg" ]
+nightly = [ "const_fn", "step_trait", "abi_x86_interrupt", "doc_cfg" ]
 abi_x86_interrupt = []
 const_fn = []
+step_trait = []
 doc_cfg = []
 
 # These features are no longer used and only there for backwards compatibility.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -335,7 +335,7 @@ impl Step for VirtAddr {
 
         // Check if we jumped the gap.
         if end.0.get_bit(47) && !start.0.get_bit(47) {
-            steps -= 0xffff_0000_0000_0000;
+            steps = steps.checked_sub(0xffff_0000_0000_0000).unwrap();
         }
 
         usize::try_from(steps).ok()

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,6 +11,7 @@ use crate::structures::paging::page_table::PageTableLevel;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 use bit_field::BitField;
 
+#[cfg(feature = "step_trait")]
 const ADDRESS_SPACE_SIZE: u64 = 0x1_0000_0000_0000;
 
 /// A canonical 64-bit virtual memory address.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -354,7 +354,7 @@ impl Step for VirtAddr {
             addr.set_bits(47.., 0x1ffff);
         }
 
-        Some(Self(addr))
+        Some(Self::new(addr))
     }
 
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
@@ -370,7 +370,7 @@ impl Step for VirtAddr {
             addr.set_bits(47.., 0);
         }
 
-        Some(Self(addr))
+        Some(Self::new(addr))
     }
 }
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -349,9 +349,16 @@ impl Step for VirtAddr {
 
         let mut addr = start.0.checked_add(offset)?;
 
-        // Jump the gap by sign extending the 47th bit.
-        if addr.get_bits(47..) == 0x1 {
-            addr.set_bits(47.., 0x1ffff);
+        match addr.get_bits(47..) {
+            0x1 => {
+                // Jump the gap by sign extending the 47th bit.
+                addr.set_bits(47.., 0x1ffff);
+            }
+            0x2 => {
+                // Address overflow
+                return None;
+            }
+            _ => {}
         }
 
         Some(Self::new(addr))
@@ -365,9 +372,16 @@ impl Step for VirtAddr {
 
         let mut addr = start.0.checked_sub(offset)?;
 
-        // Jump the gap by sign extending the 47th bit.
-        if addr.get_bits(47..) == 0x1fffe {
-            addr.set_bits(47.., 0);
+        match addr.get_bits(47..) {
+            0x1fffe => {
+                // Jump the gap by sign extending the 47th bit.
+                addr.set_bits(47.., 0);
+            }
+            0x1fffd => {
+                // Address underflow
+                return None;
+            }
+            _ => {}
         }
 
         Some(Self::new(addr))

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,6 +11,8 @@ use crate::structures::paging::page_table::PageTableLevel;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 use bit_field::BitField;
 
+const ADDRESS_SPACE_SIZE: u64 = 0x1_0000_0000_0000;
+
 /// A canonical 64-bit virtual memory address.
 ///
 /// This is a wrapper type around an `u64`, so it is always 8 bytes, even when compiled
@@ -341,6 +343,10 @@ impl Step for VirtAddr {
 
     fn forward_checked(start: Self, count: usize) -> Option<Self> {
         let offset = u64::try_from(count).ok()?;
+        if offset > ADDRESS_SPACE_SIZE {
+            return None;
+        }
+
         let mut addr = start.0.checked_add(offset)?;
 
         // Jump the gap by sign extending the 47th bit.
@@ -353,6 +359,10 @@ impl Step for VirtAddr {
 
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         let offset = u64::try_from(count).ok()?;
+        if offset > ADDRESS_SPACE_SIZE {
+            return None;
+        }
+
         let mut addr = start.0.checked_sub(offset)?;
 
         // Jump the gap by sign extending the 47th bit.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     #[cfg(feature = "step_trait")]
-    fn virtaddr_step() {
+    fn virtaddr_step_forward() {
         assert_eq!(Step::forward(VirtAddr(0), 0), VirtAddr(0));
         assert_eq!(Step::forward(VirtAddr(0), 1), VirtAddr(1));
         assert_eq!(
@@ -646,7 +646,32 @@ mod tests {
             Step::forward_checked(VirtAddr(0xffff_ffff_ffff_ffff), 1),
             None
         );
+        assert_eq!(
+            Step::forward(VirtAddr(0x7fff_ffff_ffff), 0x1234_5678_9abd),
+            VirtAddr(0xffff_9234_5678_9abc)
+        );
+        assert_eq!(
+            Step::forward(VirtAddr(0x7fff_ffff_ffff), 0x8000_0000_0000),
+            VirtAddr(0xffff_ffff_ffff_ffff)
+        );
+        assert_eq!(
+            Step::forward(VirtAddr(0x7fff_ffff_ff00), 0x8000_0000_00ff),
+            VirtAddr(0xffff_ffff_ffff_ffff)
+        );
+        assert_eq!(
+            Step::forward_checked(VirtAddr(0x7fff_ffff_ff00), 0x8000_0000_0100),
+            None
+        );
+        assert_eq!(
+            Step::forward_checked(VirtAddr(0x7fff_ffff_ffff), 0x8000_0000_0001),
+            None
+        );
+    }
 
+
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn virtaddr_step_backward() {
         assert_eq!(Step::backward(VirtAddr(0), 0), VirtAddr(0));
         assert_eq!(Step::backward_checked(VirtAddr(0), 1), None);
         assert_eq!(Step::backward(VirtAddr(1), 1), VirtAddr(0));
@@ -658,7 +683,27 @@ mod tests {
             Step::backward(VirtAddr(0xffff_8000_0000_0001), 1),
             VirtAddr(0xffff_8000_0000_0000)
         );
+        assert_eq!(
+            Step::backward(VirtAddr(0xffff_9234_5678_9abc), 0x1234_5678_9abd),
+            VirtAddr(0x7fff_ffff_ffff)
+        );
+        assert_eq!(
+            Step::backward(VirtAddr(0xffff_8000_0000_0000), 0x8000_0000_0000),
+            VirtAddr(0)
+        );
+        assert_eq!(
+            Step::backward(VirtAddr(0xffff_8000_0000_0000), 0x7fff_ffff_ff01),
+            VirtAddr(0xff)
+        );
+        assert_eq!(
+            Step::backward_checked(VirtAddr(0xffff_8000_0000_0000), 0x8000_0000_0001),
+            None
+        );
+    }
 
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn virtaddr_steps_between() {
         assert_eq!(Step::steps_between(&VirtAddr(0), &VirtAddr(0)), Some(0));
         assert_eq!(Step::steps_between(&VirtAddr(0), &VirtAddr(1)), Some(1));
         assert_eq!(Step::steps_between(&VirtAddr(1), &VirtAddr(0)), None);

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -668,7 +668,6 @@ mod tests {
         );
     }
 
-
     #[test]
     #[cfg(feature = "step_trait")]
     fn virtaddr_step_backward() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))] // IDT new()
 #![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))] // PageSize marker trait
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
+#![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]


### PR DESCRIPTION
This pr implements `core::iter::Step` for `VirtAddr` and `Page` and adds corresponding unit tests. 
This implementation jumps the gap between `0x7fff_ffff_ffff` and `0xffff_8000_0000_0000` as discussed in https://github.com/rust-osdev/x86_64/issues/293#issuecomment-903260820. 
The `Step` trait is still unstable, so the implementation is put behind a new feature flag `step_trait`. This flag is enabled by the `nightly` feature flag. 

Part of #212