### PR TITLE
Bump bitflags to 2.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rust-version = "1.57" # Needed to support panic! in const fns
 
 [dependencies]
 bit_field = "0.10.1"
-bitflags = "1.3.2"
+bitflags = "2.3.2"
 volatile = "0.4.4"
 rustversion = "1.0.5"
 

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -54,7 +54,7 @@ bitflags! {
 impl Cr0Flags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }
@@ -85,7 +85,7 @@ bitflags! {
 impl Cr3Flags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }
@@ -181,7 +181,7 @@ bitflags! {
 impl Cr4Flags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -10,6 +10,7 @@ pub struct Cr0;
 bitflags! {
     /// Configuration flags of the [`Cr0`] register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Cr0Flags: u64 {
         /// Enables protected mode.
         const PROTECTED_MODE_ENABLE = 1;
@@ -64,6 +65,7 @@ bitflags! {
     /// Controls cache settings for the highest-level page table.
     ///
     /// Unused if paging is disabled or if [`PCID`](Cr4Flags::PCID) is enabled.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Cr3Flags: u64 {
         /// Use a writethrough cache policy for the table (otherwise a writeback policy is used).
         const PAGE_LEVEL_WRITETHROUGH = 1 << 3;
@@ -80,6 +82,7 @@ pub struct Cr4;
 bitflags! {
     /// Configuration flags of the [`Cr4`] register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Cr4Flags: u64 {
         /// Enables hardware-supported performance enhancements for software running in
         /// virtual-8086 mode.

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -51,6 +51,14 @@ bitflags! {
     }
 }
 
+impl Cr0Flags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 /// Contains the Page Fault Linear Address (PFLA).
 ///
 /// When a page fault occurs, the CPU sets this register to the faulting virtual address.
@@ -71,6 +79,14 @@ bitflags! {
         const PAGE_LEVEL_WRITETHROUGH = 1 << 3;
         /// Disable caching for the table.
         const PAGE_LEVEL_CACHE_DISABLE = 1 << 4;
+    }
+}
+
+impl Cr3Flags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 
@@ -159,6 +175,14 @@ bitflags! {
         /// Also enables the `IA32_PKRS` MSR to set supervisor-mode protection
         /// key access controls.
         const PROTECTION_KEY_SUPERVISOR = 1 << 24;
+    }
+}
+
+impl Cr4Flags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -160,6 +160,12 @@ impl Dr6Flags {
             DebugAddressRegisterNumber::Dr3 => Self::TRAP3,
         }
     }
+
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
 }
 
 bitflags! {
@@ -232,6 +238,12 @@ impl Dr7Flags {
             DebugAddressRegisterNumber::Dr2 => Self::GLOBAL_BREAKPOINT_2_ENABLE,
             DebugAddressRegisterNumber::Dr3 => Self::GLOBAL_BREAKPOINT_3_ENABLE,
         }
+    }
+
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -110,6 +110,7 @@ pub struct Dr6;
 bitflags! {
     /// Debug condition flags of the [`Dr6`] register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Dr6Flags: u64 {
         /// Breakpoint condition 0 was detected.
         const TRAP0 = 1;
@@ -124,7 +125,7 @@ bitflags! {
         const TRAP3 = 1 << 3;
 
         /// Breakpoint condition was detected.
-        const TRAP = Self::TRAP0.bits | Self::TRAP1.bits | Self::TRAP2.bits | Self::TRAP3.bits;
+        const TRAP = Self::TRAP0.bits() | Self::TRAP1.bits() | Self::TRAP2.bits() | Self::TRAP3.bits();
 
         /// Next instruction accesses one of the debug registers.
         ///
@@ -164,6 +165,7 @@ impl Dr6Flags {
 bitflags! {
     /// Debug control flags of the [`Dr7`] register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct Dr7Flags: u64 {
         /// Breakpoint 0 is enabled for the current task.
         const LOCAL_BREAKPOINT_0_ENABLE = 1;

--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -163,7 +163,7 @@ impl Dr6Flags {
 
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }
@@ -242,7 +242,7 @@ impl Dr7Flags {
 
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -135,7 +135,7 @@ bitflags! {
 impl EferFlags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }
@@ -168,7 +168,7 @@ bitflags! {
 impl CetFlags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -111,6 +111,7 @@ impl SCet {
 bitflags! {
     /// Flags of the Extended Feature Enable Register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct EferFlags: u64 {
         /// Enables the `syscall` and `sysret` instructions.
         const SYSTEM_CALL_EXTENSIONS = 1;
@@ -135,6 +136,7 @@ bitflags! {
     /// Flags stored in IA32_U_CET and IA32_S_CET (Table-2-2 in Intel SDM Volume
     /// 4). The Intel SDM-equivalent names are described in parentheses.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct CetFlags: u64 {
         /// Enable shadow stack (SH_STK_EN)
         const SS_ENABLE = 1 << 0;

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -132,6 +132,14 @@ bitflags! {
     }
 }
 
+impl EferFlags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 bitflags! {
     /// Flags stored in IA32_U_CET and IA32_S_CET (Table-2-2 in Intel SDM Volume
     /// 4). The Intel SDM-equivalent names are described in parentheses.
@@ -154,6 +162,14 @@ bitflags! {
         const IBT_SUPPRESS_ENABLE = 1 << 10;
         /// Is IBT waiting for a branch to return? (read-only, TRACKER)
         const IBT_TRACKED = 1 << 11;
+    }
+}
+
+impl CetFlags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
     }
 }
 

--- a/src/registers/mxcsr.rs
+++ b/src/registers/mxcsr.rs
@@ -8,6 +8,7 @@ use bitflags::bitflags;
 bitflags! {
     /// MXCSR register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct MxCsr: u32 {
         /// Invalid operation
         const INVALID_OPERATION = 1 << 0;

--- a/src/registers/mxcsr.rs
+++ b/src/registers/mxcsr.rs
@@ -60,6 +60,14 @@ impl Default for MxCsr {
     }
 }
 
+impl MxCsr {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u32) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;

--- a/src/registers/mxcsr.rs
+++ b/src/registers/mxcsr.rs
@@ -63,7 +63,7 @@ impl Default for MxCsr {
 impl MxCsr {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u32) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u32) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -64,6 +64,14 @@ bitflags! {
     }
 }
 
+impl RFlags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -8,6 +8,7 @@ use bitflags::bitflags;
 bitflags! {
     /// The RFLAGS register.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct RFlags: u64 {
         /// Processor feature identification flag.
         ///

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -67,7 +67,7 @@ bitflags! {
 impl RFlags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -53,6 +53,14 @@ bitflags! {
     }
 }
 
+impl XCr0Flags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 #[cfg(feature = "instructions")]
 mod x86_64 {
     use super::*;

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -56,7 +56,7 @@ bitflags! {
 impl XCr0Flags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -11,6 +11,7 @@ bitflags! {
     /// For MPX, [`BNDREG`](XCr0Flags::BNDREG) and [`BNDCSR`](XCr0Flags::BNDCSR) must be set/unset simultaneously.
     /// For AVX-512, [`OPMASK`](XCr0Flags::OPMASK), [`ZMM_HI256`](XCr0Flags::ZMM_HI256), and [`HI16_ZMM`](XCr0Flags::HI16_ZMM) must be set/unset simultaneously.
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct XCr0Flags: u64 {
         /// Enables using the x87 FPU state
         /// with `XSAVE`/`XRSTOR`.

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -269,6 +269,12 @@ impl DescriptorFlags {
     /// A 64-bit user code segment
     pub const USER_CODE64: Self =
         Self::from_bits_truncate(Self::KERNEL_CODE64.bits() | Self::DPL_RING_3.bits());
+
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
 }
 
 impl Descriptor {

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -187,6 +187,7 @@ pub enum Descriptor {
 
 bitflags! {
     /// Flags for a GDT descriptor. Not all flags are valid for all descriptor types.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct DescriptorFlags: u64 {
         /// Set by the processor if this segment has been accessed. Only cleared by software.
         /// _Setting_ this bit in software prevents GDT writes on first use.

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -272,7 +272,7 @@ impl DescriptorFlags {
 
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1012,7 +1012,7 @@ bitflags! {
 impl PageFaultErrorCode {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -968,6 +968,7 @@ bitflags! {
     ///   * AMD Volume 2: 8.4.2
     ///   * Intel Volume 3A: 4.7
     #[repr(transparent)]
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct PageFaultErrorCode: u64 {
         /// If this flag is set, the page fault was caused by a page-protection violation,
         /// else the page fault was caused by a not-present page.

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1009,6 +1009,14 @@ bitflags! {
     }
 }
 
+impl PageFaultErrorCode {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 /// Describes an error code referencing a segment selector.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -172,7 +172,7 @@ bitflags! {
 impl PageTableFlags {
     #[deprecated = "use the safe `from_bits_retain` method instead"]
     /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
-    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+    pub const unsafe fn from_bits_unchecked(bits: u64) -> Self {
         Self::from_bits_retain(bits)
     }
 }

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -106,6 +106,7 @@ impl fmt::Debug for PageTableEntry {
 
 bitflags! {
     /// Possible flags for a page table entry.
+    #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct PageTableFlags: u64 {
         /// Specifies whether the mapped frame or page table is loaded in memory.
         const PRESENT =         1;

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -169,6 +169,14 @@ bitflags! {
     }
 }
 
+impl PageTableFlags {
+    #[deprecated = "use the safe `from_bits_retain` method instead"]
+    /// Convert from underlying bit representation, preserving all bits (even those not corresponding to a defined flag).
+    pub unsafe fn from_bits_unchecked(bits: u64) -> Self {
+        Self::from_bits_retain(bits)
+    }
+}
+
 /// The number of entries in a page table.
 const ENTRY_COUNT: usize = 512;
 


### PR DESCRIPTION
All of the types that use `bitflags!` have `#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]` on them to preserve backwards compatability as recommended by the bitflags changelog.