### PR TITLE
add getters for the page table frame mapping

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -42,6 +42,11 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
         &mut self.level_4_table
     }
 
+    /// Returns the `PageTableFrameMapping` used for converting virtual to physical addresses.
+    pub fn page_table_frame_mapping(&self) -> &P {
+        &self.page_table_walker.page_table_frame_mapping
+    }
+
     /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
     /// https://github.com/rust-lang/rfcs/pull/2585.
     fn map_to_1gib<A>(

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -20,13 +20,13 @@ pub struct MappedPageTable<'a, P: PageTableFrameMapping> {
 }
 
 impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
-    /// Creates a new `MappedPageTable` that uses the passed closure for converting virtual
+    /// Creates a new `MappedPageTable` that uses the passed `PageTableFrameMapping` for converting virtual
     /// to physical addresses.
     ///
     /// ## Safety
     ///
     /// This function is unsafe because the caller must guarantee that the passed `page_table_frame_mapping`
-    /// closure is correct. Also, the passed `level_4_table` must point to the level 4 page table
+    /// `PageTableFrameMapping` is correct. Also, the passed `level_4_table` must point to the level 4 page table
     /// of a valid page table hierarchy. Otherwise this function might break memory safety, e.g.
     /// by writing to an illegal memory location.
     #[inline]

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -42,6 +42,11 @@ impl<'a> OffsetPageTable<'a> {
     pub fn level_4_table(&mut self) -> &mut PageTable {
         self.inner.level_4_table()
     }
+
+    /// Returns the offset used for converting virtual to physical addresses.
+    pub fn phys_offset(&self) -> VirtAddr {
+        self.inner.page_table_frame_mapping().offset
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This pr adds two getters `MappedPageTable::page_table_frame_mapping` and `OffsetPageTable::offset`. It also fixes the doc comment for `MappedPageTable::new`.