### PR TITLE
 Provide null segment selector as associated constant on SegmentSelector

### DIFF
--- a/src/registers/segmentation.rs
+++ b/src/registers/segmentation.rs
@@ -77,6 +77,10 @@ impl SegmentSelector {
         SegmentSelector(index << 3 | (rpl as u16))
     }
 
+    /// Can be used as a selector into a non-existent segment and assigned to segment registers,
+    /// e.g. data segment register in ring 0
+    pub const NULL: Self = Self::new(0, PrivilegeLevel::Ring0);
+
     /// Returns the GDT index.
     #[inline]
     pub fn index(self) -> u16 {

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -93,6 +93,14 @@ impl GlobalDescriptorTable {
         &self.table[..self.len]
     }
 
+    /// Get the GDT's null segment descriptor.
+    ///
+    /// Can be used as a selector into a non-existent segment and assigned to segment registers.
+    #[inline]
+    pub fn null_segment_descriptor(&self) -> SegmentSelector {
+        SegmentSelector::new(0u16, PrivilegeLevel::from_u16(0u16))
+    }
+
     /// Adds the given segment descriptor to the GDT, returning the segment selector.
     ///
     /// Panics if the GDT doesn't have enough free entries to hold the Descriptor.

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -93,11 +93,11 @@ impl GlobalDescriptorTable {
         &self.table[..self.len]
     }
 
-    /// Get the GDT's null segment descriptor.
+    /// Get the GDT's null segment descriptor as selector.
     ///
     /// Can be used as a selector into a non-existent segment and assigned to segment registers.
     #[inline]
-    pub fn null_segment_descriptor(&self) -> SegmentSelector {
+    pub fn null_segment_selector(&self) -> SegmentSelector {
         SegmentSelector::new(0u16, PrivilegeLevel::from_u16(0u16))
     }
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -93,14 +93,6 @@ impl GlobalDescriptorTable {
         &self.table[..self.len]
     }
 
-    /// Get the GDT's null segment descriptor as selector.
-    ///
-    /// Can be used as a selector into a non-existent segment and assigned to segment registers.
-    #[inline]
-    pub fn null_segment_selector(&self) -> SegmentSelector {
-        SegmentSelector::new(0u16, PrivilegeLevel::from_u16(0u16))
-    }
-
     /// Adds the given segment descriptor to the GDT, returning the segment selector.
     ///
     /// Panics if the GDT doesn't have enough free entries to hold the Descriptor.


### PR DESCRIPTION
This may be useful when used as a segment selector to load a non-existent segment into the data register.
e.g.
```
DS::set_reg(gdt.null_segment_selector())
```