### PR TITLE
CI: Set `-Crelocation-model=static` in `RUSTFLAGS` for bootloader test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 15
 
+    env:
+      RUSTFLAGS: -Crelocation-model=static -Dwarnings
+
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v4


### PR DESCRIPTION
In d3b9c0573800b2e888486037e09d43ffd3ffcb97, we switched our test framework to the built-in x86_64-unknown-none target. This required a `-Crelocation-model=static` flag to work with bootloader v0.9, which we set using a `build.rustflags` config key.

In 2eb838d101cdd179d6395f79f87916a48e8c1935, we set a `RUSTFLAGS` env variable on CI to deny warnings.

Unfortunately, the above two commits conflict because the `RUSTFLAGS` env variable [takes precedence](https://doc.rust-lang.org/cargo/reference/config.html#buildrustflags) over the `build.rustflags` key. This commit fixes this by setting an explicit `RUSTFLAGS` value for the bootloader test job that contains both flags.

This should fix the CI [build errors](https://github.com/rust-osdev/x86_64/actions/runs/8594672305/job/23548107284).