### PR TITLE
fix `Page::from_page_table_indices`

### DIFF
--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -171,7 +171,7 @@ impl Page<Size1GiB> {
         let mut addr = 0;
         addr.set_bits(39..48, u64::from(p4_index));
         addr.set_bits(30..39, u64::from(p3_index));
-        Page::containing_address(VirtAddr::new(addr))
+        Page::containing_address(VirtAddr::new_truncate(addr))
     }
 }
 
@@ -189,7 +189,7 @@ impl Page<Size2MiB> {
         addr.set_bits(39..48, u64::from(p4_index));
         addr.set_bits(30..39, u64::from(p3_index));
         addr.set_bits(21..30, u64::from(p2_index));
-        Page::containing_address(VirtAddr::new(addr))
+        Page::containing_address(VirtAddr::new_truncate(addr))
     }
 }
 
@@ -209,7 +209,7 @@ impl Page<Size4KiB> {
         addr.set_bits(30..39, u64::from(p3_index));
         addr.set_bits(21..30, u64::from(p2_index));
         addr.set_bits(12..21, u64::from(p1_index));
-        Page::containing_address(VirtAddr::new(addr))
+        Page::containing_address(VirtAddr::new_truncate(addr))
     }
 
     /// Returns the level 1 page table index of this page.


### PR DESCRIPTION
When we construct the address from the page table indices, we don't make the address canonical. This was fine in the previous versions where we automatically corrected this in `VirtAddr::new`, but that's no longer the case. Instead we can use `VirtAddr::new_truncate`.