### PR TITLE
seal off the `PageSize` trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,3 +63,10 @@ impl PrivilegeLevel {
         }
     }
 }
+
+pub(crate) mod sealed {
+    pub trait Sealed {
+        /// A string representation for debug output.
+        const DEBUG_STR: &'static str;
+    }
+}

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -86,7 +86,7 @@ impl<S: PageSize> fmt::Debug for PhysFrame<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_fmt(format_args!(
             "PhysFrame[{}]({:#x})",
-            S::SIZE_AS_DEBUG_STR,
+            S::DEBUG_STR,
             self.start_address().as_u64()
         ))
     }


### PR DESCRIPTION
Users should never implement this trait themselves. This also allows us to add more supertraits to `PageSize` and `NotGiantPageSize` without introducing a major breaking change.

This is a breaking change (though I really hope users haven't been doing this previously).