### PR TITLE
Add Descriptor::dpl const method and use it in GDT construction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,13 @@ impl PrivilegeLevel {
     ///
     /// This function panics if the passed value is >3.
     #[inline]
-    pub fn from_u16(value: u16) -> PrivilegeLevel {
+    pub const fn from_u16(value: u16) -> PrivilegeLevel {
         match value {
             0 => PrivilegeLevel::Ring0,
             1 => PrivilegeLevel::Ring1,
             2 => PrivilegeLevel::Ring2,
             3 => PrivilegeLevel::Ring3,
-            i => panic!("{} is not a valid privilege level", i),
+            _ => panic!("invalid privilege level"),
         }
     }
 }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -115,20 +115,7 @@ impl GlobalDescriptorTable {
                 index
             }
         };
-
-        let rpl = match entry {
-            Descriptor::UserSegment(value) => {
-                if DescriptorFlags::from_bits_truncate(value).contains(DescriptorFlags::DPL_RING_3)
-                {
-                    PrivilegeLevel::Ring3
-                } else {
-                    PrivilegeLevel::Ring0
-                }
-            }
-            Descriptor::SystemSegment(_, _) => PrivilegeLevel::Ring0,
-        };
-
-        SegmentSelector::new(index as u16, rpl)
+        SegmentSelector::new(index as u16, entry.dpl())
     }
 
     /// Loads the GDT in the CPU using the `lgdt` instruction. This does **not** alter any of the
@@ -187,7 +174,7 @@ impl GlobalDescriptorTable {
 ///
 /// Segmentation is no longer supported in 64-bit mode, so most of the descriptor
 /// contents are ignored.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum Descriptor {
     /// Descriptor for a code or data segment.
     ///
@@ -283,6 +270,19 @@ impl DescriptorFlags {
 }
 
 impl Descriptor {
+    /// Returns the Descriptor Privilage Level (DPL). When using this descriptor
+    /// via a [`SegmentSelector`], the `rpl` and Current Privilage Level (CPL)
+    /// must less than or equal to the DPL.
+    #[inline]
+    pub const fn dpl(self) -> PrivilegeLevel {
+        let value_low = match self {
+            Descriptor::UserSegment(v) => v,
+            Descriptor::SystemSegment(v, _) => v,
+        };
+        let dpl = (value_low & DescriptorFlags::DPL_RING_3.bits()) >> 45;
+        PrivilegeLevel::from_u16(dpl as u16)
+    }
+
     /// Creates a segment descriptor for a 64-bit kernel code segment. Suitable
     /// for use with `syscall` or 64-bit `sysenter`.
     #[inline]
@@ -407,5 +407,19 @@ mod tests {
         gdt.add_entry(Descriptor::user_data_segment());
         // We have one free slot, but the GDT requires two
         gdt.add_entry(Descriptor::tss_segment(&TSS));
+    }
+
+    #[test]
+    pub fn descriptor_dpl() {
+        assert_eq!(
+            Descriptor::kernel_code_segment().dpl(),
+            PrivilegeLevel::Ring0
+        );
+        assert_eq!(
+            Descriptor::kernel_data_segment().dpl(),
+            PrivilegeLevel::Ring0
+        );
+        assert_eq!(Descriptor::user_code_segment().dpl(), PrivilegeLevel::Ring3);
+        assert_eq!(Descriptor::user_code_segment().dpl(), PrivilegeLevel::Ring3);
     }
 }

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -202,7 +202,8 @@ bitflags! {
         const EXECUTABLE        = 1 << 43;
         /// This flag must be set for user segments (in contrast to system segments).
         const USER_SEGMENT      = 1 << 44;
-        /// The DPL for this descriptor is Ring 3. In 64-bit mode, ignored for data segments.
+        /// These two bits encode the Descriptor Privilege Level (DPL) for this descriptor.
+        /// If both bits are set, the DPL is Ring 3, if both are unset, the DPL is Ring 0.
         const DPL_RING_3        = 3 << 45;
         /// Must be set for any segment, causes a segment not present exception if not set.
         const PRESENT           = 1 << 47;
@@ -270,9 +271,10 @@ impl DescriptorFlags {
 }
 
 impl Descriptor {
-    /// Returns the Descriptor Privilage Level (DPL). When using this descriptor
-    /// via a [`SegmentSelector`], the `rpl` and Current Privilage Level (CPL)
-    /// must less than or equal to the DPL.
+    /// Returns the Descriptor Privilege Level (DPL). When using this descriptor
+    /// via a [`SegmentSelector`], the RPL and Current Privilege Level (CPL)
+    /// must less than or equal to the DPL, except for stack segments where the
+    /// RPL, CPL, and DPL must all be equal.
     #[inline]
     pub const fn dpl(self) -> PrivilegeLevel {
         let value_low = match self {


### PR DESCRIPTION
This requires making `PrivilegeLevel::from_u16` const. That, in turn, requires making the panic message slightly less informative.

Note that this is also a functional change when building a GDT. Before, if you had a User/System Segment, the RPL would always be 0, unless it was a User Segment with a DPL of 3, in which case the RPL would be 3. Now the RPL will consistently match the DPL. This seems like the more intuitive approach. However, I doubt it makes much of a difference in practice (as the RPL mechanism is sort of useless to begin with).

If this functional change is an issue, I can add in code (and documentation) to explicitly define the DPL -> RPL mapping. 