### PR TITLE
Update data layout of test target for LLVM 18

### DIFF
--- a/testing/x86_64-bare-metal.json
+++ b/testing/x86_64-bare-metal.json
@@ -1,6 +1,6 @@
 {
   "llvm-target": "x86_64-unknown-none",
-  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
   "target-pointer-width": "64",


### PR DESCRIPTION
Should fix the "Bootloader Integration Test" job on CI.