### PR TITLE
properly jump the address gap in CleanUp

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -646,7 +646,11 @@ impl<'a, P: PageTableFrameMapping> CleanUp for MappedPageTable<'a, P> {
                     .skip(usize::from(start))
                 {
                     if let Ok(page_table) = page_table_walker.next_table_mut(entry) {
-                        let start = table_addr + (offset_per_entry * (i as u64));
+                        let start = VirtAddr::forward_checked_impl(
+                            table_addr,
+                            (offset_per_entry as usize) * i,
+                        )
+                        .unwrap();
                         let end = start + (offset_per_entry - 1);
                         let start = Page::<Size4KiB>::containing_address(start);
                         let start = start.max(range.start);

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -891,7 +891,11 @@ impl<'a> CleanUp for RecursivePageTable<'a> {
                     })
                 {
                     if let Ok(frame) = entry.frame() {
-                        let start = table_addr + (offset_per_entry * (i as u64));
+                        let start = VirtAddr::forward_checked_impl(
+                            table_addr,
+                            (offset_per_entry as usize) * i,
+                        )
+                        .unwrap();
                         let end = start + (offset_per_entry - 1);
                         let start = Page::<Size4KiB>::containing_address(start);
                         let start = start.max(range.start);


### PR DESCRIPTION
Starting with 0.15, the addition operator will no longer implicitly jump the gap in the address space. Instead, we can use Step::forward.

Fixes #468