### PR TITLE
Add the `iretq` function to the `InterruptStackFrameValue` struct.

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -955,6 +955,7 @@ impl InterruptStackFrameValue {
     /// CS and SS register can all cause undefined behaviour when done incorrectly.
     ///
     #[inline(always)]
+    #[cfg(feature = "instructions")]
     pub unsafe fn iretq(&self) -> ! {
         unsafe {
             core::arch::asm!(

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -959,7 +959,7 @@ impl InterruptStackFrameValue {
     pub unsafe fn iretq(&self) -> ! {
         unsafe {
             core::arch::asm!(
-                "push {data_segment}",
+                "push {stack_segment}",
                 "push {new_stack_pointer}",
                 "push {rflags}",
                 "push {code_segment}",
@@ -969,7 +969,7 @@ impl InterruptStackFrameValue {
                 new_instruction_pointer = in(reg) self.instruction_pointer.as_u64(),
                 new_stack_pointer = in(reg) self.stack_pointer.as_u64(),
                 code_segment = in(reg) self.code_segment,
-                data_segment = in(reg) self.stack_segment,
+                stack_segment = in(reg) self.stack_segment,
                 options(noreturn)
             )
         }

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -945,7 +945,7 @@ pub struct InterruptStackFrameValue {
 impl InterruptStackFrameValue {
     /// Call the `iretq` (interrupt return) instruction.
     ///
-    /// It is not required to be in a interrupt handler to be able to call this instruction.
+    /// This function doesn't have to be called in an interrupt handler.
     /// By manually construction a new [`InterruptStackFrameValue`] it's possible to transition
     /// from a higher privilege level to a lower one.
     ///


### PR DESCRIPTION
I've added the `iretq` function that can be used to transition from a higher privilege level to a lower privilege level. This can be useful when implementing multitasking for example. 