### PR TITLE
TryFrom implementation for ExceptionVector

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -24,6 +24,7 @@ use crate::registers::rflags::RFlags;
 use crate::{PrivilegeLevel, VirtAddr};
 use bit_field::BitField;
 use bitflags::bitflags;
+use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::Bound::{Excluded, Included, Unbounded};
@@ -1326,6 +1327,42 @@ pub enum ExceptionVector {
 
     /// Security Exception
     Security = 0x1E,
+}
+
+impl TryFrom<u8> for ExceptionVector {
+    type Error = ();
+
+    /// Tries to convert the exception vector number to [`ExceptionVector`]
+    ///
+    /// Fails if exception vector number is Coprocessor Segment Overrun, reserved or not exception vector number
+    fn try_from(exception_vector_number: u8) -> Result<Self, Self::Error> {
+        match exception_vector_number {
+            0x00 => Ok(Self::Division),
+            0x01 => Ok(Self::Debug),
+            0x02 => Ok(Self::NonMaskableInterrupt),
+            0x03 => Ok(Self::Breakpoint),
+            0x04 => Ok(Self::Overflow),
+            0x05 => Ok(Self::BoundRange),
+            0x06 => Ok(Self::InvalidOpcode),
+            0x07 => Ok(Self::DeviceNotAvailable),
+            0x08 => Ok(Self::Double),
+            0x0A => Ok(Self::InvalidTss),
+            0x0B => Ok(Self::SegmentNotPresent),
+            0x0C => Ok(Self::Stack),
+            0x0D => Ok(Self::GeneralProtection),
+            0x0E => Ok(Self::Page),
+            0x10 => Ok(Self::X87FloatingPoint),
+            0x11 => Ok(Self::AlignmentCheck),
+            0x12 => Ok(Self::MachineCheck),
+            0x13 => Ok(Self::SimdFloatingPoint),
+            0x14 => Ok(Self::Virtualization),
+            0x15 => Ok(Self::ControlProtection),
+            0x1C => Ok(Self::HypervisorInjection),
+            0x1D => Ok(Self::VmmCommunication),
+            0x1E => Ok(Self::Security),
+            _ => Err(()),
+        }
+    }
 }
 
 #[cfg(all(

--- a/src/structures/tss.rs
+++ b/src/structures/tss.rs
@@ -5,16 +5,17 @@ use core::mem::size_of;
 
 /// In 64-bit mode the TSS holds information that is not
 /// directly related to the task-switch mechanism,
-/// but is used for finding kernel level stack
-/// if interrupts arrive while in kernel mode.
+/// but is used for stack switching when interrupt occurs.
 #[derive(Debug, Clone, Copy)]
 #[repr(C, packed(4))]
 pub struct TaskStateSegment {
     reserved_1: u32,
     /// The full 64-bit canonical forms of the stack pointers (RSP) for privilege levels 0-2.
+    /// The stack pointers used to load the stack when a privilege level change occurs from a lower privilege level to a higher one.
     pub privilege_stack_table: [VirtAddr; 3],
     reserved_2: u64,
     /// The full 64-bit canonical forms of the interrupt stack table (IST) pointers.
+    /// The stack pointers used to load the stack when an entry in the Interrupt Descriptor Table has an IST value other than 0.
     pub interrupt_stack_table: [VirtAddr; 7],
     reserved_3: u64,
     reserved_4: u16,


### PR DESCRIPTION
There is currently no way to create an instance of `idt::ExceptionVector` having an interrupt number. At the same time it would be convenient for the user to use this enum to handle interrupts.

As for the implementation, I couldn't think of what type of error it should return.