### PR TITLE
chore: migrate from legacy `rust-toolchain` to `rust-toolchain.toml`

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,0 @@
-nightly

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
See [The toolchain file - Overrides - The rustup book](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file).