### PR TITLE
Make GlobalDescriptorTable const generic

### DIFF
--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -9,7 +9,7 @@ pub use crate::structures::DescriptorTablePointer;
 /// Load a GDT.
 ///
 /// Use the
-/// [`GlobalDescriptorTable`](crate::structures::gdt::GlobalDescriptorTable) struct for a high-level
+/// [`BasicGlobalDescriptorTable`](crate::structures::gdt::BasicGlobalDescriptorTable) struct for a high-level
 /// interface to loading a GDT.
 ///
 /// ## Safety

--- a/src/registers/segmentation.rs
+++ b/src/registers/segmentation.rs
@@ -8,13 +8,13 @@ use core::fmt;
 #[cfg(doc)]
 use crate::{
     registers::control::Cr4Flags,
-    structures::gdt::{Descriptor, DescriptorFlags, GlobalDescriptorTable},
+    structures::gdt::{Descriptor, DescriptorFlags, BasicGlobalDescriptorTable},
 };
 
 /// An x86 segment
 ///
 /// Segment registers on x86 are 16-bit [`SegmentSelector`]s, which index into
-/// the [`GlobalDescriptorTable`]. The corresponding GDT entry is used to
+/// the [`BasicGlobalDescriptorTable`]. The corresponding GDT entry is used to
 /// configure the segment itself. Note that most segmentation functionality is
 /// disabled in 64-bit mode. See the individual segments for more information.
 pub trait Segment {


### PR DESCRIPTION
To avoid breaking compatibility, renamed to `BasicGlobalDescriptorTable`, and made `GlobalDescriptorTable` be an alias with 8 entreis.

Went with the rename + alias approach due to [this](https://github.com/rust-osdev/x86_64/issues/395#issuecomment-1312283775) issue.