### PR TITLE
Allow passing index as :ident in set_general_handler macro

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1170,6 +1170,9 @@ macro_rules! set_general_handler {
     ($idt:expr, $handler:ident, $idx:literal) => {
         $crate::set_general_handler!($idt, $handler, $idx..=$idx);
     };
+    ($idt:expr, $handler:ident, $idx:ident) => {
+        $crate::set_general_handler!($idt, $handler, $idx..=$idx);
+    };
     ($idt:expr, $handler:ident, $range:expr) => {{
         /// This constant is used to avoid spamming the same compilation error ~200 times
         /// when the handler's signature is wrong.


### PR DESCRIPTION
Hello, please consider this small QOL change to the set_general_handler macro.

This would allow the index to be specified by a const or variable e.g.

```rust
const PAGEFAULT: u8 = 0xe;

set_general_handler(idt, page_fault, PAGEFAULT);
```

instead of being forced to convert it to a range

```rust
set_general_handler(idt, page_fault, PAGEFAULT..PAGEFAULT)
```

I'm not sure if there's any way to make this change less repetitive by having `$idx` be either literal or ident. It might also be worth considering refactoring out the setting individual handler functionality (the `$idx` variants) into its own macro and allow users to pass a `$range:ident` to the current macro to avoid ambiguity.