### PR TITLE
Set permissions to github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,9 @@ on:
     - cron: "40 4 * * *" # every day at 4:40
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   stable:
     name: "Test MSRV and Stable Features"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,15 @@ on:
     branches:
       - "master"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: "Release"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     timeout-minutes: 15
     environment: crates_io_release
 


### PR DESCRIPTION
### Changes

Closes #411 

- set permission to build.yml to contents read. Success run example: https://github.com/joycebrum/x86_64/actions/runs/4451339527
- set top level permission of release.yml to contents: read and grant contents: write on the job level. Considering the parmission to read on crates, I could not test it completely (although it had run with success on my fork). But considering that the GITHUB_TOKEN would basically be used to the POST on refs, the contents: write is enough.

Thanks and let me know if I missed anything.
