### PR TITLE
Update Docs and CI to note MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,56 @@ on:
   pull_request:
 
 jobs:
+  stable:
+    name: "Test MSRV and Stable Features"
+    strategy:
+      matrix:
+        rust:
+          - nightly
+          - 1.59
+          - 1.57
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.rust }}
+        override: true
+    - name: Run cargo build for stable
+      if: matrix.rust != 1.57
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --no-default-features --features instructions
+    - name: Run cargo build for stable without instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --no-default-features
+    - name: Run cargo doc for stable
+      if: matrix.rust != 1.57
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-default-features --features instructions
+    - name: Run cargo doc for stable without instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: doc
+        args: --no-default-features
+    - name: Run cargo test for stable
+      if: matrix.rust != 1.57
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features --features instructions
+    - name: Run cargo test for stable without instructions
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
+        args: --no-default-features
+
   test:
     name: "Test"
 
@@ -27,23 +77,13 @@ jobs:
     timeout-minutes: 15
 
     steps:
-    - name: "Checkout Repository"
-      uses: actions/checkout@v1
-
-    - name: Install Rustup
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
-        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      if: runner.os == 'macOS'
-
-    - name: Set Rustup profile to minimal
-      run: rustup set profile minimal
-
-    - name: Install musl target on Linux
-      run: |
-        rustup target add x86_64-unknown-linux-musl
-        sudo apt-get install musl-tools musl-dev
-      if: runner.os == 'Linux'
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
+        override: true
+        target: x86_64-unknown-linux-musl
 
     - name: "Print Rust Version"
       run: |
@@ -60,37 +100,11 @@ jobs:
       with:
         command: doc
 
-    - name: "Run cargo doc for stable"
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --no-default-features --features instructions
-      if: runner.os != 'Windows'
-
-    - name: "Run cargo doc without default features"
-      uses: actions-rs/cargo@v1
-      with:
-        command: doc
-        args: --no-default-features
-
-    - name: "Run cargo build for stable without instructions"
+    - name: "Run cargo build on musl"
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --no-default-features
-
-    - name: "Run cargo build for stable"
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --no-default-features --features instructions
-      if: runner.os != 'Windows'
-
-    - name: "Run cargo build for stable on musl"
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --target x86_64-unknown-linux-musl --no-default-features --features instructions
+        args: --target x86_64-unknown-linux-musl
       if: runner.os == 'Linux'
 
     - name: "Run cargo test"
@@ -98,18 +112,11 @@ jobs:
       with:
         command: test
 
-    - name: "Run cargo test for stable"
+    - name: "Run cargo test on musl"
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --no-default-features --features instructions
-      if: runner.os != 'Windows'
-
-    - name: "Run cargo test for stable on musl"
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --target x86_64-unknown-linux-musl --no-default-features --features instructions
+        args: --target x86_64-unknown-linux-musl
       if: runner.os == 'Linux'
 
     - name: "Install Rustup Targets"
@@ -138,11 +145,11 @@ jobs:
 
     steps:
     - name: "Checkout Repository"
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Cache binaries
       id: cache-bin
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: binaries
         key: ${{ runner.OS }}-binaries
@@ -151,7 +158,12 @@ jobs:
       shell: bash
 
     - name: "Install Rustup Components"
-      run: rustup component add rust-src llvm-tools-preview
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+        components: rust-src, llvm-tools-preview
     - name: "Install cargo-xbuild"
       run: cargo install cargo-xbuild --debug --root binaries
     - name: "Install bootimage"
@@ -189,18 +201,30 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-    - uses: actions/checkout@v1
-    - run: rustup toolchain install nightly --profile minimal --component rustfmt
-    - run: cargo +nightly fmt -- --check
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+        components: rustfmt
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fmt
+        args: --all -- --check
 
   clippy:
     name: "Clippy"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v1
-    - run: rustup toolchain install nightly --profile minimal --component clippy
-    - name: "Run `cargo clippy`"
-      uses: actions-rs/cargo@v1
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        override: true
+        profile: minimal
+        components: clippy
+    - uses: actions-rs/cargo@v1
       with:
         command: clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
 version = "0.14.8"
 edition = "2018"
+rust-version = "1.57" # Needed to support panic! in const fns
 
 [dependencies]
 bit_field = "0.10.1"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Support for x86_64 specific instructions (e.g. TLB flush), registers (e.g. contr
 * `nightly`: Enables features only available on nightly Rust; enabled by default.
 * `instructions`: Enabled by default, turns on x86\_64 specific instructions, and dependent features. Only available for x86\_64 targets.
 
-## Building with stable rust
+## Minimum Supported Rust Version (MSRV)
 
-This needs to have the [compile-time requirements](https://github.com/alexcrichton/cc-rs#compile-time-requirements) of the `cc` crate installed on your system.
-It was currently only tested on Linux and MacOS.
+If no features are enabled (`--no-default-features`), Rust 1.57.0 is required.
+
+If only the `instructions` feature is enabled (`--no-default-features --features instructions`), Rust 1.59.0 is required.
+
+If the `nightly` feature or any of its sub-features is enabled, a recent nightly is required.

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1336,6 +1336,7 @@ macro_rules! set_general_handler_entry {
 mod test {
     use super::*;
 
+    #[allow(dead_code)]
     fn entry_present(idt: &InterruptDescriptorTable, index: usize) -> bool {
         let options = match index {
             8 => &idt.double_fault.options,

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -502,9 +502,9 @@ pub trait CleanUp {
     /// ```
     /// # use core::ops::RangeInclusive;
     /// # use x86_64::{VirtAddr, structures::paging::{
-    /// #    FrameDeallocator, Size4KiB, MappedPageTable, mapper::{RecursivePageTable, CleanUp}, page::{Page, PageRangeInclusive},
+    /// #    FrameDeallocator, Size4KiB, mapper::CleanUp, page::Page,
     /// # }};
-    /// # unsafe fn test(page_table: &mut RecursivePageTable, frame_deallocator: &mut impl FrameDeallocator<Size4KiB>) {
+    /// # unsafe fn test(page_table: &mut impl CleanUp, frame_deallocator: &mut impl FrameDeallocator<Size4KiB>) {
     /// // clean up all page tables in the lower half of the address space
     /// let lower_half = Page::range_inclusive(
     ///     Page::containing_address(VirtAddr::new(0)),


### PR DESCRIPTION
This change updates our `README` to note what our Minimum Supported Rust Version (MSRV) is for each feature configuration. It also uses the [`rust-version` cargo feature](https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field) to make this information consumable by cargo.

Our MSRVs are:
  - `not(instructions)` and `not(nightly)` - Rust 1.57
  - `instructions` and `not(nightly)` - Rust 1.59
  - `nightly` - Rust Nightly (sufficiently recent)

I also updated some of our tests so that things would build/test on stable without errors or warnings. Finally, I updated the CI to actually test our MSRV (by moving some of our tests to a different "stable" job).

Signed-off-by: Joe Richey <joerichey@google.com>