### PR TITLE
feat: add `update()` to `Cr3`, `Dr7`, `SFMask`, `UCet`, `SCet`, `mxcsr`, `rflags`, and `XCr0`

### DIFF
--- a/src/registers/debug.rs
+++ b/src/registers/debug.rs
@@ -499,5 +499,18 @@ mod x86_64 {
                 asm!("mov dr7, {}", in(reg) value, options(nomem, nostack, preserves_flags));
             }
         }
+
+        /// Update the DR7 value.
+        ///
+        /// Preserves the value of reserved fields.
+        #[inline]
+        pub fn update<F>(f: F)
+        where
+            F: FnOnce(&mut Dr7Value),
+        {
+            let mut value = Self::read();
+            f(&mut value);
+            Self::write(value);
+        }
     }
 }

--- a/src/registers/mxcsr.rs
+++ b/src/registers/mxcsr.rs
@@ -83,6 +83,17 @@ mod x86_64 {
         }
     }
 
+    /// Update MXCSR.
+    #[inline]
+    pub fn update<F>(f: F)
+    where
+        F: FnOnce(&mut MxCsr),
+    {
+        let mut mxcsr = self::read();
+        f(&mut mxcsr);
+        self::write(mxcsr);
+    }
+
     #[cfg(test)]
     mod test {
         use crate::registers::mxcsr::*;

--- a/src/registers/rflags.rs
+++ b/src/registers/rflags.rs
@@ -126,6 +126,25 @@ mod x86_64 {
         }
     }
 
+    /// Updates the RFLAGS register, preserves reserved bits.
+    ///
+    /// ## Safety
+    ///
+    /// Unsafe because undefined becavior can occur if certain flags are modified. For example,
+    /// the `DF` flag must be unset in all Rust code. Also, modifying `CF`, `PF`, or any other
+    /// flags also used by Rust/LLVM can result in undefined behavior too.
+    #[inline]
+    pub unsafe fn update<F>(f: F)
+    where
+        F: FnOnce(&mut RFlags),
+    {
+        let mut flags = self::read();
+        f(&mut flags);
+        unsafe {
+            self::write(flags);
+        }
+    }
+
     #[cfg(test)]
     mod test {
         use crate::registers::rflags::read;

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -145,5 +145,26 @@ mod x86_64 {
                 );
             }
         }
+
+        /// Update XCR0 flags.
+        ///
+        /// Preserves the value of reserved fields.
+        /// Panics if invalid combinations of [`XCr0Flags`] are set.
+        ///
+        /// ## Safety
+        ///
+        /// This function is unsafe because it's possible to
+        /// enable features that are not supported by the architecture.
+        #[inline]
+        pub unsafe fn update<F>(f: F)
+        where
+            F: FnOnce(&mut XCr0Flags),
+        {
+            let mut flags = Self::read();
+            f(&mut flags);
+            unsafe {
+                Self::write(flags);
+            }
+        }
     }
 }

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -85,7 +85,7 @@ mod x86_64 {
         /// ## Safety
         ///
         /// This function is unsafe because it's possible to
-        /// enable features that are not supported by the architecture
+        /// enable features that are not supported by the architecture.
         #[inline]
         pub unsafe fn write(flags: XCr0Flags) {
             let old_value = Self::read_raw();


### PR DESCRIPTION
This adds `update()`, akin to `update()` on `Cr0`, `Cr4`, and `Efer` to the following types/modules:

- `Cr3`
- `Dr7`
- `SFMask`
- `UCet`
- `SCet`
- `mxcsr`
- `rflags`
- `XCr0`