### PR TITLE
fix(idt): panic in `impl fmt::Debug for EntryOptions`

### DIFF
--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -1002,8 +1002,8 @@ impl EntryOptions {
         self
     }
 
-    fn stack_index(&self) -> u16 {
-        self.bits.get_bits(0..3) - 1
+    fn stack_index(&self) -> Option<u16> {
+        self.bits.get_bits(0..3).checked_sub(1)
     }
 }
 
@@ -1718,6 +1718,11 @@ mod test {
                 assert!(entry_present(&idt, i));
             }
         }
+    }
+
+    #[test]
+    fn idt_fmt_debug() {
+        dbg!(InterruptDescriptorTable::new());
     }
 
     #[test]


### PR DESCRIPTION
When running this test (debug-printing an empty IDT) without the fix, there is a panic:

```console
running 1 test
[src/structures/idt.rs:1725:9] InterruptDescriptorTable::new() = InterruptDescriptorTable {
    divide_error: Entry {
        handler_addr: 0x0,
        options: EntryOptions {
            code_selector: SegmentSelector {
                index: 0,
                rpl: Ring0,
            },
thread 'structures::idt::test::idt_fmt_debug' panicked at src/structures/idt.rs:1006:9:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test structures::idt::test::idt_fmt_debug ... FAILED
```

This is because `EntryOptions::stack_index` subtracts one from the corresponding bits, which are zero for `EntryOptions::minimal`.

This fix inlines `EntryOptions::stack_index` into the `fmt::Debug` implementation and changes the subtraction into a checked subtraction, displaying either `None` or `Some(number)` for `stack_index` in the `fmt::Debug` implementation.

It might make sense to also change the signature `EntryOptions::stack_index` to return an `Option<u16>` itself to enable getting a non-present stack index in user code, but that would be a breaking change.