### PR TITLE
tss: Initialize iopb to be empty instead of zero

### DIFF
--- a/src/structures/tss.rs
+++ b/src/structures/tss.rs
@@ -1,6 +1,7 @@
 //! Provides a type for the task state segment structure.
 
 use crate::VirtAddr;
+use core::mem::size_of;
 
 /// In 64-bit mode the TSS holds information that is not
 /// directly related to the task-switch mechanism,
@@ -22,18 +23,34 @@ pub struct TaskStateSegment {
 }
 
 impl TaskStateSegment {
-    /// Creates a new TSS with zeroed privilege and interrupt stack table and a zero
-    /// `iomap_base`.
+    /// Creates a new TSS with zeroed privilege and interrupt stack table and an
+    /// empty I/O-Permission Bitmap.
+    ///
+    /// As we always set the TSS segment limit to
+    /// `size_of::<TaskStateSegment>() - 1`, this means that `iomap_base` is
+    /// initialized to `size_of::<TaskStateSegment>()`.
     #[inline]
     pub const fn new() -> TaskStateSegment {
         TaskStateSegment {
             privilege_stack_table: [VirtAddr::zero(); 3],
             interrupt_stack_table: [VirtAddr::zero(); 7],
-            iomap_base: 0,
+            iomap_base: size_of::<TaskStateSegment>() as u16,
             reserved_1: 0,
             reserved_2: 0,
             reserved_3: 0,
             reserved_4: 0,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    pub fn check_tss_size() {
+        // Per the SDM, the minimum size of a TSS is 0x68 bytes, giving a
+        // minimum limit of 0x67.
+        assert_eq!(size_of::<TaskStateSegment>(), 0x68);
     }
 }


### PR DESCRIPTION
Fixes #195.

To make the IOPB invalid we set it to `1` more than the TSS segment limit. This is [what linux does](https://github.com/torvalds/linux/blob/eaa54b1458ca84092e513d554dd6d234245e6bef/arch/x86/include/asm/processor.h#L370). 

Signed-off-by: Joe Richey <joerichey@google.com>