### PR TITLE
Make `Entry::handler_addr()` a public method

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -735,12 +735,13 @@ impl<F> Entry<F> {
         &mut self.options
     }
 
-    /// Returns the virtual address of this IDT entry's handler function as a `u64`.
+    /// Returns the virtual address of this IDT entry's handler function.
     #[inline]
-    pub fn handler_addr(&self) -> u64 {
-        self.pointer_low as u64
+    pub fn handler_addr(&self) -> VirtAddr {
+        let addr = self.pointer_low as u64
             | (self.pointer_middle as u64) << 16
-            | (self.pointer_high as u64) << 32
+            | (self.pointer_high as u64) << 32;
+        VirtAddr::new_truncate(addr)
     }
 }
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -735,8 +735,9 @@ impl<F> Entry<F> {
         &mut self.options
     }
 
+    /// Returns the virtual address of this IDT entry's handler function as a `u64`.
     #[inline]
-    fn handler_addr(&self) -> u64 {
+    pub fn handler_addr(&self) -> u64 {
         self.pointer_low as u64
             | (self.pointer_middle as u64) << 16
             | (self.pointer_high as u64) << 32

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -741,6 +741,8 @@ impl<F> Entry<F> {
         let addr = self.pointer_low as u64
             | (self.pointer_middle as u64) << 16
             | (self.pointer_high as u64) << 32;
+        // addr is a valid VirtAddr, as the pointer members are either all zero,
+        // or have been set by set_handler_addr (which takes a VirtAddr).
         VirtAddr::new_truncate(addr)
     }
 }


### PR DESCRIPTION
This is a very minor change that's both harmless and useful for various purposes in an OS.

PR submitted at the request of @phil-opp ([see here](https://github.com/theseus-os/Theseus/pull/499#issuecomment-1077368004))

## Potential changes
Note that we could gate the function (or just its `pub`-ness) behind `cfg(feature = "instructions")` for consistency, but then we'd need to change the implementation of `Debug` for `Entry`. Seems best to leave it as is.

We could also construct a `VirtAddr` from the return value and return that instead, but personally I believe that adds unnecessary complexity. I also think some of this crate's other functions assume `VirtAddr`s in a lot of high-level wrapper functions where the value doesn't necessarily represent a virtual address (but that's a matter for a separate issue), so I'm inclined to not return a `VirtAddr` here.