### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/instructions/mod.rs
+++ b/src/instructions/mod.rs
@@ -32,8 +32,11 @@ pub fn nop() {
     }
 }
 
-/// Emits a '[magic breakpoint](https://wiki.osdev.org/Bochs#Magic_Breakpoint)' instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
-/// emulator. Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
+/// Emits a '[magic breakpoint](https://wiki.osdev.org/Bochs#Magic_Breakpoint)'
+/// instruction for the [Bochs](http://bochs.sourceforge.net/) CPU
+/// emulator.
+///
+/// Make sure to set `magic_break: enabled=1` in your `.bochsrc` file.
 #[inline]
 pub fn bochs_breakpoint() {
     unsafe {

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -150,7 +150,7 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
     }
 }
 
-impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
+impl<P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'_, P> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -258,7 +258,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'a, P> {
     }
 }
 
-impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
+impl<P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'_, P> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -386,7 +386,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'a, P> {
     }
 }
 
-impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
+impl<P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'_, P> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -530,7 +530,7 @@ impl<'a, P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'a, P> {
     }
 }
 
-impl<'a, P: PageTableFrameMapping> Translate for MappedPageTable<'a, P> {
+impl<P: PageTableFrameMapping> Translate for MappedPageTable<'_, P> {
     #[allow(clippy::inconsistent_digit_grouping)]
     fn translate(&self, addr: VirtAddr) -> TranslateResult {
         let p4 = &self.level_4_table;
@@ -594,7 +594,7 @@ impl<'a, P: PageTableFrameMapping> Translate for MappedPageTable<'a, P> {
     }
 }
 
-impl<'a, P: PageTableFrameMapping> CleanUp for MappedPageTable<'a, P> {
+impl<P: PageTableFrameMapping> CleanUp for MappedPageTable<'_, P> {
     #[inline]
     unsafe fn clean_up<D>(&mut self, frame_deallocator: &mut D)
     where

--- a/src/structures/paging/mapper/offset_page_table.rs
+++ b/src/structures/paging/mapper/offset_page_table.rs
@@ -65,7 +65,7 @@ unsafe impl PageTableFrameMapping for PhysOffset {
 
 // delegate all trait implementations to inner
 
-impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
+impl Mapper<Size1GiB> for OffsetPageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -134,7 +134,7 @@ impl<'a> Mapper<Size1GiB> for OffsetPageTable<'a> {
     }
 }
 
-impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
+impl Mapper<Size2MiB> for OffsetPageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -203,7 +203,7 @@ impl<'a> Mapper<Size2MiB> for OffsetPageTable<'a> {
     }
 }
 
-impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
+impl Mapper<Size4KiB> for OffsetPageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -272,14 +272,14 @@ impl<'a> Mapper<Size4KiB> for OffsetPageTable<'a> {
     }
 }
 
-impl<'a> Translate for OffsetPageTable<'a> {
+impl Translate for OffsetPageTable<'_> {
     #[inline]
     fn translate(&self, addr: VirtAddr) -> TranslateResult {
         self.inner.translate(addr)
     }
 }
 
-impl<'a> CleanUp for OffsetPageTable<'a> {
+impl CleanUp for OffsetPageTable<'_> {
     #[inline]
     unsafe fn clean_up<D>(&mut self, frame_deallocator: &mut D)
     where

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -299,7 +299,7 @@ impl<'a> RecursivePageTable<'a> {
     }
 }
 
-impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
+impl Mapper<Size1GiB> for RecursivePageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -419,7 +419,7 @@ impl<'a> Mapper<Size1GiB> for RecursivePageTable<'a> {
     }
 }
 
-impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
+impl Mapper<Size2MiB> for RecursivePageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -574,7 +574,7 @@ impl<'a> Mapper<Size2MiB> for RecursivePageTable<'a> {
     }
 }
 
-impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
+impl Mapper<Size4KiB> for RecursivePageTable<'_> {
     #[inline]
     unsafe fn map_to_with_table_flags<A>(
         &mut self,
@@ -763,7 +763,7 @@ impl<'a> Mapper<Size4KiB> for RecursivePageTable<'a> {
     }
 }
 
-impl<'a> Translate for RecursivePageTable<'a> {
+impl Translate for RecursivePageTable<'_> {
     #[allow(clippy::inconsistent_digit_grouping)]
     fn translate(&self, addr: VirtAddr) -> TranslateResult {
         let page = Page::containing_address(addr);
@@ -836,7 +836,7 @@ impl<'a> Translate for RecursivePageTable<'a> {
     }
 }
 
-impl<'a> CleanUp for RecursivePageTable<'a> {
+impl CleanUp for RecursivePageTable<'_> {
     #[inline]
     unsafe fn clean_up<D>(&mut self, frame_deallocator: &mut D)
     where


### PR DESCRIPTION
- Break long doc paragraph
- Elide explicit lifetimes when possible

Builds on top of #501, should be merged afterwards.