### PR TITLE
User CET Register

### DIFF
--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -55,6 +55,14 @@ pub struct LStar;
 #[derive(Debug)]
 pub struct SFMask;
 
+/// IA32_U_CET: user mode CET configuration
+#[derive(Debug)]
+pub struct UCet;
+
+/// IA32_S_CET: supervisor mode CET configuration
+#[derive(Debug)]
+pub struct SCet;
+
 impl Efer {
     /// The underlying model specific register.
     pub const MSR: Msr = Msr(0xC000_0080);
@@ -90,6 +98,16 @@ impl SFMask {
     pub const MSR: Msr = Msr(0xC000_0084);
 }
 
+impl UCet {
+    /// The underlying model specific register.
+    pub const MSR: Msr = Msr(0x6A0);
+}
+
+impl SCet {
+    /// The underlying model specific register.
+    pub const MSR: Msr = Msr(0x6A2);
+}
+
 bitflags! {
     /// Flags of the Extended Feature Enable Register.
     pub struct EferFlags: u64 {
@@ -112,12 +130,37 @@ bitflags! {
     }
 }
 
+bitflags! {
+    /// Flags stored in IA32_U_CET and IA32_S_CET (Table-2-2 in Intel SDM Volume
+    /// 4). The Intel SDM-equivalent names are described in parentheses.
+    pub struct CetFlags: u64 {
+        /// Enable shadow stack (SH_STK_EN)
+        const SS_ENABLE = 1 << 0;
+        /// Enable WRSS{D,Q}W instructions (WR_SHTK_EN)
+        const SS_WRITE_ENABLE = 1 << 1;
+        /// Enable indirect branch tracking (ENDBR_EN)
+        const IBT_ENABLE = 1 << 2;
+        /// Enable legacy treatment for indirect branch tracking (LEG_IW_EN)
+        const IBT_LEGACY_ENABLE = 1 << 3;
+        /// Enable no-track opcode prefix for indirect branch tracking (NO_TRACK_EN)
+        const IBT_NO_TRACK_ENABLE = 1 << 4;
+        /// Disable suppression of CET on legacy compatibility (SUPPRESS_DIS)
+        const IBT_LEGACY_SUPPRESS_ENABLE = 1 << 5;
+        /// Enable suppression of indirect branch tracking (SUPPRESS)
+        const IBT_SUPPRESS_ENABLE = 1 << 10;
+        /// Is IBT waiting for a branch to return? (read-only, TRACKER)
+        const IBT_TRACKED = 1 << 11;
+    }
+}
+
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;
     use crate::addr::VirtAddr;
     use crate::registers::rflags::RFlags;
     use crate::structures::gdt::SegmentSelector;
+    use crate::structures::paging::Page;
+    use crate::structures::paging::Size4KiB;
     use crate::PrivilegeLevel;
     use bit_field::BitField;
     use core::convert::TryInto;
@@ -443,6 +486,76 @@ mod x86_64 {
         pub fn write(value: RFlags) {
             let mut msr = Self::MSR;
             unsafe { msr.write(value.bits()) };
+        }
+    }
+
+    impl UCet {
+        /// Read the raw IA32_U_CET.
+        #[inline]
+        fn read_raw() -> u64 {
+            unsafe { Self::MSR.read() }
+        }
+
+        /// Write the raw IA32_U_CET.
+        #[inline]
+        fn write_raw(value: u64) {
+            let mut msr = Self::MSR;
+            unsafe {
+                msr.write(value);
+            }
+        }
+
+        /// Read IA32_U_CET. Returns a tuple of the flags and the address to the legacy code page bitmap.
+        #[inline]
+        pub fn read() -> (CetFlags, Page) {
+            let value = Self::read_raw();
+            let cet_flags = CetFlags::from_bits_truncate(value);
+            let legacy_bitmap =
+                Page::from_start_address(VirtAddr::new(value & !(Page::<Size4KiB>::SIZE - 1)))
+                    .unwrap();
+
+            (cet_flags, legacy_bitmap)
+        }
+
+        /// Write IA32_U_CET.
+        #[inline]
+        pub fn write(flags: CetFlags, legacy_bitmap: Page) {
+            Self::write_raw(flags.bits() | legacy_bitmap.start_address().as_u64());
+        }
+    }
+
+    impl SCet {
+        /// Read the raw IA32_S_CET.
+        #[inline]
+        fn read_raw() -> u64 {
+            unsafe { Self::MSR.read() }
+        }
+
+        /// Write the raw IA32_S_CET.
+        #[inline]
+        fn write_raw(value: u64) {
+            let mut msr = Self::MSR;
+            unsafe {
+                msr.write(value);
+            }
+        }
+
+        /// Read IA32_S_CET. Returns a tuple of the flags and the address to the legacy code page bitmap.
+        #[inline]
+        pub fn read() -> (CetFlags, Page) {
+            let value = Self::read_raw();
+            let cet_flags = CetFlags::from_bits_truncate(value);
+            let legacy_bitmap =
+                Page::from_start_address(VirtAddr::new(value & !(Page::<Size4KiB>::SIZE - 1)))
+                    .unwrap();
+
+            (cet_flags, legacy_bitmap)
+        }
+
+        /// Write IA32_S_CET.
+        #[inline]
+        pub fn write(flags: CetFlags, legacy_bitmap: Page) {
+            Self::write_raw(flags.bits() | legacy_bitmap.start_address().as_u64());
         }
     }
 }


### PR DESCRIPTION
This embedded to some of SGX structures (at least SECS and REPORT), so that's I need to bring some support to x86_64 crate. Does not cover fields TRACKER but EB_LEG_BITMAP_BASE but:

- They are not part of the settable flags.
- They need to be encoded and decoded separately, i.e. in all cases need their own accessors

Actually SGX structures and encl* need only UCetFlags but it would have been crippled just to implement that structure without context. 