### PR TITLE
fix(interrupts): replace compiler fences with potentially-synchronizing assembly

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -1,7 +1,6 @@
 //! Enabling and disabling interrupts
 
 use core::arch::asm;
-use core::sync::atomic::{compiler_fence, Ordering};
 
 /// Returns whether interrupts are enabled.
 #[inline]
@@ -16,10 +15,10 @@ pub fn are_enabled() -> bool {
 /// This is a wrapper around the `sti` instruction.
 #[inline]
 pub fn enable() {
-    // Prevent earlier writes to be moved beyond this point
-    compiler_fence(Ordering::Release);
+    // Omit `nomem` to imitate a lock release. Otherwise, the compiler
+    // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("sti", options(nomem, nostack));
+        asm!("sti", options(nostack));
     }
 }
 
@@ -28,10 +27,10 @@ pub fn enable() {
 /// This is a wrapper around the `cli` instruction.
 #[inline]
 pub fn disable() {
-    // Prevent future writes to be moved before this point.
-    compiler_fence(Ordering::Acquire);
+    // Omit `nomem` to imitate a lock acquire. Otherwise, the compiler
+    // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("cli", options(nomem, nostack));
+        asm!("cli", options(nostack));
     }
 }
 

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -18,7 +18,7 @@ pub fn enable() {
     // Omit `nomem` to imitate a lock release. Otherwise, the compiler
     // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("sti", options(nostack));
+        asm!("sti", options(preserves_flags, nostack));
     }
 }
 
@@ -30,7 +30,7 @@ pub fn disable() {
     // Omit `nomem` to imitate a lock acquire. Otherwise, the compiler
     // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("cli", options(nostack));
+        asm!("cli", options(preserves_flags, nostack));
     }
 }
 


### PR DESCRIPTION
Follow up on https://github.com/rust-osdev/x86_64/pull/436.

I am sorry to open this discussion again, but the previous PR is not sufficient to prevent unexpected behavior.

Compiler fences only synchronize with atomic instructions. When creating a thread-local critical section, we need to prevent reordering of any reads and writes across interrupt toggles, not just atomic ones. To achieve this, we omit `nomem` from `asm!`. Since then, the assembly might potentially perform synchronizing operations such as acquiring or releasing a lock, the compiler won't move any reads and writes through these assembly blocks.

See https://github.com/mkroening/interrupt-ref-cell/issues/5#issuecomment-1753047784.

As an unrelated optimization, I also added `preserves_flags` here, since `IF` from `EFLAGS` must not be restored upon exiting the `asm` block when specifying `perserves_flags`: [Rules for inline assembly—Inline assembly—The Rust Reference](https://doc.rust-lang.org/stable/reference/inline-assembly.html#rules-for-inline-assembly)