### PR TITLE
Don't set nomem in load_tss

### DIFF
--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -78,6 +78,6 @@ pub fn sidt() -> DescriptorTablePointer {
 #[inline]
 pub unsafe fn load_tss(sel: SegmentSelector) {
     unsafe {
-        asm!("ltr {0:x}", in(reg) sel.0, options(nomem, nostack, preserves_flags));
+        asm!("ltr {0:x}", in(reg) sel.0, options(nostack, preserves_flags));
     }
 }


### PR DESCRIPTION
As pointed out in #323, `ltr` writes memory, as it modifies the corresponding TSS `Descriptor` in the GDT. Because of this, setting `nomem` is inaccurate.

Signed-off-by: Joe Richey <joerichey@google.com>