### PR TITLE
Adding `is_empty` to PageTable

### DIFF
--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -216,6 +216,12 @@ impl PageTable {
     pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut PageTableEntry> {
         self.entries.iter_mut()
     }
+
+    /// Checks if the page table is empty (all entries are zero).
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.iter().all(|entry| entry.is_unused())
+    }
 }
 
 impl Index<usize> for PageTable {


### PR DESCRIPTION
I think that this would be nice to have instead of writing
`page_table.iter().all(|entry| entry.is_unused())` all the time.
