### PR TITLE
update Step::steps_between to latest rust nightly version

### DIFF
--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -315,14 +315,14 @@ where
         if let Some(mut pages) = self.page_range {
             while !pages.is_empty() {
                 // Calculate out how many pages we still need to flush.
-                let count = Page::<S>::steps_between_impl(&pages.start, &pages.end).unwrap();
+                let count = Page::<S>::steps_between_u64(&pages.start, &pages.end).unwrap();
 
                 // Make sure that we never jump the gap in the address space when flushing.
                 let second_half_start =
                     Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
                 let count = if pages.start < second_half_start {
                     let count_to_second_half =
-                        Page::steps_between_impl(&pages.start, &second_half_start).unwrap();
+                        Page::steps_between_u64(&pages.start, &second_half_start).unwrap();
                     cmp::min(count, count_to_second_half)
                 } else {
                     count
@@ -348,8 +348,7 @@ where
                 // Even if the count is zero, one page is still flushed and so
                 // we need to advance by at least one.
                 let inc_count = cmp::max(count, 1);
-                pages.start =
-                    Page::forward_checked_impl(pages.start, usize::from(inc_count)).unwrap();
+                pages.start = Page::forward_checked_u64(pages.start, u64::from(inc_count)).unwrap();
             }
         } else {
             unsafe {

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -646,11 +646,9 @@ impl<P: PageTableFrameMapping> CleanUp for MappedPageTable<'_, P> {
                     .skip(usize::from(start))
                 {
                     if let Ok(page_table) = page_table_walker.next_table_mut(entry) {
-                        let start = VirtAddr::forward_checked_impl(
-                            table_addr,
-                            (offset_per_entry as usize) * i,
-                        )
-                        .unwrap();
+                        let start =
+                            VirtAddr::forward_checked_u64(table_addr, offset_per_entry * i as u64)
+                                .unwrap();
                         let end = start + (offset_per_entry - 1);
                         let start = Page::<Size4KiB>::containing_address(start);
                         let start = start.max(range.start);

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -891,11 +891,9 @@ impl CleanUp for RecursivePageTable<'_> {
                     })
                 {
                     if let Ok(frame) = entry.frame() {
-                        let start = VirtAddr::forward_checked_impl(
-                            table_addr,
-                            (offset_per_entry as usize) * i,
-                        )
-                        .unwrap();
+                        let start =
+                            VirtAddr::forward_checked_u64(table_addr, offset_per_entry * i as u64)
+                                .unwrap();
                         let end = start + (offset_per_entry - 1);
                         let start = Page::<Size4KiB>::containing_address(start);
                         let start = start.max(range.start);

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -353,8 +353,12 @@ impl From<PageTableIndex> for usize {
 #[cfg(feature = "step_trait")]
 impl Step for PageTableIndex {
     #[inline]
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
-        end.0.checked_sub(start.0).map(usize::from)
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        end.0
+            .checked_sub(start.0)
+            .map(usize::from)
+            .map(|steps| (steps, Some(steps)))
+            .unwrap_or((0, None))
     }
 
     #[inline]


### PR DESCRIPTION
This implements the signature change in https://github.com/rust-lang/rust/pull/130867

I also used this opportunity to change the backing implementation to use `u64` instead of `usize`. That way functions like `steps_between` is always working for `Page` even on 32bit architectures. The old implementation would return `None` even if the step count is knowable for `Pages` but not for `VirtAddr`.

I wasn't sure whether I should create this PR against master or next. While this is a breaking change it is a breaking change in a nightly feature, where breaking changes are expected. If you want I can easily rebase this on next.