### PR TITLE
add Mapper::clear to clear any page table entry regardless of present flag

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Breaking changes
 
 - [add `Mapper::clear` to clear any page table entry regardless of the present flag](https://github.com/rust-osdev/x86_64/pull/484)
+- [`Mapper::unmap` now also returns the flags of the page ](https://github.com/rust-osdev/x86_64/pull/484)
 
 # 0.15.1 – 2024-03-19
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Breaking changes
+
+- [add `Mapper::clear` to clear any page table entry regardless of the present flag](https://github.com/rust-osdev/x86_64/pull/484)
+
 # 0.15.1 – 2024-03-19
 
 ## New Features

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -169,7 +169,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
     fn unmap(
         &mut self,
         page: Page<Size1GiB>,
-    ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size1GiB>, PageTableFlags, MapperFlush<Size1GiB>), UnmapError> {
         let p4 = &mut self.level_4_table;
         let p3 = self
             .page_table_walker
@@ -189,7 +189,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
             .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(p3_entry.addr()))?;
 
         p3_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size1GiB>) -> Result<UnmappedFrame<Size1GiB>, UnmapError> {
@@ -309,7 +309,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
-    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size2MiB>, PageTableFlags, MapperFlush<Size2MiB>), UnmapError> {
         let p4 = &mut self.level_4_table;
         let p3 = self
             .page_table_walker
@@ -332,7 +332,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
             .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(p2_entry.addr()))?;
 
         p2_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size2MiB>) -> Result<UnmappedFrame<Size2MiB>, UnmapError> {
@@ -470,7 +470,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
-    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size4KiB>, PageTableFlags, MapperFlush<Size4KiB>), UnmapError> {
         let p4 = &mut self.level_4_table;
         let p3 = self
             .page_table_walker
@@ -488,9 +488,10 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
+        let flags = p1_entry.flags();
 
         p1_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size4KiB>) -> Result<UnmappedFrame<Size4KiB>, UnmapError> {

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -9,7 +9,7 @@ pub use self::recursive_page_table::{InvalidPageTable, RecursivePageTable};
 use crate::structures::paging::{
     frame_alloc::{FrameAllocator, FrameDeallocator},
     page::PageRangeInclusive,
-    page_table::PageTableFlags,
+    page_table::{PageTableEntry, PageTableFlags},
     Page, PageSize, PhysFrame, Size1GiB, Size2MiB, Size4KiB,
 };
 use crate::{PhysAddr, VirtAddr};
@@ -284,6 +284,14 @@ pub trait Mapper<S: PageSize> {
     /// Note that no page tables or pages are deallocated.
     fn unmap(&mut self, page: Page<S>) -> Result<(PhysFrame<S>, MapperFlush<S>), UnmapError>;
 
+    /// Clears a mapping from the page table and returns the frame that used to be mapped.
+    ///
+    /// Unlike [`Mapper::unmap`] this will ignore the present flag of the page and will successfully
+    /// clear the table entry for any valid page.
+    ///
+    /// Note that no page tables or pages are deallocated.
+    fn clear(&mut self, page: Page<S>) -> Result<UnmappedFrame<S>, UnmapError>;
+
     /// Updates the flags of an existing mapping.
     ///
     /// To read the current flags of a mapped page, use the [`Translate::translate`] method.
@@ -374,6 +382,27 @@ pub trait Mapper<S: PageSize> {
         let page = Page::containing_address(VirtAddr::new(frame.start_address().as_u64()));
         unsafe { self.map_to(page, frame, flags, frame_allocator) }
     }
+}
+
+/// The result of [`Mapper::clear`], representing either
+/// the unmapped frame or the entry data if the frame is not marked as present.
+#[derive(Debug)]
+#[must_use = "Page table changes must be flushed or ignored if the page is present."]
+pub enum UnmappedFrame<S: PageSize> {
+    /// The frame was present before the [`Mapper::clear`] call
+    Present {
+        /// The physical frame that was unmapped
+        frame: PhysFrame<S>,
+        /// The flags of the frame that was unmapped
+        flags: PageTableFlags,
+        /// The changed page, to flush the TLB
+        flush: MapperFlush<S>,
+    },
+    /// The frame was not present before the [`Mapper::clear`] call
+    NotPresent {
+        /// The page table entry
+        entry: PageTableEntry,
+    },
 }
 
 /// This type represents a page whose mapping has changed in the page table.

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -282,7 +282,10 @@ pub trait Mapper<S: PageSize> {
     /// Removes a mapping from the page table and returns the frame that used to be mapped.
     ///
     /// Note that no page tables or pages are deallocated.
-    fn unmap(&mut self, page: Page<S>) -> Result<(PhysFrame<S>, MapperFlush<S>), UnmapError>;
+    fn unmap(
+        &mut self,
+        page: Page<S>,
+    ) -> Result<(PhysFrame<S>, PageTableFlags, MapperFlush<S>), UnmapError>;
 
     /// Clears a mapping from the page table and returns the frame that used to be mapped.
     ///

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -88,7 +88,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size1GiB>,
-    ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size1GiB>, PageTableFlags, MapperFlush<Size1GiB>), UnmapError> {
         self.inner.unmap(page)
     }
 
@@ -162,7 +162,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
-    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size2MiB>, PageTableFlags, MapperFlush<Size2MiB>), UnmapError> {
         self.inner.unmap(page)
     }
 
@@ -236,7 +236,7 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
-    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size4KiB>, PageTableFlags, MapperFlush<Size4KiB>), UnmapError> {
         self.inner.unmap(page)
     }
 

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -93,6 +93,11 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    fn clear(&mut self, page: Page<Size1GiB>) -> Result<UnmappedFrame<Size1GiB>, UnmapError> {
+        self.inner.clear(page)
+    }
+
+    #[inline]
     unsafe fn update_flags(
         &mut self,
         page: Page<Size1GiB>,
@@ -162,6 +167,11 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 
     #[inline]
+    fn clear(&mut self, page: Page<Size2MiB>) -> Result<UnmappedFrame<Size2MiB>, UnmapError> {
+        self.inner.clear(page)
+    }
+
+    #[inline]
     unsafe fn update_flags(
         &mut self,
         page: Page<Size2MiB>,
@@ -228,6 +238,11 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
         page: Page<Size4KiB>,
     ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
         self.inner.unmap(page)
+    }
+
+    #[inline]
+    fn clear(&mut self, page: Page<Size4KiB>) -> Result<UnmappedFrame<Size4KiB>, UnmapError> {
+        self.inner.clear(page)
     }
 
     #[inline]

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -318,7 +318,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size1GiB>,
-    ) -> Result<(PhysFrame<Size1GiB>, MapperFlush<Size1GiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size1GiB>, PageTableFlags, MapperFlush<Size1GiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
 
@@ -342,7 +342,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
             .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(p3_entry.addr()))?;
 
         p3_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size1GiB>) -> Result<UnmappedFrame<Size1GiB>, UnmapError> {
@@ -473,7 +473,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size2MiB>,
-    ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size2MiB>, PageTableFlags, MapperFlush<Size2MiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
         p4_entry.frame().map_err(|err| match err {
@@ -503,7 +503,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
             .map_err(|AddressNotAligned| UnmapError::InvalidFrameAddress(p2_entry.addr()))?;
 
         p2_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size2MiB>) -> Result<UnmappedFrame<Size2MiB>, UnmapError> {
@@ -669,7 +669,7 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
     fn unmap(
         &mut self,
         page: Page<Size4KiB>,
-    ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
+    ) -> Result<(PhysFrame<Size4KiB>, PageTableFlags, MapperFlush<Size4KiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
         p4_entry.frame().map_err(|err| match err {
@@ -698,9 +698,10 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
+        let flags = p1_entry.flags();
 
         p1_entry.set_unused();
-        Ok((frame, MapperFlush::new(page)))
+        Ok((frame, flags, MapperFlush::new(page)))
     }
 
     fn clear(&mut self, page: Page<Size4KiB>) -> Result<UnmappedFrame<Size4KiB>, UnmapError> {


### PR DESCRIPTION
Add a way to clear page table entries that don't have the present flag set. 

See #481 for an explanation

fixes: #481