### PR TITLE
mark as 0.15 as beta release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Cache binaries
         id: cache-bin
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: binaries
           key: ${{ runner.OS }}-binaries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.15.0"
+version = "0.15.0-beta"
 edition = "2018"
 rust-version = "1.59" # Needed to support inline asm and default const generics
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-# 0.15.0 – 2024-01-14
+# 0.15.0-beta – 2024-02-08
 
 ## Breaking changes
 

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -189,11 +189,9 @@ impl Page<Size1GiB> {
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
     ) -> Self {
-        use bit_field::BitField;
-
         let mut addr = 0;
-        addr.set_bits(39..48, u64::from(p4_index));
-        addr.set_bits(30..39, u64::from(p3_index));
+        addr |= u64::from(p4_index) << 39;
+        addr |= u64::from(p3_index) << 30;
         Page::containing_address(VirtAddr::new_truncate(addr))
     }
 }
@@ -206,12 +204,10 @@ impl Page<Size2MiB> {
         p3_index: PageTableIndex,
         p2_index: PageTableIndex,
     ) -> Self {
-        use bit_field::BitField;
-
         let mut addr = 0;
-        addr.set_bits(39..48, u64::from(p4_index));
-        addr.set_bits(30..39, u64::from(p3_index));
-        addr.set_bits(21..30, u64::from(p2_index));
+        addr |= u64::from(p4_index) << 39;
+        addr |= u64::from(p3_index) << 30;
+        addr |= u64::from(p2_index) << 21;
         Page::containing_address(VirtAddr::new_truncate(addr))
     }
 }
@@ -225,13 +221,11 @@ impl Page<Size4KiB> {
         p2_index: PageTableIndex,
         p1_index: PageTableIndex,
     ) -> Self {
-        use bit_field::BitField;
-
         let mut addr = 0;
-        addr.set_bits(39..48, u64::from(p4_index));
-        addr.set_bits(30..39, u64::from(p3_index));
-        addr.set_bits(21..30, u64::from(p2_index));
-        addr.set_bits(12..21, u64::from(p1_index));
+        addr |= u64::from(p4_index) << 39;
+        addr |= u64::from(p3_index) << 30;
+        addr |= u64::from(p2_index) << 21;
+        addr |= u64::from(p1_index) << 12;
         Page::containing_address(VirtAddr::new_truncate(addr))
     }
 

--- a/testing/x86_64-bare-metal.json
+++ b/testing/x86_64-bare-metal.json
@@ -1,6 +1,6 @@
 {
   "llvm-target": "x86_64-unknown-none",
-  "data-layout": "e-m:e-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
   "target-pointer-width": "64",


### PR DESCRIPTION
Following this PR, we can then immediately open up another PR merging `next` into `master`. There shouldn't be any conflicts because we recently merged `master` into `next`.