### PR TITLE
fix warnings & remove broken CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, macos-12, macos-latest, windows-latest]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 15

--- a/src/registers/segmentation.rs
+++ b/src/registers/segmentation.rs
@@ -76,7 +76,7 @@ impl SegmentSelector {
     ///  * `rpl`: the requested privilege level
     #[inline]
     pub const fn new(index: u16, rpl: PrivilegeLevel) -> SegmentSelector {
-        SegmentSelector(index << 3 | (rpl as u16))
+        SegmentSelector((index << 3) | (rpl as u16))
     }
 
     /// Can be used as a selector into a non-existent segment and assigned to segment registers,

--- a/src/registers/xcontrol.rs
+++ b/src/registers/xcontrol.rs
@@ -73,7 +73,7 @@ mod x86_64 {
                     out("rax") low, out("rdx") high,
                     options(nomem, nostack, preserves_flags),
                 );
-                (high as u64) << 32 | (low as u64)
+                ((high as u64) << 32) | (low as u64)
             }
         }
 

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -844,8 +844,8 @@ impl<F> Entry<F> {
     #[inline]
     pub fn handler_addr(&self) -> VirtAddr {
         let addr = self.pointer_low as u64
-            | (self.pointer_middle as u64) << 16
-            | (self.pointer_high as u64) << 32;
+            | ((self.pointer_middle as u64) << 16)
+            | ((self.pointer_high as u64) << 32);
         // addr is a valid VirtAddr, as the pointer members are either all zero,
         // or have been set by set_handler_addr (which takes a VirtAddr).
         VirtAddr::new_truncate(addr)


### PR DESCRIPTION
This PR fixes a couple of warnings and removes maco-12 from a matrix job (macos-12 has been removed).