### PR TITLE
Add `MapperFlush` method to get page

### DIFF
--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -409,6 +409,12 @@ impl<S: PageSize> MapperFlush<S> {
     /// Don't flush the TLB and silence the “must be used” warning.
     #[inline]
     pub fn ignore(self) {}
+
+    /// Returns the page to be flushed.
+    #[inline]
+    pub fn page(&self) -> Page<S> {
+        self.0
+    }
 }
 
 /// This type represents a change of a page table requiring a complete TLB flush


### PR DESCRIPTION
This PR adds a way to get the page to be flushed from a `MapperFlush` instance. This is needed for multiple CPUs to perform the flush.