### PR TITLE
Enable `doc_auto_cfg` on `docs.rs` builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,15 @@ nightly = ["const_fn", "step_trait", "abi_x86_interrupt"]
 abi_x86_interrupt = []
 const_fn = []
 step_trait = []
+doc_auto_cfg = []
 
 # These features are no longer used and only there for backwards compatibility.
 external_asm = []
 inline_asm = []
 doc_cfg = []
+
+[package.metadata.docs.rs]
+all-features = true
 
 [package.metadata.release]
 dev-version = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
+#![cfg_attr(feature = "doc_auto_cfg", feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
This flag includes `#[cfg]` bounds in the generated documentation.

For example, the docs for the `x86_64::structures::paging::mapper` module now look like this:

![image](https://user-images.githubusercontent.com/1131315/222894491-00d65a47-fe43-4208-9105-c2413a9e8067.png)

We see that `OffsetPageTable` is now annotated with `64-bit` because the module has `#![cfg(target_pointer_width = "64")]`. Similarly, the `RecursivePageTable` struct is now annotated with `instructions` because it is `#[cfg(feature = "instructions")]`. 