### PR TITLE
Allow GDT to be loaded with shared reference

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
+#![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT::append()
 #![cfg_attr(feature = "asm_const", feature(asm_const))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,9 +11,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-use core::cell::UnsafeCell;
-use core::sync::atomic::{AtomicBool, Ordering};
-
 pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};
 
 pub mod addr;
@@ -66,60 +63,3 @@ impl PrivilegeLevel {
         }
     }
 }
-
-/// A wrapper that can be used to safely create one mutable reference `&'static mut T` from a static variable.
-///
-/// `SingleUseCell` is safe because it ensures that it only ever gives out one reference.
-///
-/// ``SingleUseCell<T>` is a safe alternative to `static mut` or a static `UnsafeCell<T>`.
-#[derive(Debug)]
-pub struct SingleUseCell<T> {
-    used: AtomicBool,
-    value: UnsafeCell<T>,
-}
-
-impl<T> SingleUseCell<T> {
-    /// Construct a new SingleUseCell.
-    pub const fn new(value: T) -> Self {
-        Self {
-            used: AtomicBool::new(false),
-            value: UnsafeCell::new(value),
-        }
-    }
-
-    /// Try to acquire a mutable reference to the wrapped value.
-    /// This will only succeed the first time the function is
-    /// called and fail on all following calls.
-    ///
-    /// ```
-    /// use x86_64::SingleUseCell;
-    ///
-    /// static FOO: SingleUseCell<i32> = SingleUseCell::new(0);
-    ///
-    /// // Call `try_get_mut` for the first time and get a reference.
-    /// let first: &'static mut i32 = FOO.try_get_mut().unwrap();
-    /// assert_eq!(first, &0);
-    ///
-    /// // Calling `try_get_mut` again will return `None`.
-    /// assert_eq!(FOO.try_get_mut(), None);
-    /// ```
-    pub fn try_get_mut(&self) -> Option<&mut T> {
-        let already_used = self.used.swap(true, Ordering::AcqRel);
-        if already_used {
-            None
-        } else {
-            Some(unsafe {
-                // SAFETY: no reference has been given out yet and we won't give out another.
-                &mut *self.value.get()
-            })
-        }
-    }
-}
-
-// SAFETY: Sharing a `SingleUseCell<T>` between threads is safe regardless of whether `T` is `Sync`
-// because we only expose the inner value once to one thread. The `T: Send` bound makes sure that
-// sending a unique reference to another thread is safe.
-unsafe impl<T: Send> Sync for SingleUseCell<T> {}
-
-// SAFETY: It's safe to send a `SingleUseCell<T>` to another thread if it's safe to send `T`.
-unsafe impl<T: Send> Send for SingleUseCell<T> {}

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -124,6 +124,9 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
         // TODO: Replace with compiler error when feature(generic_const_exprs) is stable.
         assert!(MAX > 0, "A GDT cannot have 0 entries");
         assert!(MAX <= (1 << 13), "A GDT can only have at most 2^13 entries");
+
+        // TODO: Replace with inline_const when it's stable.
+        #[allow(clippy::declare_interior_mutable_const)]
         const NULL: Entry = Entry::new(0);
         Self {
             table: [NULL; MAX],

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -5,6 +5,7 @@ use crate::structures::tss::TaskStateSegment;
 use crate::PrivilegeLevel;
 use bit_field::BitField;
 use bitflags::bitflags;
+use core::fmt;
 // imports for intra-doc links
 #[cfg(doc)]
 use crate::registers::segmentation::{Segment, CS, SS};
@@ -16,7 +17,7 @@ use crate::registers::segmentation::{Segment, CS, SS};
 /// uses either 1 Entry (if it is a [`UserSegment`](Descriptor::UserSegment)) or
 /// 2 Entries (if it is a [`SystemSegment`](Descriptor::SystemSegment)). This
 /// type exists to give users access to the raw entry bits in a GDT.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct Entry(u64);
 
@@ -30,6 +31,13 @@ impl Entry {
     /// bits may correspond to those in [`DescriptorFlags`].
     pub fn raw(&self) -> u64 {
         self.0
+    }
+}
+
+impl fmt::Debug for Entry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display inner value as hex
+        write!(f, "Entry({:#018x})", self.raw())
     }
 }
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -223,7 +223,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     /// [`SS::set_reg()`] and [`CS::set_reg()`].
     #[cfg(feature = "instructions")]
     #[inline]
-    pub fn load(&'static mut self) {
+    pub fn load(&'static self) {
         // SAFETY: static lifetime ensures no modification after loading.
         unsafe { self.load_unsafe() };
     }
@@ -241,7 +241,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     ///
     #[cfg(feature = "instructions")]
     #[inline]
-    pub unsafe fn load_unsafe(&mut self) {
+    pub unsafe fn load_unsafe(&self) {
         use crate::instructions::tables::lgdt;
         unsafe {
             lgdt(&self.pointer());

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -118,6 +118,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     /// * the provided slice has more than `MAX` entries
     /// * the provided slice is empty
     /// * the first entry is not zero
+    #[cfg_attr(not(feature = "instructions"), allow(rustdoc::broken_intra_doc_links))]
     #[inline]
     pub const fn from_raw_entries(slice: &[u64]) -> Self {
         let len = slice.len();
@@ -147,10 +148,10 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
         &self.table[..self.len]
     }
 
-    /// Adds the given segment descriptor to the GDT, returning the segment selector.
+    /// Appends the given segment descriptor to the GDT, returning the segment selector.
     ///
-    /// Note that depending on the type of the [`Descriptor`] this may add either
-    /// one or two new entries.
+    /// Note that depending on the type of the [`Descriptor`] this may append
+    /// either one or two new [`Entry`]s to the table.
     ///
     /// Panics if the GDT doesn't have enough free entries.
     #[inline]

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
 use x86_64::structures::tss::TaskStateSegment;
-use x86_64::{SingleUseCell, VirtAddr};
+use x86_64::VirtAddr;
 
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
@@ -18,12 +18,12 @@ lazy_static! {
         };
         tss
     };
-    static ref GDT: (SingleUseCell<GlobalDescriptorTable>, Selectors) = {
+    static ref GDT: (GlobalDescriptorTable, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
         let code_selector = gdt.append(Descriptor::kernel_code_segment());
         let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
         (
-            SingleUseCell::new(gdt),
+            gdt,
             Selectors {
                 code_selector,
                 tss_selector,
@@ -41,7 +41,7 @@ pub fn init() {
     use x86_64::instructions::segmentation::{Segment, CS};
     use x86_64::instructions::tables::load_tss;
 
-    GDT.0.try_get_mut().unwrap().load();
+    GDT.0.load();
     unsafe {
         CS::set_reg(GDT.1.code_selector);
         load_tss(GDT.1.tss_selector);

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -20,8 +20,8 @@ lazy_static! {
     };
     static ref GDT: (SingleUseCell<GlobalDescriptorTable>, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
-        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
-        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        let code_selector = gdt.append(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
         (
             SingleUseCell::new(gdt),
             Selectors {

--- a/testing/src/gdt.rs
+++ b/testing/src/gdt.rs
@@ -20,6 +20,8 @@ lazy_static! {
     };
     static ref GDT: (GlobalDescriptorTable, Selectors) = {
         let mut gdt = GlobalDescriptorTable::new();
+        // Add an unused segment so we get a different value for CS
+        gdt.append(Descriptor::kernel_data_segment());
         let code_selector = gdt.append(Descriptor::kernel_code_segment());
         let tss_selector = gdt.append(Descriptor::tss_segment(&TSS));
         (
@@ -41,9 +43,16 @@ pub fn init() {
     use x86_64::instructions::segmentation::{Segment, CS};
     use x86_64::instructions::tables::load_tss;
 
+    // Make sure loading CS actually changes the value
     GDT.0.load();
-    unsafe {
-        CS::set_reg(GDT.1.code_selector);
-        load_tss(GDT.1.tss_selector);
-    }
+    assert_ne!(CS::get_reg(), GDT.1.code_selector);
+    unsafe { CS::set_reg(GDT.1.code_selector) };
+    assert_eq!(CS::get_reg(), GDT.1.code_selector);
+
+    // Loading the TSS should mark the GDT entry as busy
+    let tss_idx: usize = GDT.1.tss_selector.index().into();
+    let old_tss_entry = GDT.0.entries()[tss_idx].clone();
+    unsafe { load_tss(GDT.1.tss_selector) };
+    let new_tss_entry = GDT.0.entries()[tss_idx].clone();
+    assert_ne!(old_tss_entry, new_tss_entry);
 }


### PR DESCRIPTION
Depends on #380 

In #322 it was pointed out that calling `load_tss` would modify the GDT entry for the TSS (to mark it as busy). This meant our GDT required some sort of interior mutability if we wanted to use it in a `static`  context. #323 solved this problem by requiring `&mut` to call `load` and `load_unsafe`, thus ensuring that the GDT would be mutable after it was loaded. It also introduced `SingleUseCell` to make such manipulations more ergonomic.

This PR takes a different approach. The idea is basically the initial version of #323 using `AtomicU64`. The main difference is that:
  - We can use the `Entry` type from #380 to make the code cleaner.
  - We only need to use `AtomicU64` if it's possible for code to call `load` and `load_tss`, so we can gate this on `#[cfg(feature = "instructions")]`.

By doing things this way, we can go back to using shared references for `load` and `load_unsafe`, which is much more ergonomic. We can then get rid of `SingleUseCell` (which doesn't really fit well with this x86_64-specific crate). Also, using an atomic, shared, static type better reflects how the processor uses the GDT. It's almost always read-only, can be shared between cores, and once in use is only updated atomically. In fact, the Intel documentation for `LTR` even says:
```
TSSsegmentDescriptor(busy) := 1;
(* Locked read-modify-write operation on the entire descriptor when setting busy flag *)
```

In the future, we could also use the interior mutability of our GDT structure to add a method like:
```rust
/// Like `GlobalDescriptorTable::append()` except that it uses a shared reference.
#[inline]
pub fn append_atomic(&self, entry: Descriptor) -> SegmentSelector {
   // Atomically update the length and write the entry/entries 
}
```
which would allow for a GDT to be a normal `static` item, and eliminate some uses of `lazy_static!`.

Finally, I also added some tests to make sure that `load_tss` changing the TSS entry is actually observable.