### PR TITLE
remove #![feature(asm_const)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT::append()
-#![cfg_attr(feature = "asm_const", feature(asm_const))]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_auto_cfg", feature(doc_auto_cfg))]


### PR DESCRIPTION
This feature will be stable as of Rust 1.80 and so enabling it explicitly throws a warning. This PR fixes builds on the latest nightly version.