### PR TITLE
Remove software_interrupt! macro

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -135,18 +135,6 @@ pub fn int3() {
 
 /// Generate a software interrupt by invoking the `int` instruction.
 ///
-/// This currently needs to be a macro because the `int` argument needs to be an
-/// immediate. This macro will be replaced by a generic function when support for
-/// const generics is implemented in Rust.
-#[macro_export]
-macro_rules! software_interrupt {
-    ($x:expr) => {{
-        asm!("int {id}", id = const $x, options(nomem, nostack));
-    }};
-}
-
-/// Generate a software interrupt by invoking the `int` instruction.
-///
 /// ## Safety
 ///
 /// Invoking an arbitrary interrupt is unsafe. It can cause your system to


### PR DESCRIPTION
Given that const generics are stable but const values in `asm!` are not,
having a macro in addition to a generic function isn't really useful.

See https://github.com/rust-osdev/x86_64/pull/344#discussion_r835898335

Signed-off-by: Joe Richey <joerichey@google.com>