### PR TITLE
Add SGX structures and methods for dynamic memory management

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -6,6 +6,7 @@ pub mod interrupts;
 pub mod port;
 pub mod random;
 pub mod segmentation;
+pub mod sgx;
 pub mod tables;
 pub mod tlb;
 

--- a/src/instructions/sgx/enclu.rs
+++ b/src/instructions/sgx/enclu.rs
@@ -1,0 +1,98 @@
+//! ENCLU opcode wrappers
+
+use crate::structures::paging::Page;
+use crate::structures::sgx::*;
+use core::arch::asm;
+
+/// Error codes for EACCEPT
+#[derive(Debug)]
+pub enum AcceptError {
+    /// Unknown error
+    Unknown,
+    /// CPU cores have not exited from the previous grace period.
+    PageNotTracked,
+    /// Attributes of the destination page are incorrect.
+    PageAttributesMismatch,
+}
+
+/// Acknowledge host's request to add a new page or change its permissions.
+#[inline]
+pub fn accept(secinfo: &SecInfo, dest: Page) -> Result<(), AcceptError> {
+    const EACCEPT: usize = 0x05;
+    let ret;
+
+    unsafe {
+        asm!(
+            "xchg       {RBX}, rbx",
+            "enclu",
+            "mov        rbx, {RBX}",
+
+            RBX = inout(reg) secinfo => _,
+            in("rax") EACCEPT,
+            in("rcx") dest.start_address().as_u64(),
+            lateout("rax") ret,
+        );
+    }
+
+    match ret {
+        0 => Ok(()),
+        11 => Err(AcceptError::PageNotTracked),
+        19 => Err(AcceptError::PageAttributesMismatch),
+        _ => Err(AcceptError::Unknown),
+    }
+}
+
+/// Error codes for EACCEPTCOPY
+#[derive(Debug)]
+pub enum AcceptCopyError {
+    /// Unknown error
+    Unknown,
+    /// Attributes of the destination page are incorrect.
+    PageAttributesMismatch,
+}
+
+/// Acknowledge host's request to add a new page, and populate the page with
+/// the given permissions and data.
+#[inline]
+pub fn accept_copy(secinfo: &SecInfo, dest: Page, src: Page) -> Result<(), AcceptCopyError> {
+    pub const EACCEPTCOPY: usize = 0x07;
+    let ret;
+
+    unsafe {
+        asm!(
+            "xchg       {RBX}, rbx",
+            "enclu",
+            "mov        rbx, {RBX}",
+
+            RBX = inout(reg) secinfo => _,
+            in("rax") EACCEPTCOPY,
+            in("rcx") dest.start_address().as_u64(),
+            in("rdx") src.start_address().as_u64(),
+            lateout("rax") ret,
+        );
+    }
+
+    match ret {
+        0 => Ok(()),
+        19 => Err(AcceptCopyError::PageAttributesMismatch),
+        _ => Err(AcceptCopyError::Unknown),
+    }
+}
+
+/// Extend page permissions.
+#[inline]
+pub fn extend_permissions(secinfo: &SecInfo, dest: Page) {
+    pub const EMODPE: usize = 0x06;
+
+    unsafe {
+        asm!(
+            "xchg       {RBX}, rbx",
+            "enclu",
+            "mov        rbx, {RBX}",
+
+            RBX = inout(reg) secinfo => _,
+            in("rax") EMODPE,
+            in("rcx") dest.start_address().as_u64(),
+        );
+    }
+}

--- a/src/instructions/sgx/mod.rs
+++ b/src/instructions/sgx/mod.rs
@@ -1,0 +1,3 @@
+//! Wrappers for SGX instructions.
+
+pub mod enclu;

--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -8,6 +8,7 @@ pub mod idt;
 
 pub mod paging;
 pub mod port;
+pub mod sgx;
 pub mod tss;
 
 /// A struct describing a pointer to a descriptor table (GDT / IDT).

--- a/src/structures/sgx.rs
+++ b/src/structures/sgx.rs
@@ -1,0 +1,72 @@
+//! Provides architectural structures for Intel SGX.
+
+bitflags::bitflags! {
+    /// Page permissions and wait state
+    #[repr(transparent)]
+    pub struct PageFlags: u8 {
+        /// Read access
+        const READ = 1 << 0;
+        /// Write access
+        const WRITE = 1 << 1;
+        /// Execution access
+        const EXEC = 1 << 2;
+        /// EAUG waiting for EACCEPT or EACCEPTCOPY
+        const PENDING = 1 << 3;
+        /// EMODT waiting for EACCEPT
+        const MODIFIED = 1 << 4;
+        /// EMODPR waiting for EACCEPT
+        const RESTRICTED = 1 << 5;
+    }
+}
+
+/// Page type
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum PageType {
+    /// SGX Enclave Control Structure (SECS)
+    Secs = 0,
+    /// Thread Control Structure (TCS)
+    Tcs = 1,
+    /// Regular page
+    Regular = 2,
+    /// Version Array (VA) page
+    VersionArray = 3,
+    /// Removable from a running enclave
+    Trimmed = 4,
+    /// The first page of a shadow stack
+    ShadowStackFirst = 5,
+    /// A shadow stack page
+    ShadowStackRest = 6,
+}
+
+/// Page state
+#[derive(Copy, Clone, Debug)]
+#[repr(C, align(64))]
+pub struct SecInfo {
+    page_flags: PageFlags,
+    page_type: PageType,
+    reserved: [u8; 62],
+}
+
+impl SecInfo {
+    /// Create a new instance.
+    #[inline]
+    pub const fn new(page_type: PageType, page_flags: PageFlags) -> SecInfo {
+        SecInfo {
+            page_flags,
+            page_type,
+            reserved: [0; 62],
+        }
+    }
+
+    /// Return page type of the page.
+    pub fn page_type(&self) -> PageType {
+        self.page_type
+    }
+
+    /// Return state flags of the page.
+    pub fn page_flags(&self) -> PageFlags {
+        self.page_flags
+    }
+}


### PR DESCRIPTION
```
Introduce crate::structures::sgx for holding a flat list of SGX
micro-architectural structures, which are described in Intel SDM Vol. 3D,
chapter 34. Start with SECINFO, which describes page attributes for a
single page inside an SGX enclave (a protected memory region).
    
Add wrappers for EACCEPT, EACCEPTCOPY and EMODPE leaf functions of ENCLU
opcode, which are used to acknowledge, when a change is requested by the
host, and also modify enclave attributes. Add SGX return codes relevant
for the added functions.

Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>
```