### PR TITLE
Fix Issue #396

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1051,7 +1051,7 @@ impl SelectorErrorCode {
 
     /// The index of the selector which caused the error.
     pub fn index(&self) -> u64 {
-        self.flags.get_bits(3..16)
+        self.flags.get_bits(4..16)
     }
 
     /// If true, the #SS or #GP has returned zero as opposed to a SelectorErrorCode.

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1051,7 +1051,19 @@ impl SelectorErrorCode {
 
     /// The index of the selector which caused the error.
     pub fn index(&self) -> u64 {
-        self.flags.get_bits(4..16)
+        let descriptor_table = match self.flags.get_bits(1..3) {
+            0b00 => DescriptorTable::Gdt,
+            0b01 => DescriptorTable::Idt,
+            0b10 => DescriptorTable::Ldt,
+            0b11 => DescriptorTable::Idt,
+            _ => unreachable!(),
+        };
+        
+        if descriptor_table == DescriptorTable::Idt {
+            self.flags.get_bits(4..16)
+        } else {
+            self.flags.get_bits(3..16)
+        }
     }
 
     /// If true, the #SS or #GP has returned zero as opposed to a SelectorErrorCode.

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1051,13 +1051,7 @@ impl SelectorErrorCode {
 
     /// The index of the selector which caused the error.
     pub fn index(&self) -> u64 {
-        let descriptor_table = match self.flags.get_bits(1..3) {
-            0b00 => DescriptorTable::Gdt,
-            0b01 => DescriptorTable::Idt,
-            0b10 => DescriptorTable::Ldt,
-            0b11 => DescriptorTable::Idt,
-            _ => unreachable!(),
-        };
+        let descriptor_table = self.descriptor_table();
         
         if descriptor_table == DescriptorTable::Idt {
             self.flags.get_bits(4..16)

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1052,7 +1052,7 @@ impl SelectorErrorCode {
     /// The index of the selector which caused the error.
     pub fn index(&self) -> u64 {
         let descriptor_table = self.descriptor_table();
-        
+
         if descriptor_table == DescriptorTable::Idt {
             self.flags.get_bits(4..16)
         } else {


### PR DESCRIPTION
In 64-bit mode, the selector index is from the 4th bit onward; this attempts to get the 32-bit selector error code which causes [erroneous selector indices](https://stackoverflow.com/questions/74807148/why-would-a-np-fault-expecting-an-idt-entry-at-index-302-even-be-possible) to be returned.