### PR TITLE
remove `external_asm` and `inline_asm` features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: doc
-        args: --no-default-features --features external_asm,instructions
+        args: --no-default-features --features instructions
       if: runner.os != 'Windows'
 
     - name: "Run cargo doc without default features"
@@ -83,14 +83,14 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --no-default-features --features external_asm,instructions
+        args: --no-default-features --features instructions
       if: runner.os != 'Windows'
 
     - name: "Run cargo build for stable on musl"
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
+        args: --target x86_64-unknown-linux-musl --no-default-features --features instructions
       if: runner.os == 'Linux'
 
     - name: "Run cargo test"
@@ -102,14 +102,14 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --no-default-features --features external_asm,instructions
+        args: --no-default-features --features instructions
       if: runner.os != 'Windows'
 
     - name: "Run cargo test for stable on musl"
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --target x86_64-unknown-linux-musl --no-default-features --features external_asm,instructions
+        args: --target x86_64-unknown-linux-musl --no-default-features --features instructions
       if: runner.os == 'Linux'
 
     - name: "Install Rustup Targets"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,6 @@ const_fn = []
 asm_const = []
 doc_cfg = []
 
-# These features are no longer used and only there for backwards compatibility.
-external_asm = []
-inline_asm = []
-
 [package.metadata.release]
 no-dev-version = true
 pre-release-replacements = [

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Support for x86_64 specific instructions (e.g. TLB flush), registers (e.g. contr
 
 * `nightly`: Enables features only available on nightly Rust; enabled by default.
 * `instructions`: Enabled by default, turns on x86\_64 specific instructions, and dependent features. Only available for x86\_64 targets.
-* `external_asm`: Use this to build with non-nightly rust. Needs `default-features = false, features = ["instructions"]`. Is unsupported on Windows.
 
 ## Building with stable rust
 


### PR DESCRIPTION
This pr removes the deprecated `external_asm` and `inline_asm` features for the next breaking release.

This is a followup pr for https://github.com/rust-osdev/x86_64/pull/343#pullrequestreview-893417513.