### PR TITLE
backport #513

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - "master"
+      - "x86_64-0.14.x"
     tags:
       - "*"
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - "master"
+      - "x86_64-0.14.x"
 
 permissions:
   contents: read

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.14.12"
+version = "0.14.13"
 edition = "2018"
 rust-version = "1.57" # Needed to support panic! in const fns
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+# 0.14.13 – 2024-11-30
+
+## Fixes
+
+- [fix signature of Step::steps_between implementations](https://github.com/rust-osdev/x86_64/pull/520)
+
 # 0.14.12 – 2023-02-09
 
 ## New Features

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -75,10 +75,10 @@ impl Segment for CS {
         unsafe {
             asm!(
                 "push {sel}",
-                "lea {tmp}, [1f + rip]",
+                "lea {tmp}, [55f + rip]",
                 "push {tmp}",
                 "retfq",
-                "1:",
+                "55:",
                 sel = in(reg) u64::from(sel.0),
                 tmp = lateout(reg) _,
                 options(preserves_flags),

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -298,14 +298,14 @@ where
         if let Some(mut pages) = self.page_range {
             while !pages.is_empty() {
                 // Calculate out how many pages we still need to flush.
-                let count = Page::<S>::steps_between_impl(&pages.start, &pages.end).unwrap();
+                let count = Page::<S>::steps_between_impl(&pages.start, &pages.end).0;
 
                 // Make sure that we never jump the gap in the address space when flushing.
                 let second_half_start =
                     Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
                 let count = if pages.start < second_half_start {
                     let count_to_second_half =
-                        Page::steps_between_impl(&pages.start, &second_half_start).unwrap();
+                        Page::steps_between_impl(&pages.start, &second_half_start).0;
                     cmp::min(count, count_to_second_half)
                 } else {
                     count

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -150,9 +150,11 @@ impl<S: PageSize> Page<S> {
     }
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
-    pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> Option<usize> {
-        VirtAddr::steps_between_impl(&start.start_address, &end.start_address)
-            .map(|steps| steps / S::SIZE as usize)
+    pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        let (lower, upper) = VirtAddr::steps_between_impl(&start.start_address, &end.start_address);
+        let lower = lower / S::SIZE as usize;
+        let upper = upper.map(|steps| steps / S::SIZE as usize);
+        (lower, upper)
     }
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
@@ -279,7 +281,7 @@ impl<S: PageSize> Sub<Self> for Page<S> {
 
 #[cfg(feature = "step_trait")]
 impl<S: PageSize> Step for Page<S> {
-    fn steps_between(start: &Self, end: &Self) -> Option<usize> {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
         Self::steps_between_impl(start, end)
     }
 


### PR DESCRIPTION
We need to backport #513 to v0.14 because there are a lot of people still depending on v0.14 and it's currently broken on nightly.

I created a new branch `x86_64-0.14.x` to use for backporting fixes. This branch currently points at the commit that released v0.14.12 (the last commit before we started merging v0.15 stuff into master). I enabled branch protections on this new branch. This PR targets that new branch.

The first commit in this PR adjusts CI to run on the new branch so that our CI pipeline can create the release.

For the second commit, I cherry-picked b9e3d259ef84868c757c809c7d04c6d4bccfa402. This commit contains the fixes for newer nightlies. For the third commit, I cherry-picked 3fec974dadc45b7cf2507af1937fe95eb42ecb1e to fix a deny-by-default warning. Note that this PR doesn't backport any other fixes.

The last two commits prepare a new release. 