### PR TITLE
const_fn: Remove stabilized features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
-#![cfg_attr(feature = "const_fn", feature(const_fn_fn_ptr_basics))] // IDT new()
-#![cfg_attr(feature = "const_fn", feature(const_fn_trait_bound))] // PageSize marker trait
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -410,6 +410,7 @@ pub struct InterruptDescriptorTable {
 }
 
 impl InterruptDescriptorTable {
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Creates a new IDT filled with non-present entries.
         #[inline]

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -11,7 +11,8 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
 pub struct PhysFrame<S: PageSize = Size4KiB> {
-    pub(crate) start_address: PhysAddr, // TODO: remove when start_address() is const
+    // TODO: Make private when our minimum supported stable Rust version is 1.61
+    pub(crate) start_address: PhysAddr,
     size: PhantomData<S>,
 }
 
@@ -29,6 +30,7 @@ impl<S: PageSize> PhysFrame<S> {
         Ok(unsafe { PhysFrame::from_start_address_unchecked(address) })
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the frame that starts at the given virtual address.
         ///
@@ -53,6 +55,7 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the start address of the frame.
         #[inline]
@@ -61,6 +64,7 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the size the frame (4KB, 2MB or 1GB).
         #[inline]
@@ -69,6 +73,7 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns a range of frames, exclusive `end`.
         #[inline]
@@ -77,6 +82,7 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns a range of frames, inclusive `end`.
         #[inline]

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -77,6 +77,7 @@ impl<S: PageSize> Page<S> {
         Ok(Page::containing_address(address))
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the page that starts at the given virtual address.
         ///
@@ -101,6 +102,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the start address of the page.
         #[inline]
@@ -109,6 +111,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the size the page (4KB, 2MB or 1GB).
         #[inline]
@@ -117,6 +120,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the level 4 page table index of this page.
         #[inline]
@@ -125,6 +129,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the level 3 page table index of this page.
         #[inline]
@@ -133,6 +138,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the table index of this page at the specified level.
         #[inline]
@@ -141,6 +147,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns a range of pages, exclusive `end`.
         #[inline]
@@ -149,6 +156,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns a range of pages, inclusive `end`.
         #[inline]
@@ -159,6 +167,7 @@ impl<S: PageSize> Page<S> {
 }
 
 impl<S: NotGiantPageSize> Page<S> {
+    // TODO: Remove const_fn! when our minimum supported stable Rust version is 1.61
     const_fn! {
         /// Returns the level 2 page table index of this page.
         #[inline]


### PR DESCRIPTION
Both `const_fn_fn_ptr_basics` and `const_fn_trait_bound` were stabilized
in Rust relese 1.61. We can't immediately remove the `const_fn!` quite
yet. 1.61 is not yet on stable, and even it were, removing them would
increase our MSRV to 1.61 (which we may or may not want to do in a patch
release).

See also: https://github.com/rust-osdev/x86_64/issues/262#issuecomment-1077340045

Signed-off-by: Joe Richey <joerichey@google.com>