### PR TITLE
Release v0.14.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.14.11"
+version = "0.14.12"
 edition = "2018"
 rust-version = "1.57" # Needed to support panic! in const fns
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,20 @@
 # Unreleased
 
+# 0.14.12 – 2023-02-09
+
 ## New Features
 
 - [Add `HandlerFuncType` trait](https://github.com/rust-osdev/x86_64/pull/439)
+- [Support `VirtAddr::from_ptr` for `T: ?Sized`](https://github.com/rust-osdev/x86_64/pull/442)
+- [Expose `Cr3::write_raw`](https://github.com/rust-osdev/x86_64/pull/445)
+
+## Fixes
+
+- [Use synchronizing assembly for `interrupts::enable`/`disable`](https://github.com/rust-osdev/x86_64/pull/440)
+
+## Other Improvements
+
+- [Optimize `Page::from_page_table_indices`](https://github.com/rust-osdev/x86_64/pull/456)
 
 # 0.14.11 – 2022-09-15
 


### PR DESCRIPTION
This will be the last non-breaking release before v0.15

Updates the Changelog to include all changes (except for those related to testing/CI).