### PR TITLE
Remove stabilized `const_mut_refs` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ rustversion = "1.0.5"
 [features]
 default = ["nightly", "instructions"]
 instructions = []
-nightly = [ "const_fn", "step_trait", "abi_x86_interrupt", "asm_const" ]
+nightly = ["const_fn", "step_trait", "abi_x86_interrupt", "asm_const"]
 abi_x86_interrupt = []
+# deprecated, no longer needed
 const_fn = []
 asm_const = []
 step_trait = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_mut_refs))] // GDT::append()
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_auto_cfg", feature(doc_auto_cfg))]

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -193,8 +193,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     ///
     /// Panics if the GDT doesn't have enough free entries.
     #[inline]
-    #[cfg_attr(feature = "const_fn", rustversion::attr(all(), const))]
-    pub fn append(&mut self, entry: Descriptor) -> SegmentSelector {
+    pub const fn append(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => {
                 if self.len > self.table.len().saturating_sub(1) {
@@ -246,8 +245,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     }
 
     #[inline]
-    #[cfg_attr(feature = "const_fn", rustversion::attr(all(), const))]
-    fn push(&mut self, value: u64) -> usize {
+    const fn push(&mut self, value: u64) -> usize {
         let index = self.len;
         self.table[index] = Entry::new(value);
         self.len += 1;


### PR DESCRIPTION
Make `GDT::append` and `GDT::push` `const` by default. The `const_fn` feature is now a no-op.

Fixes #499 