### PR TITLE
expose DEBUG_STR more directly

### DIFF
--- a/src/instructions/port.rs
+++ b/src/instructions/port.rs
@@ -68,7 +68,10 @@ impl PortWrite for u32 {
 }
 
 /// A marker trait for access types which allow accessing port values.
-pub trait PortAccess: Sealed {}
+pub trait PortAccess: Sealed {
+    /// A string representation for debug output.
+    const DEBUG_STR: &'static str;
+}
 
 /// A marker trait for access types which allow reading port values.
 pub trait PortReadAccess: PortAccess {}
@@ -80,30 +83,30 @@ pub trait PortWriteAccess: PortAccess {}
 #[derive(Debug)]
 pub struct ReadOnlyAccess(());
 
-impl Sealed for ReadOnlyAccess {
+impl Sealed for ReadOnlyAccess {}
+impl PortAccess for ReadOnlyAccess {
     const DEBUG_STR: &'static str = "ReadOnly";
 }
-impl PortAccess for ReadOnlyAccess {}
 impl PortReadAccess for ReadOnlyAccess {}
 
 /// An access marker type indicating that a port is only allowed to write values.
 #[derive(Debug)]
 pub struct WriteOnlyAccess(());
 
-impl Sealed for WriteOnlyAccess {
+impl Sealed for WriteOnlyAccess {}
+impl PortAccess for WriteOnlyAccess {
     const DEBUG_STR: &'static str = "WriteOnly";
 }
-impl PortAccess for WriteOnlyAccess {}
 impl PortWriteAccess for WriteOnlyAccess {}
 
 /// An access marker type indicating that a port is allowed to read or write values.
 #[derive(Debug)]
 pub struct ReadWriteAccess(());
 
-impl Sealed for ReadWriteAccess {
+impl Sealed for ReadWriteAccess {}
+impl PortAccess for ReadWriteAccess {
     const DEBUG_STR: &'static str = "ReadWrite";
 }
-impl PortAccess for ReadWriteAccess {}
 impl PortReadAccess for ReadWriteAccess {}
 impl PortWriteAccess for ReadWriteAccess {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,8 +65,5 @@ impl PrivilegeLevel {
 }
 
 pub(crate) mod sealed {
-    pub trait Sealed {
-        /// A string representation for debug output.
-        const DEBUG_STR: &'static str;
-    }
+    pub trait Sealed {}
 }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -14,6 +14,9 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 pub trait PageSize: Copy + Eq + PartialOrd + Ord + Sealed {
     /// The page size in bytes.
     const SIZE: u64;
+
+    /// A string representation of the page size for debug output.
+    const DEBUG_STR: &'static str;
 }
 
 /// This trait is implemented for 4KiB and 2MiB pages, but not for 1GiB pages.
@@ -35,31 +38,28 @@ pub enum Size1GiB {}
 
 impl PageSize for Size4KiB {
     const SIZE: u64 = 4096;
+    const DEBUG_STR: &'static str = "4KiB";
 }
 
 impl NotGiantPageSize for Size4KiB {}
 
-impl Sealed for super::Size4KiB {
-    const DEBUG_STR: &'static str = "4KiB";
-}
+impl Sealed for super::Size4KiB {}
 
 impl PageSize for Size2MiB {
     const SIZE: u64 = Size4KiB::SIZE * 512;
+    const DEBUG_STR: &'static str = "2MiB";
 }
 
 impl NotGiantPageSize for Size2MiB {}
 
-impl Sealed for super::Size2MiB {
-    const DEBUG_STR: &'static str = "2MiB";
-}
+impl Sealed for super::Size2MiB {}
 
 impl PageSize for Size1GiB {
     const SIZE: u64 = Size2MiB::SIZE * 512;
-}
-
-impl Sealed for super::Size1GiB {
     const DEBUG_STR: &'static str = "1GiB";
 }
+
+impl Sealed for super::Size1GiB {}
 
 /// A virtual memory page.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
The constant is Sealed::DEBUG_STR was also already exposed to users in its subtraits, but due to Sealed being unnamable reading DEBUG_STR was somewhat difficult. Moving the associated constants from the supertrait into the subtraits isn't a breaking change and makes it a bit more convenient to reference.

Fixes #470