### PR TITLE
Add structures::gdt::Entry type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
+#![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT::append()
 #![cfg_attr(feature = "asm_const", feature(asm_const))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -5,6 +5,7 @@ use crate::structures::tss::TaskStateSegment;
 use crate::PrivilegeLevel;
 use bit_field::BitField;
 use bitflags::bitflags;
+use core::fmt;
 // imports for intra-doc links
 #[cfg(doc)]
 use crate::registers::segmentation::{Segment, CS, SS};
@@ -16,7 +17,7 @@ use crate::registers::segmentation::{Segment, CS, SS};
 /// uses either 1 Entry (if it is a [`UserSegment`](Descriptor::UserSegment)) or
 /// 2 Entries (if it is a [`SystemSegment`](Descriptor::SystemSegment)). This
 /// type exists to give users access to the raw entry bits in a GDT.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Entry(u64);
 
@@ -30,6 +31,13 @@ impl Entry {
     /// bits may correspond to those in [`DescriptorFlags`].
     pub fn raw(&self) -> u64 {
         self.0
+    }
+}
+
+impl fmt::Debug for Entry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display inner value as hex
+        write!(f, "Entry({:#018x})", self.raw())
     }
 }
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -118,6 +118,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     /// * the provided slice has more than `MAX` entries
     /// * the provided slice is empty
     /// * the first entry is not zero
+    #[cfg_attr(not(feature = "instructions"), allow(rustdoc::broken_intra_doc_links))]
     #[inline]
     pub const fn from_raw_entries(slice: &[u64]) -> Self {
         let len = slice.len();
@@ -147,10 +148,10 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
         &self.table[..self.len]
     }
 
-    /// Adds the given segment descriptor to the GDT, returning the segment selector.
+    /// Appends the given segment descriptor to the GDT, returning the segment selector.
     ///
-    /// Note that depending on the type of the [`Descriptor`] this may add either
-    /// one or two new entries.
+    /// Note that depending on the type of the [`Descriptor`] this may append
+    /// either one or two new [`Entry`]s to the table.
     ///
     /// Panics if the GDT doesn't have enough free entries.
     #[inline]

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -20,8 +20,8 @@ lazy_static! {
     };
     static ref GDT: (SingleUseCell<GlobalDescriptorTable>, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
-        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
-        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        let code_selector = gdt.append(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
         (
             SingleUseCell::new(gdt),
             Selectors {


### PR DESCRIPTION
The current documentation for the GDT often confuses entries and `Descriptor`s.
For example, adding a new `Descriptor` uses a method confusingly named
`add_entry`.

An entry is a raw 64-bit value that is indexed by a segment selector.
The `MAX` length of the GDT is a number of _entries_, not `Descriptor`s.

To fix this confusion, this PR makes the following changes:
  - Adds a transparent `u64` newtype called `Entry`.
  - Updates the `GlobalDescriptorTable` documentation to correctly use
    `Entry` or `Descriptor` where appropriate.
  - Renames the `add_entry` to `append`.
    - This better expresses that this method might add multiple entries.
  - Renames `from_raw_slice` to `from_raw_entries`
    - As @Freax13 provided out, if we add some checks, this method can be safe.
  - Renames `as_raw_slice` to `entries`
    - This method now returns a slice of `Entry`s instead of `u64`s

This also fixes an issue where our `assert!`s in `empty()` wouldn't
trigger if the GDT was constructed from raw values.

Signed-off-by: Joe Richey <joerichey@google.com>