### PR TITLE
constify PhysFrame functions

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -495,7 +495,15 @@ impl PhysAddr {
     where
         U: Into<u64>,
     {
-        PhysAddr(align_down(self.0, align.into()))
+        self.align_down_u64(align.into())
+    }
+
+    /// Aligns the physical address downwards to the given alignment.
+    ///
+    /// See the `align_down` function for more information.
+    #[inline]
+    pub(crate) const fn align_down_u64(self, align: u64) -> Self {
+        PhysAddr(align_down(self.0, align))
     }
 
     /// Checks whether the physical address has the demanded alignment.
@@ -504,7 +512,13 @@ impl PhysAddr {
     where
         U: Into<u64>,
     {
-        self.align_down(align) == self
+        self.is_aligned_u64(align.into())
+    }
+
+    /// Checks whether the physical address has the demanded alignment.
+    #[inline]
+    pub(crate) const fn is_aligned_u64(self, align: u64) -> bool {
+        self.align_down_u64(align).as_u64() == self.as_u64()
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -21,8 +21,9 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// Returns an error if the address is not correctly aligned (i.e. is not a valid frame start).
     #[inline]
+    #[rustversion::attr(since(1.61), const)]
     pub fn from_start_address(address: PhysAddr) -> Result<Self, AddressNotAligned> {
-        if !address.is_aligned(S::SIZE) {
+        if !address.is_aligned_u64(S::SIZE) {
             return Err(AddressNotAligned);
         }
 
@@ -46,9 +47,10 @@ impl<S: PageSize> PhysFrame<S> {
 
     /// Returns the frame that contains the given physical address.
     #[inline]
+    #[rustversion::attr(since(1.61), const)]
     pub fn containing_address(address: PhysAddr) -> Self {
         PhysFrame {
-            start_address: address.align_down(S::SIZE),
+            start_address: address.align_down_u64(S::SIZE),
             size: PhantomData,
         }
     }


### PR DESCRIPTION
This PR makes `PhysFrame::from_start_address` and `PhysFrame::containing_address` const.