### PR TITLE
gdt: Improve panic message when SystemSegment is pushed

### DIFF
--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -47,7 +47,7 @@ use crate::registers::segmentation::{Segment, CS, SS};
 #[derive(Debug, Clone)]
 pub struct GlobalDescriptorTable {
     table: [u64; 8],
-    next_free: usize,
+    len: usize,
 }
 
 impl GlobalDescriptorTable {
@@ -56,7 +56,7 @@ impl GlobalDescriptorTable {
     pub const fn new() -> GlobalDescriptorTable {
         GlobalDescriptorTable {
             table: [0; 8],
-            next_free: 1,
+            len: 1,
         }
     }
 
@@ -68,21 +68,21 @@ impl GlobalDescriptorTable {
     /// * The provided slice **must not be larger than 8 items** (only up to the first 8 will be observed.)
     #[inline]
     pub const unsafe fn from_raw_slice(slice: &[u64]) -> GlobalDescriptorTable {
-        let next_free = slice.len();
+        let len = slice.len();
         let mut table = [0; 8];
         let mut idx = 0;
 
         assert!(
-            next_free <= 8,
+            len <= 8,
             "initializing a GDT from a slice requires it to be **at most** 8 elements."
         );
 
-        while idx != next_free {
+        while idx < len {
             table[idx] = slice[idx];
             idx += 1;
         }
 
-        GlobalDescriptorTable { table, next_free }
+        GlobalDescriptorTable { table, len }
     }
 
     /// Get a reference to the internal table.
@@ -90,7 +90,7 @@ impl GlobalDescriptorTable {
     /// The resulting slice may contain system descriptors, which span two `u64`s.
     #[inline]
     pub fn as_raw_slice(&self) -> &[u64] {
-        &self.table[..self.next_free]
+        &self.table[..self.len]
     }
 
     /// Adds the given segment descriptor to the GDT, returning the segment selector.
@@ -101,13 +101,13 @@ impl GlobalDescriptorTable {
     pub fn add_entry(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => {
-                if self.next_free > self.table.len() - 1 {
+                if self.len > self.table.len() - 1 {
                     panic!("GDT full")
                 }
                 self.push(value)
             }
             Descriptor::SystemSegment(value_low, value_high) => {
-                if self.next_free > self.table.len() - 2 {
+                if self.len > self.table.len() - 2 {
                     panic!("GDT requires two free spaces to hold a SystemSegment")
                 }
                 let index = self.push(value_low);
@@ -165,9 +165,9 @@ impl GlobalDescriptorTable {
     #[inline]
     #[cfg_attr(feature = "const_fn", rustversion::attr(all(), const))]
     fn push(&mut self, value: u64) -> usize {
-        let index = self.next_free;
+        let index = self.len;
         self.table[index] = value;
-        self.next_free += 1;
+        self.len += 1;
         index
     }
 
@@ -178,7 +178,7 @@ impl GlobalDescriptorTable {
         use core::mem::size_of;
         super::DescriptorTablePointer {
             base: crate::VirtAddr::new(self.table.as_ptr() as u64),
-            limit: (self.next_free * size_of::<u64>() - 1) as u16,
+            limit: (self.len * size_of::<u64>() - 1) as u16,
         }
     }
 }
@@ -361,6 +361,7 @@ mod tests {
         gdt.add_entry(Descriptor::UserSegment(DescriptorFlags::USER_CODE32.bits()));
         gdt.add_entry(Descriptor::user_data_segment());
         gdt.add_entry(Descriptor::user_code_segment());
+        assert_eq!(gdt.len, 6);
         gdt
     }
 
@@ -369,6 +370,7 @@ mod tests {
     fn make_full_gdt() -> GlobalDescriptorTable {
         let mut gdt = make_six_entry_gdt();
         gdt.add_entry(Descriptor::tss_segment(&TSS));
+        assert_eq!(gdt.len, 8);
         gdt
     }
 
@@ -377,7 +379,9 @@ mod tests {
         // Make sure we don't panic with user segments
         let mut gdt = make_six_entry_gdt();
         gdt.add_entry(Descriptor::user_data_segment());
+        assert_eq!(gdt.len, 7);
         gdt.add_entry(Descriptor::user_data_segment());
+        assert_eq!(gdt.len, 8);
         // Make sure we don't panic with system segments
         let _ = make_full_gdt();
     }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -101,13 +101,13 @@ impl GlobalDescriptorTable {
     pub fn add_entry(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => {
-                if self.len > self.table.len() - 1 {
+                if self.len > self.table.len().saturating_sub(1) {
                     panic!("GDT full")
                 }
                 self.push(value)
             }
             Descriptor::SystemSegment(value_low, value_high) => {
-                if self.len > self.table.len() - 2 {
+                if self.len > self.table.len().saturating_sub(2) {
                     panic!("GDT requires two free spaces to hold a SystemSegment")
                 }
                 let index = self.push(value_low);


### PR DESCRIPTION
This is a minor, non-breaking change.

When pushing a `SystemSegment` the GDT has to have two entries free. Rather than pushing part of the `SystemSegment` and _then_ panicking, we can panic before we even modify the GDT, and give a better error message. This new behavior also seems  less surprising, as normally if a mutation operation panics, the structure isn't modified.

I also renamed the `next_free` private member to `len` (with these changes it makes the code more readable). I also added some tests to make sure we are correctly handling the `add_entry` command.

Signed-off-by: Joe Richey <joerichey@google.com>