### PR TITLE
CI: Run `semver-checks` using stable Rust

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,4 +236,4 @@ jobs:
           cache-targets: false
       - run: cargo install cargo-semver-checks --locked
       - name: Check semver
-        run: cargo semver-checks check-release
+        run: cargo +stable semver-checks check-release


### PR DESCRIPTION
Looks like the semver checks work on stable even though we're using some unstable features.

This fixes the failing semver checks CI job.