### PR TITLE
Implement conversion traits for PhysAddr and VirtAddr

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -706,6 +706,29 @@ impl Sub<PhysAddr> for PhysAddr {
     }
 }
 
+impl TryFrom<u64> for PhysAddr {
+    type Error = PhysAddrNotValid;
+
+    #[inline]
+    fn try_from(addr: u64) -> Result<Self, Self::Error> {
+        Self::try_new(addr)
+    }
+}
+
+impl From<u32> for PhysAddr {
+    #[inline]
+    fn from(addr: u32) -> Self {
+        Self::new(addr.into())
+    }
+}
+
+impl From<PhysAddr> for u64 {
+    #[inline]
+    fn from(addr: PhysAddr) -> Self {
+        addr.0
+    }
+}
+
 /// Align address downwards.
 ///
 /// Returns the greatest `x` with alignment `align` so that `x <= addr`.


### PR DESCRIPTION
Implements the following conversions:
- `TryFrom<u64>` for `VirtAddr` and `PhysAddr`
- `TryFrom<usize>` for `VirtAddr` and `PhysAddr`
- `From<u32>` for `VirtAddr` and `PhysAddr`
- `TryFrom<*const T>` for `VirtAddr`
- `TryFrom<*mut T>` for `VirtAddr`
- `From<&T>` for `VirtAddr`
- `From<&mut T>` for `VirtAddr`
- `From<VirtAddr>` for `u64`, `*const T` and `*mut T`
- `From<PhysAddr>` for `u64`

I restricted pointer and `usize` conversions with `#[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]`. This restriction isn't strictly necessary for `TryFrom`, but without it we would need a different error type than what `try_new` uses.

Closes #268.
See also [#293 (comment)](https://github.com/rust-osdev/x86_64/issues/293#issuecomment-901804330) by @josephlr.