### PR TITLE
set repr to transparent for various types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.57" # Needed to support panic! in const fns
 
 [dependencies]
 bit_field = "0.10.1"
-bitflags = "1.0.4"
+bitflags = "1.3.2"
 volatile = "0.4.4"
 rustversion = "1.0.5"
 

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -9,6 +9,7 @@ pub struct Cr0;
 
 bitflags! {
     /// Configuration flags of the [`Cr0`] register.
+    #[repr(transparent)]
     pub struct Cr0Flags: u64 {
         /// Enables protected mode.
         const PROTECTED_MODE_ENABLE = 1;
@@ -78,6 +79,7 @@ pub struct Cr4;
 
 bitflags! {
     /// Configuration flags of the [`Cr4`] register.
+    #[repr(transparent)]
     pub struct Cr4Flags: u64 {
         /// Enables hardware-supported performance enhancements for software running in
         /// virtual-8086 mode.

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -109,6 +109,7 @@ pub struct Dr6;
 
 bitflags! {
     /// Debug condition flags of the [`Dr6`] register.
+    #[repr(transparent)]
     pub struct Dr6Flags: u64 {
         /// Breakpoint condition 0 was detected.
         const TRAP0 = 1;

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -110,6 +110,7 @@ impl SCet {
 
 bitflags! {
     /// Flags of the Extended Feature Enable Register.
+    #[repr(transparent)]
     pub struct EferFlags: u64 {
         /// Enables the `syscall` and `sysret` instructions.
         const SYSTEM_CALL_EXTENSIONS = 1;
@@ -133,6 +134,7 @@ bitflags! {
 bitflags! {
     /// Flags stored in IA32_U_CET and IA32_S_CET (Table-2-2 in Intel SDM Volume
     /// 4). The Intel SDM-equivalent names are described in parentheses.
+    #[repr(transparent)]
     pub struct CetFlags: u64 {
         /// Enable shadow stack (SH_STK_EN)
         const SS_ENABLE = 1 << 0;

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -7,6 +7,7 @@ use bitflags::bitflags;
 
 bitflags! {
     /// The RFLAGS register.
+    #[repr(transparent)]
     pub struct RFlags: u64 {
         /// Processor feature identification flag.
         ///

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -10,6 +10,7 @@ bitflags! {
     ///
     /// For MPX, [`BNDREG`](XCr0Flags::BNDREG) and [`BNDCSR`](XCr0Flags::BNDCSR) must be set/unset simultaneously.
     /// For AVX-512, [`OPMASK`](XCr0Flags::OPMASK), [`ZMM_HI256`](XCr0Flags::ZMM_HI256), and [`HI16_ZMM`](XCr0Flags::HI16_ZMM) must be set/unset simultaneously.
+    #[repr(transparent)]
     pub struct XCr0Flags: u64 {
         /// Enables using the x87 FPU state
         /// with `XSAVE`/`XRSTOR`.


### PR DESCRIPTION
Now that the representation is fixed, these types can be embedded into other structures such as AMD's `VMCB` and `VMSA` or Intel's `ATTRIBUTES` (SGX).