### PR TITLE
silence warning about cast

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -857,6 +857,12 @@ macro_rules! impl_handler_func_type {
         unsafe impl HandlerFuncType for $f {
             #[inline]
             fn to_virt_addr(self) -> VirtAddr {
+                // Casting a function pointer to u64 is fine, if the pointer
+                // width doesn't exeed 64 bits.
+                #[cfg_attr(
+                    any(target_pointer_width = "32", target_pointer_width = "64"),
+                    allow(clippy::fn_to_numeric_cast)
+                )]
                 VirtAddr::new(self as u64)
             }
         }


### PR DESCRIPTION
The lint exists to warn about incompatibilities with different architectures, but this code only runs on x86-64 anyway, so portability is not a concern.

This fixes a nightly breakage.