### PR TITLE
don't use label starting with `1`

### DIFF
--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -75,10 +75,10 @@ impl Segment for CS {
         unsafe {
             asm!(
                 "push {sel}",
-                "lea {tmp}, [1f + rip]",
+                "lea {tmp}, [55f + rip]",
                 "push {tmp}",
                 "retfq",
-                "1:",
+                "55:",
                 sel = in(reg) u64::from(sel.0),
                 tmp = lateout(reg) _,
                 options(preserves_flags),


### PR DESCRIPTION
Starting with the latest nightly, this results in an error:

```
error: avoid using labels containing only the digits `0` and `1` in inline assembly
  --> src/instructions/segmentation.rs:81:18
   |
81 |                 "1:",
   |                  ^ use a different label that doesn't start with `0` or `1`
   |
   = note: an LLVM bug makes these labels ambiguous with a binary literal number
   = note: `#[deny(binary_asm_labels)]` on by default
```