### PR TITLE
Remove usize trait impls

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -281,23 +281,6 @@ impl AddAssign<u64> for VirtAddr {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
-impl Add<usize> for VirtAddr {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: usize) -> Self::Output {
-        self + rhs as u64
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl AddAssign<usize> for VirtAddr {
-    #[inline]
-    fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(rhs as u64)
-    }
-}
-
 impl Sub<u64> for VirtAddr {
     type Output = Self;
     #[inline]
@@ -310,23 +293,6 @@ impl SubAssign<u64> for VirtAddr {
     #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl Sub<usize> for VirtAddr {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: usize) -> Self::Output {
-        self - rhs as u64
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl SubAssign<usize> for VirtAddr {
-    #[inline]
-    fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(rhs as u64)
     }
 }
 
@@ -564,23 +530,6 @@ impl AddAssign<u64> for PhysAddr {
     }
 }
 
-#[cfg(target_pointer_width = "64")]
-impl Add<usize> for PhysAddr {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: usize) -> Self::Output {
-        self + rhs as u64
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl AddAssign<usize> for PhysAddr {
-    #[inline]
-    fn add_assign(&mut self, rhs: usize) {
-        self.add_assign(rhs as u64)
-    }
-}
-
 impl Sub<u64> for PhysAddr {
     type Output = Self;
     #[inline]
@@ -593,23 +542,6 @@ impl SubAssign<u64> for PhysAddr {
     #[inline]
     fn sub_assign(&mut self, rhs: u64) {
         *self = *self - rhs;
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl Sub<usize> for PhysAddr {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: usize) -> Self::Output {
-        self - rhs as u64
-    }
-}
-
-#[cfg(target_pointer_width = "64")]
-impl SubAssign<usize> for PhysAddr {
-    #[inline]
-    fn sub_assign(&mut self, rhs: usize) {
-        self.sub_assign(rhs as u64)
     }
 }
 

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -13,7 +13,7 @@ lazy_static! {
             static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
 
             let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
-            let stack_end = stack_start + STACK_SIZE;
+            let stack_end = stack_start + STACK_SIZE as u64;
             stack_end
         };
         tss


### PR DESCRIPTION
This removes `Add`/`AddAssign`/`Sub`/`SubAssign` with `usize` from
`VirtAddr` and `PhysAddr` (which are always 64-bit, even on 32-bit
platforms). This makes it possible to write code like:

```rust
let addr1 = PhysAddr::new(0x52);
let addr2 = addr1 + 3;
```

without getting a "multiple `impl`s" compiler error.

This is essentially the breaking change mentioned in
https://github.com/rust-osdev/x86_64/issues/293#issuecomment-901804330

Signed-off-by: Joe Richey <joerichey@google.com>