### PR TITLE
Increase alginment for packed structures

### DIFF
--- a/src/structures/mod.rs
+++ b/src/structures/mod.rs
@@ -13,10 +13,28 @@ pub mod tss;
 /// A struct describing a pointer to a descriptor table (GDT / IDT).
 /// This is in a format suitable for giving to 'lgdt' or 'lidt'.
 #[derive(Debug, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C, packed(2))]
 pub struct DescriptorTablePointer {
     /// Size of the DT.
     pub limit: u16,
     /// Pointer to the memory region containing the DT.
     pub base: VirtAddr,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    #[test]
+    pub fn check_descriptor_pointer_size() {
+        // Per the SDM, a descriptor pointer has to be 2+8=10 bytes
+        assert_eq!(size_of::<DescriptorTablePointer>(), 10);
+        // Make sure that we can reference a pointer's limit
+        let p = DescriptorTablePointer {
+            limit: 5,
+            base: VirtAddr::zero(),
+        };
+        let _: &u16 = &p.limit;
+    }
 }

--- a/src/structures/tss.rs
+++ b/src/structures/tss.rs
@@ -8,7 +8,7 @@ use core::mem::size_of;
 /// but is used for finding kernel level stack
 /// if interrupts arrive while in kernel mode.
 #[derive(Debug, Clone, Copy)]
-#[repr(C, packed)]
+#[repr(C, packed(4))]
 pub struct TaskStateSegment {
     reserved_1: u32,
     /// The full 64-bit canonical forms of the stack pointers (RSP) for privilege levels 0-2.


### PR DESCRIPTION
While both TaskStateSegment and DescriptorTablePointer can't have their
normal C alignment due to their definition. However, this doesn't mean
their alignment has to be `1`.

This PR sets their alignment to be the max possible while still
preserving their ABI definied structure. I added some tests to make sure
there is not a regression.

This can also result in more efficient code generation on platofrms
without unalgined loads. https://rust.godbolt.org/z/EPbbMxeq1

Signed-off-by: Joe Richey <joerichey@google.com>