### PR TITLE
Allow the GDT to be of any length

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -75,7 +75,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     /// # Safety
     ///
     /// * The user must make sure that the entries are well formed
-    /// * The provided slice **must not be larger than 8 items** (only up to the first 8 will be observed.)
+    /// * Panics if the provided slice has more than `MAX` entries
     #[inline]
     pub const unsafe fn from_raw_slice(slice: &[u64]) -> Self {
         let next_free = slice.len();
@@ -84,7 +84,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
 
         assert!(
             next_free <= MAX,
-            "initializing a GDT from a slice requires it to be **at most** 8 elements."
+            "cannot initialize GDT with slice exceeding the maximum length"
         );
 
         while idx != next_free {


### PR DESCRIPTION
This uses a const generic `MAX` parameter to specify the length. This is arguably a breaking change as it bumps the MSRV to 1.59 though its use of default const generics. It also can make some function call require additional type annotations:
```rust
// Before
let gdt = GlobalDescriptorTable::from_raw_slice(slice);
// After
let gdt = GlobalDescriptorTable::<8>::from_raw_slice(slice);
```

Fixes #333 

Signed-off-by: Joe Richey <joerichey@google.com>