### PR TITLE
fix field order for INVPCID descriptor

### DIFF
--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -49,8 +49,8 @@ pub enum InvPicdCommand {
 #[repr(C)]
 #[derive(Debug)]
 struct InvpcidDescriptor {
-    address: u64,
     pcid: u64,
+    address: u64,
 }
 
 /// Structure of a PCID. A PCID has to be <= 4096 for x86_64.
@@ -95,8 +95,8 @@ impl fmt::Display for PcidTooBig {
 #[inline]
 pub unsafe fn flush_pcid(command: InvPicdCommand) {
     let mut desc = InvpcidDescriptor {
-        address: 0,
         pcid: 0,
+        address: 0,
     };
 
     let kind: u64;


### PR DESCRIPTION
Both Intel's and AMD's manuals describe the INVPCID descriptor as a 128-bit value with the linear address stored in the upper half and the PCID stored in the lower half. x86 uses little-endian byte ordering and so the lower half (pcid) should be stored before the upper half (address). Previously, our `InvpcidDescriptor` type stored the halves in the opposite order with the address before the pcid.
This patch fixes the order, so that the pcid is stored before the address. This new order is also the order used by Linux and OpenBSD:
https://github.com/torvalds/linux/blob/3e5e6c9900c3d71895e8bdeacfb579462e98eba1/arch/x86/include/asm/invpcid.h#L8
https://github.com/openbsd/src/blob/4e368faebf86e9a349446b5839c333bc17bd3f9a/sys/arch/amd64/include/cpufunc.h#L173
It's beyond me how this wasn't noticed earlier. The previous incorrect layout could lead to TLB entries not being flushed and #GP faults.