### PR TITLE
fix signature of Step::steps_between implementations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: x86_64-unknown-linux-musl, i686-unknown-linux-gnu, thumbv7em-none-eabihf
+          targets: x86_64-unknown-linux-musl, i686-unknown-linux-musl, thumbv7em-none-eabihf
 
       - run: cargo build
 
@@ -72,8 +72,11 @@ jobs:
 
       - name: "Build on non x86_64 platforms"
         run: |
-          cargo build --target i686-unknown-linux-gnu --no-default-features --features nightly
+          cargo build --target i686-unknown-linux-musl --no-default-features --features nightly
           cargo build --target thumbv7em-none-eabihf --no-default-features --features nightly
+
+      - run: cargo test --target i686-unknown-linux-musl --no-default-features --features nightly
+        if: runner.os == 'Linux'
 
   bootloader-test:
     name: "Bootloader Integration Test"

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -669,22 +669,27 @@ mod tests {
             Step::forward_checked(VirtAddr(0xffff_ffff_ffff_ffff), 1),
             None
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::forward(VirtAddr(0x7fff_ffff_ffff), 0x1234_5678_9abd),
             VirtAddr(0xffff_9234_5678_9abc)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::forward(VirtAddr(0x7fff_ffff_ffff), 0x8000_0000_0000),
             VirtAddr(0xffff_ffff_ffff_ffff)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::forward(VirtAddr(0x7fff_ffff_ff00), 0x8000_0000_00ff),
             VirtAddr(0xffff_ffff_ffff_ffff)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::forward_checked(VirtAddr(0x7fff_ffff_ff00), 0x8000_0000_0100),
             None
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::forward_checked(VirtAddr(0x7fff_ffff_ffff), 0x8000_0000_0001),
             None
@@ -705,18 +710,22 @@ mod tests {
             Step::backward(VirtAddr(0xffff_8000_0000_0001), 1),
             VirtAddr(0xffff_8000_0000_0000)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::backward(VirtAddr(0xffff_9234_5678_9abc), 0x1234_5678_9abd),
             VirtAddr(0x7fff_ffff_ffff)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::backward(VirtAddr(0xffff_8000_0000_0000), 0x8000_0000_0000),
             VirtAddr(0)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::backward(VirtAddr(0xffff_8000_0000_0000), 0x7fff_ffff_ff01),
             VirtAddr(0xff)
         );
+        #[cfg(target_pointer_width = "64")]
         assert_eq!(
             Step::backward_checked(VirtAddr(0xffff_8000_0000_0000), 0x8000_0000_0001),
             None
@@ -820,6 +829,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_from_ptr_array() {
         let slice = &[1, 2, 3, 4, 5];
         // Make sure that from_ptr(slice) is the address of the first element

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -823,7 +823,10 @@ mod tests {
     fn test_from_ptr_array() {
         let slice = &[1, 2, 3, 4, 5];
         // Make sure that from_ptr(slice) is the address of the first element
-        assert_eq!(VirtAddr::from_ptr(slice), VirtAddr::from_ptr(&slice[0]));
+        assert_eq!(
+            VirtAddr::from_ptr(slice.as_slice()),
+            VirtAddr::from_ptr(&slice[0])
+        );
     }
 }
 

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -315,14 +315,14 @@ where
         if let Some(mut pages) = self.page_range {
             while !pages.is_empty() {
                 // Calculate out how many pages we still need to flush.
-                let count = Page::<S>::steps_between_impl(&pages.start, &pages.end).unwrap();
+                let count = Page::<S>::steps_between_impl(&pages.start, &pages.end).0;
 
                 // Make sure that we never jump the gap in the address space when flushing.
                 let second_half_start =
                     Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
                 let count = if pages.start < second_half_start {
                     let count_to_second_half =
-                        Page::steps_between_impl(&pages.start, &second_half_start).unwrap();
+                        Page::steps_between_impl(&pages.start, &second_half_start).0;
                     cmp::min(count, count_to_second_half)
                 } else {
                     count

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -160,9 +160,11 @@ impl<S: PageSize> Page<S> {
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
-    pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> Option<usize> {
-        VirtAddr::steps_between_impl(&start.start_address, &end.start_address)
-            .map(|steps| steps / S::SIZE as usize)
+    pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        let (lower, upper) = VirtAddr::steps_between_impl(&start.start_address, &end.start_address);
+        let lower = lower / S::SIZE as usize;
+        let upper = upper.map(|steps| steps / S::SIZE as usize);
+        (lower, upper)
     }
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
@@ -293,7 +295,7 @@ impl<S: PageSize> Sub<Self> for Page<S> {
 
 #[cfg(feature = "step_trait")]
 impl<S: PageSize> Step for Page<S> {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         Self::steps_between_impl(start, end)
     }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -353,8 +353,8 @@ impl From<PageTableIndex> for usize {
 #[cfg(feature = "step_trait")]
 impl Step for PageTableIndex {
     #[inline]
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        end.0.checked_sub(start.0).map(usize::from)
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        Step::steps_between(&start.0, &end.0)
     }
 
     #[inline]


### PR DESCRIPTION
A recent nightly changed the signature of `Step::steps_between` to match the signature of `Iterator::size_hint`. This PR changes our implementations to match the new signature. This PR also fixes the `Step` implementation of `Page` on 32-bit platforms.

Closes #512
Cc @isaka-james @tsatke 
