### PR TITLE
add write_pcid_no_flush

### DIFF
--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -326,6 +326,21 @@ mod x86_64 {
             }
         }
 
+        /// Write a new P4 table address into the CR3 register without flushing existing TLB entries for
+        /// the PCID.
+        ///
+        /// ## Safety
+        ///
+        /// Changing the level 4 page table is unsafe, because it's possible to violate memory safety by
+        /// changing the page mapping.
+        /// [`Cr4Flags::PCID`] must be set before calling this method.
+        #[inline]
+        pub unsafe fn write_pcid_no_flush(frame: PhysFrame, pcid: Pcid) {
+            unsafe {
+                Cr3::write_raw_impl(true, frame, pcid.value());
+            }
+        }
+
         /// Write a new P4 table address into the CR3 register.
         ///
         /// ## Safety


### PR DESCRIPTION
If Cr4.PCID is set and the 63rd bit is clear when moving into Cr3, the processor flushes all TLB entries for the given PCID (Intel SDM, Volume 3, 4.10.4.1 and AMD APM, Volume 2, 5.5.1). This is similar to the operation without PCID in which the processor also flushes all TLB entries every time a new value is moved into Cr3. Given that the entire idea behind PCIDs is to not flush all entries when Cr3 is changed, we should also provide a write method that sets the 63rd bit when moving into Cr3. This PR adds `write_pcid_no_flush` to do just that.

A very quick and dirty comparison between `write_pcid` and `write_pcid_no_flush` showed a ~~10%~~ 25+% performance improvement.

It could be argued that setting the 63rd bit should be the default, however, I'm a bit concerned that users rely on the flushing behavior (either intentionally or unintentionally) and so suddenly changing to non-flushing behavior could break code (This seems to be the case for a codebase I'm working on).  In a future breaking release, we may want to change `write_pcid` to take an additional parameter specifying whether flushing behavior is intended.