### PR TITLE
Remove unused `doc_cfg` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ rustversion = "1.0.5"
 [features]
 default = ["nightly", "instructions"]
 instructions = []
-nightly = ["const_fn", "step_trait", "abi_x86_interrupt", "doc_cfg"]
+nightly = ["const_fn", "step_trait", "abi_x86_interrupt"]
 abi_x86_interrupt = []
 const_fn = []
 step_trait = []
-doc_cfg = []
 
 # These features are no longer used and only there for backwards compatibility.
 external_asm = []
 inline_asm = []
+doc_cfg = []
 
 [package.metadata.release]
 dev-version = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT add_entry()
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
-#![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
We used this unstable feature in the past for annotating nightly-only macros that require inline assembly: https://github.com/rust-osdev/x86_64/commit/17ca2b07cdee30daf9ea4c5c7d271f2cb998b00b. Now that inline assembly is stable, we don't use that feature anymore, so I think we can remove it.