### PR TITLE
Update docs to clarify new `set_handler_fn` behavior

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -22,6 +22,7 @@
 - [Add structures::gdt::Entry type](https://github.com/rust-osdev/x86_64/pull/380)
 - [Allow GDT to be loaded with shared reference](https://github.com/rust-osdev/x86_64/pull/381)
 - [seal off the `PageSize` trait](https://github.com/rust-osdev/x86_64/pull/404)
+- [idt: Fixup Options structure and cleanup set_handler_fn](https://github.com/rust-osdev/x86_64/pull/226)
 
 ## New Features
 
@@ -33,10 +34,6 @@
 - [activate `feature(asm_const)`](https://github.com/rust-osdev/x86_64/pull/320)
 - [gdt: Check that MAX is in range](https://github.com/rust-osdev/x86_64/pull/365)
 - [fix `Page::from_page_table_indices`](https://github.com/rust-osdev/x86_64/pull/398)
-
-## Other improvements
-
-- [idt: Fixup Options structure and cleanup set_handler_fn](https://github.com/rust-osdev/x86_64/pull/226)
 
 # 0.14.11 – 2023-09-15
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -771,10 +771,12 @@ impl<F> Entry<F> {
         }
     }
 
-    /// Set the handler address for the IDT entry and sets the present bit.
-    ///
-    /// For the code selector field, this function uses the code segment selector currently
-    /// active in the CPU.
+    /// Sets the handler address for the IDT entry and sets the following defaults:
+    ///   - The code selector is the code segment currently active in the CPU
+    ///   - The present bit is set
+    ///   - Interrupts are disabled on handler invocation
+    ///   - The privilege level (DPL) is [`PrivilegeLevel::Ring0`]
+    ///   - No IST is configured (existing stack will be used)
     ///
     /// The function returns a mutable reference to the entry's options that allows
     /// further customization.
@@ -814,10 +816,12 @@ impl<F> Entry<F> {
 
 #[cfg(feature = "instructions")]
 impl<F: HandlerFuncType> Entry<F> {
-    /// Set the handler function for the IDT entry and sets the present bit.
-    ///
-    /// For the code selector field, this function uses the code segment selector currently
-    /// active in the CPU.
+    /// Sets the handler function for the IDT entry and sets the following defaults:
+    ///   - The code selector is the code segment currently active in the CPU
+    ///   - The present bit is set
+    ///   - Interrupts are disabled on handler invocation
+    ///   - The privilege level (DPL) is [`PrivilegeLevel::Ring0`]
+    ///   - No IST is configured (existing stack will be used)
     ///
     /// The function returns a mutable reference to the entry's options that allows
     /// further customization.


### PR DESCRIPTION
- Update docs to clarify new defaults for `set_handler_fn`
  - Use the doc comment introduced in https://github.com/rust-osdev/x86_64/pull/226.
- List new IDT defaults as breaking change in changelog
