### PR TITLE
fix CI job for building on MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
           - nightly
           - 1.59
     runs-on: ubuntu-latest
+    env:
+      # rustup prioritizes environment variables over rust-toolchain.toml files.
+      RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -193,7 +193,8 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     ///
     /// Panics if the GDT doesn't have enough free entries.
     #[inline]
-    pub const fn append(&mut self, entry: Descriptor) -> SegmentSelector {
+    #[rustversion::attr(since(1.83), const)]
+    pub fn append(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => {
                 if self.len > self.table.len().saturating_sub(1) {
@@ -245,7 +246,8 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     }
 
     #[inline]
-    const fn push(&mut self, value: u64) -> usize {
+    #[rustversion::attr(since(1.83), const)]
+    fn push(&mut self, value: u64) -> usize {
         let index = self.len;
         self.table[index] = Entry::new(value);
         self.len += 1;


### PR DESCRIPTION
It turns out that dtolnay/rust-toolchain sets the installed toolchain as the global default, but rustup prioritizes our rust-toolchain.toml. Instead, set an environment variable. RUSTUP_TOOLCHAIN has a higher priority than rust-toolchain.toml [^1].

[^1]: https://rust-lang.github.io/rustup/overrides.html#overrides