### PR TITLE
run xtest bash shell

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
 
       - name: "Run Test Framework"
         run: cargo xtest
+        shell: bash
         working-directory: "testing"
 
   check_formatting:


### PR DESCRIPTION
For some reason cargo-xtest cannot be found on Windows if the shell is not set to bash. This used to work and regressed about two weeks ago for not immediately obvious reason. Considering that there is no big downside to running xtest with the bash shell, we'll just use that for now.

See https://github.com/rust-osdev/x86_64/actions/runs/4350740158 as an example of a run that fails because cargo-xtest cannot be found.