### PR TITLE
Add page attribute table support

### DIFF
--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -727,7 +727,7 @@ mod x86_64 {
         /// All affected pages must be flushed from the TLB. Processor caches may also need to be
         /// flushed. Additionally, all pages that map to a given frame must have the same memory
         /// type.
-        /// 
+        ///
         /// The PAT must be supported on the CPU, otherwise a general protection exception will
         /// occur. Support can be detected using the `cpuid` instruction.
         #[inline]

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -120,15 +120,15 @@ impl Pat {
     /// The underlying model specific register.
     pub const MSR: Msr = Msr(0x277);
     /// The default PAT configuration following a power up or reset of the processor.
-    pub const DEFAULT: [PatFlags; 8] = [
-        PatFlags::WRITE_BACK,
-        PatFlags::WRITE_THROUGH,
-        PatFlags::UNCACHED,
-        PatFlags::UNCACHEABLE,
-        PatFlags::WRITE_BACK,
-        PatFlags::WRITE_THROUGH,
-        PatFlags::UNCACHED,
-        PatFlags::UNCACHEABLE,
+    pub const DEFAULT: [PatMemoryType; 8] = [
+        PatMemoryType::WriteBack,
+        PatMemoryType::WriteThrough,
+        PatMemoryType::Uncached,
+        PatMemoryType::Uncacheable,
+        PatMemoryType::WriteBack,
+        PatMemoryType::WriteThrough,
+        PatMemoryType::Uncached,
+        PatMemoryType::Uncacheable,
     ];
 }
 
@@ -182,48 +182,39 @@ bitflags! {
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
-/// Flags for the [PAT](Pat).
-pub struct PatFlags(u8);
-impl PatFlags {
+/// Memory types used in the [PAT](Pat).
+#[repr(u8)]
+pub enum PatMemoryType {
     /// Disables caching.
-    pub const UNCACHEABLE: Self = Self(0x00);
+    Uncacheable = 0x00,
     /// Uses a write combining cache policy.
-    pub const WRITE_COMBINING: Self = Self(0x01);
+    WriteCombining = 0x01,
     /// Uses a write through cache policy.
-    pub const WRITE_THROUGH: Self = Self(0x04);
+    WriteThrough = 0x04,
     /// Uses a write protected cache policy.
-    pub const WRITE_PROTECTED: Self = Self(0x05);
+    WriteProtected = 0x05,
     /// Uses a write back cache policy.
-    pub const WRITE_BACK: Self = Self(0x06);
+    WriteBack = 0x06,
     /// Same as uncacheable, but can be overridden by MTRRs.
-    pub const UNCACHED: Self = Self(0x07);
-
+    Uncached = 0x07,
+}
+impl PatMemoryType {
     /// Converts from bits, returning `None` if the value is invalid.
     pub const fn from_bits(bits: u8) -> Option<Self> {
-        match Self(bits) {
-            Self::UNCACHEABLE
-            | Self::WRITE_COMBINING
-            | Self::WRITE_THROUGH
-            | Self::WRITE_PROTECTED
-            | Self::WRITE_BACK
-            | Self::UNCACHED => Some(Self(bits)),
+        match bits {
+            0x00 => Some(Self::Uncacheable),
+            0x01 => Some(Self::WriteCombining),
+            0x04 => Some(Self::WriteThrough),
+            0x05 => Some(Self::WriteProtected),
+            0x06 => Some(Self::WriteBack),
+            0x07 => Some(Self::Uncached),
             _ => None,
         }
     }
 
-    /// Converts from bits without checking if the value is valid.
-    ///
-    /// # Safety
-    ///
-    /// `bits` must correspond to a valid memory type, otherwise a general protection exception will
-    /// occur if it is written to the PAT.
-    pub const unsafe fn from_bits_unchecked(bits: u8) -> Self {
-        Self(bits)
-    }
-
     /// Gets the underlying bits.
     pub const fn bits(self) -> u8 {
-        self.0
+        self as u8
     }
 }
 
@@ -706,34 +697,32 @@ mod x86_64 {
     impl Pat {
         /// Reads IA32_PAT.
         ///
-        /// # Safety
-        ///
         /// The PAT must be supported on the CPU, otherwise a general protection exception will
         /// occur. Support can be detected using the `cpuid` instruction.
         #[inline]
-        pub unsafe fn read() -> [PatFlags; 8] {
+        pub fn read() -> [PatMemoryType; 8] {
             let bits = unsafe { Self::MSR.read() };
-            let mut flags = [PatFlags::UNCACHEABLE; 8];
+            let mut flags = [PatMemoryType::Uncacheable; 8];
             for (i, flag) in flags.iter_mut().enumerate() {
-                *flag = PatFlags((bits >> (8 * i)) as u8);
+                *flag = PatMemoryType::from_bits((bits >> (8 * i)) as u8).unwrap();
             }
             flags
         }
 
         /// Writes IA32_PAT.
         ///
+        /// The PAT must be supported on the CPU, otherwise a general protection exception will
+        /// occur. Support can be detected using the `cpuid` instruction.
+        ///
         /// # Safety
         ///
         /// All affected pages must be flushed from the TLB. Processor caches may also need to be
         /// flushed. Additionally, all pages that map to a given frame must have the same memory
         /// type.
-        ///
-        /// The PAT must be supported on the CPU, otherwise a general protection exception will
-        /// occur. Support can be detected using the `cpuid` instruction.
         #[inline]
-        pub unsafe fn write(flags: [PatFlags; 8]) {
+        pub unsafe fn write(table: [PatMemoryType; 8]) {
             let mut bits = 0u64;
-            for (i, flag) in flags.iter().enumerate() {
+            for (i, flag) in table.iter().enumerate() {
                 bits |= (flag.bits() as u64) << (8 * i);
             }
             let mut msr = Self::MSR;

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -421,7 +421,6 @@ impl<P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'_, P> {
 
         let frame = p1_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         p1_entry.set_unused();
@@ -711,6 +710,9 @@ impl<P: PageTableFrameMapping> PageTableWalker<P> {
         &self,
         entry: &'b PageTableEntry,
     ) -> Result<&'b PageTable, PageTableWalkError> {
+        if entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(PageTableWalkError::MappedToHugePage);
+        }
         let page_table_ptr = self
             .page_table_frame_mapping
             .frame_to_pointer(entry.frame()?);
@@ -729,6 +731,9 @@ impl<P: PageTableFrameMapping> PageTableWalker<P> {
         &self,
         entry: &'b mut PageTableEntry,
     ) -> Result<&'b mut PageTable, PageTableWalkError> {
+        if entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(PageTableWalkError::MappedToHugePage);
+        }
         let page_table_ptr = self
             .page_table_frame_mapping
             .frame_to_pointer(entry.frame()?);
@@ -832,7 +837,6 @@ impl From<FrameError> for PageTableWalkError {
     #[inline]
     fn from(err: FrameError) -> Self {
         match err {
-            FrameError::HugeFrame => PageTableWalkError::MappedToHugePage,
             FrameError::FrameNotPresent => PageTableWalkError::NotMapped,
         }
     }

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -421,6 +421,8 @@ impl<P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'_, P> {
 
         let frame = p1_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         p1_entry.set_unused();
@@ -837,6 +839,8 @@ impl From<FrameError> for PageTableWalkError {
     #[inline]
     fn from(err: FrameError) -> Self {
         match err {
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
             FrameError::FrameNotPresent => PageTableWalkError::NotMapped,
         }
     }

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -325,7 +325,7 @@ impl Mapper<Size1GiB> for RecursivePageTable<'_> {
         if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p4_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),
@@ -448,7 +448,7 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
         if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p4_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),
@@ -459,7 +459,7 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
         if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p3_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p3_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),
@@ -611,7 +611,7 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p4_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),
@@ -622,7 +622,7 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p3_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p3_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),
@@ -633,7 +633,7 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         if p2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
             return Err(UnmapError::ParentEntryHugePage);
         }
-        p2_entry.frame::<Size4KiB>().map_err(|err| match err {
+        p2_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             #[allow(deprecated)]
             FrameError::HugeFrame => unreachable!(),

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -327,6 +327,8 @@ impl Mapper<Size1GiB> for RecursivePageTable<'_> {
         }
         p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
@@ -448,6 +450,8 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
         }
         p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
@@ -457,6 +461,8 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
         }
         p3_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
@@ -607,6 +613,8 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         }
         p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
@@ -616,6 +624,8 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         }
         p3_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
@@ -625,6 +635,8 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         }
         p2_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         let p1 = unsafe { &mut *(p1_ptr(page, self.recursive_index)) };
@@ -632,6 +644,8 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
 
         let frame = p1_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
+            #[allow(deprecated)]
+            FrameError::HugeFrame => unreachable!(),
         })?;
 
         p1_entry.set_unused();

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -322,9 +322,11 @@ impl Mapper<Size1GiB> for RecursivePageTable<'_> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
 
-        p4_entry.frame().map_err(|err| match err {
+        if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
@@ -441,16 +443,20 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
     ) -> Result<(PhysFrame<Size2MiB>, MapperFlush<Size2MiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p3_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
@@ -596,23 +602,29 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
     ) -> Result<(PhysFrame<Size4KiB>, MapperFlush<Size4KiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        if p4_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p4_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        if p3_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p3_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
         let p2_entry = &p2[page.p2_index()];
-        p2_entry.frame().map_err(|err| match err {
+        if p2_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            return Err(UnmapError::ParentEntryHugePage);
+        }
+        p2_entry.frame::<Size4KiB>().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p1 = unsafe { &mut *(p1_ptr(page, self.recursive_index)) };
@@ -620,7 +632,6 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
 
         let frame = p1_entry.frame().map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         p1_entry.set_unused();
@@ -818,9 +829,6 @@ impl Translate for RecursivePageTable<'_> {
         if p1_entry.is_unused() {
             return TranslateResult::NotMapped;
         }
-        if p1_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-            panic!("level 1 entry has huge page bit set")
-        }
 
         let frame = match PhysFrame::from_start_address(p1_entry.addr()) {
             Ok(frame) => frame,
@@ -890,6 +898,9 @@ impl CleanUp for RecursivePageTable<'_> {
                         !(level == PageTableLevel::Four && *i == recursive_index.into())
                     })
                 {
+                    if entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+                        continue;
+                    }
                     if let Ok(frame) = entry.frame() {
                         let start = VirtAddr::forward_checked_impl(
                             table_addr,

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -15,9 +15,6 @@ use bitflags::bitflags;
 pub enum FrameError {
     /// The entry does not have the `PRESENT` flag set, so it isn't currently mapped to a frame.
     FrameNotPresent,
-    /// The entry does have the `HUGE_PAGE` flag set. The `frame` method has a standard 4KiB frame
-    /// as return type, so a huge frame can't be returned.
-    HugeFrame,
 }
 
 /// A 64-bit page table entry.
@@ -63,16 +60,12 @@ impl PageTableEntry {
     /// Returns the following errors:
     ///
     /// - `FrameError::FrameNotPresent` if the entry doesn't have the `PRESENT` flag set.
-    /// - `FrameError::HugeFrame` if the entry has the `HUGE_PAGE` flag set (for huge pages the
-    ///    `addr` function must be used)
     #[inline]
-    pub fn frame(&self) -> Result<PhysFrame, FrameError> {
-        if !self.flags().contains(PageTableFlags::PRESENT) {
-            Err(FrameError::FrameNotPresent)
-        } else if self.flags().contains(PageTableFlags::HUGE_PAGE) {
-            Err(FrameError::HugeFrame)
-        } else {
+    pub fn frame<S: PageSize>(&self) -> Result<PhysFrame<S>, FrameError> {
+        if self.flags().contains(PageTableFlags::PRESENT) {
             Ok(PhysFrame::containing_address(self.addr()))
+        } else {
+            Err(FrameError::FrameNotPresent)
         }
     }
 
@@ -86,7 +79,6 @@ impl PageTableEntry {
     /// Map the entry to the specified physical frame with the specified flags.
     #[inline]
     pub fn set_frame(&mut self, frame: PhysFrame, flags: PageTableFlags) {
-        assert!(!flags.contains(PageTableFlags::HUGE_PAGE));
         self.set_addr(frame.start_address(), flags)
     }
 
@@ -128,17 +120,21 @@ bitflags! {
         /// Controls whether accesses from userspace (i.e. ring 3) are permitted.
         const USER_ACCESSIBLE = 1 << 2;
         /// If this bit is set, a “write-through” policy is used for the cache, else a “write-back”
-        /// policy is used.
+        /// policy is used. This referred to as the page-level write-through (PWT) bit.
         const WRITE_THROUGH =   1 << 3;
-        /// Disables caching for the pointed entry is cacheable.
+        /// Disables caching for the pointed entry if it is cacheable. This referred to as the
+        /// page-level cache disable (PCD) bit.
         const NO_CACHE =        1 << 4;
         /// Set by the CPU when the mapped frame or page table is accessed.
         const ACCESSED =        1 << 5;
         /// Set by the CPU on a write to the mapped frame.
         const DIRTY =           1 << 6;
-        /// Specifies that the entry maps a huge frame instead of a page table. Only allowed in
-        /// P2 or P3 tables.
+        /// Specifies that the entry maps a huge frame instead of a page table. This is the same bit
+        /// as `PAT_4KIB_PAGE`.
         const HUGE_PAGE =       1 << 7;
+        /// This is the PAT bit for page table entries that point to 4KiB pages. This is the same
+        /// bit as `HUGE_PAGE`.
+        const PAT_4KIB_PAGE =   1 << 7;
         /// Indicates that the mapping is present in all address spaces, so it isn't flushed from
         /// the TLB on an address space switch.
         const GLOBAL =          1 << 8;
@@ -148,6 +144,8 @@ bitflags! {
         const BIT_10 =          1 << 10;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.
         const BIT_11 =          1 << 11;
+        /// This is the PAT bit for page table entries that point to huge pages.
+        const PAT_HUGE_PAGE =   1 << 12;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.
         const BIT_52 =          1 << 52;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -15,7 +15,7 @@ use bitflags::bitflags;
 pub enum FrameError {
     /// The entry does not have the `PRESENT` flag set, so it isn't currently mapped to a frame.
     FrameNotPresent,
-    #[deprecated = "`HugeFrame` is no longer returned by the `frame` method, as it can now return huge pages"]
+    #[deprecated = "`HugeFrame` is no longer returned by the `frame` method"]
     /// The entry does have the `HUGE_PAGE` flag set.
     HugeFrame,
 }
@@ -64,7 +64,7 @@ impl PageTableEntry {
     ///
     /// - `FrameError::FrameNotPresent` if the entry doesn't have the `PRESENT` flag set.
     #[inline]
-    pub fn frame<S: PageSize>(&self) -> Result<PhysFrame<S>, FrameError> {
+    pub fn frame(&self) -> Result<PhysFrame, FrameError> {
         if self.flags().contains(PageTableFlags::PRESENT) {
             Ok(PhysFrame::containing_address(self.addr()))
         } else {

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -15,6 +15,9 @@ use bitflags::bitflags;
 pub enum FrameError {
     /// The entry does not have the `PRESENT` flag set, so it isn't currently mapped to a frame.
     FrameNotPresent,
+    #[deprecated = "`HugeFrame` is no longer returned by the `frame` method, as it can now return huge pages"]
+    /// The entry does have the `HUGE_PAGE` flag set.
+    HugeFrame,
 }
 
 /// A 64-bit page table entry.


### PR DESCRIPTION
This adds support for the page attribute table MSR, and allows level 1 page table entries to have the `HUGE_PAGE` bit set. The `HUGE_PAGE` bit is used as the `PAT` bit to index the table for 4KiB pages.