### PR TITLE
fix(interrupts): add compiler fences to enable and disable

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -1,6 +1,7 @@
 //! Enabling and disabling interrupts
 
 use core::arch::asm;
+use core::sync::atomic::{compiler_fence, Ordering};
 
 /// Returns whether interrupts are enabled.
 #[inline]
@@ -15,6 +16,8 @@ pub fn are_enabled() -> bool {
 /// This is a wrapper around the `sti` instruction.
 #[inline]
 pub fn enable() {
+    // Prevent earlier writes to be moved beyond this point
+    compiler_fence(Ordering::Release);
     unsafe {
         asm!("sti", options(nomem, nostack));
     }
@@ -25,6 +28,8 @@ pub fn enable() {
 /// This is a wrapper around the `cli` instruction.
 #[inline]
 pub fn disable() {
+    // Prevent future writes to be moved before this point.
+    compiler_fence(Ordering::Acquire);
     unsafe {
         asm!("cli", options(nomem, nostack));
     }


### PR DESCRIPTION
This actually bit me on AArch64, but this should apply to x86-64 as well:

Without this PR, the compiler may reorder memory accesses over these `asm!` calls. While `interrupts::enable` and `interrupts::disable` don't make claims about synchronizations, the docs strongly imply synchronization of the calling thread with _itself_.

Essentially, without compiler fences, code after `interrupts::disable` may still execute while interrupts are enabled. Conversely, code before `interrupts::enable` may only execute after interrupts have been enabled. This also translates to `without_interrupts`: code inside the closure may actually execute _with_ interrupts.

This bug may require very specific conditions to show up. In my case ([the Hermit kernel](https://github.com/hermit-os/kernel)), some aggressive inlining resulted in improper access to a `RefCell` from an interrupt handler.

What do you think? :)