### PR TITLE
feat(msr): add IA32_APIC_BASE support

### DIFF
--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -235,7 +235,10 @@ bitflags! {
         // bits 0 - 7 are reserved.
         /// Indicates whether the current processor is the bootstrap processor
         const BSP = 1 << 8;
-        // bits 9 - 10 are reserved.
+        // bit 9 is reserved.
+        /// Places the local APIC in the x2APIC mode. Processor support for x2APIC feature can be
+        /// detected using the `cpuid` instruction. (CPUID.(EAX=1):ECX.21)
+        const X2APIC_ENABLE = 1 << 10;
         /// Enables or disables the local Apic
         const LAPIC_ENABLE = 1 << 11;
         /// Specifies the base address of the APIC registers. This 24-bit value is extended by 12 bits at the low end to form the base address.

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -773,7 +773,7 @@ mod x86_64 {
         pub fn read_raw() -> (PhysFrame, u64) {
             let raw = unsafe { Self::MSR.read() };
             // extract bits 32 - 51 (incl.)
-            let addr = PhysAddr::new((raw >> 32) & 0xFFFFF);
+            let addr = PhysAddr::new(raw & 0x_000F_FFFF_FFFF_F000);
             let frame = PhysFrame::containing_address(addr);
             (frame, raw)
         }


### PR DESCRIPTION
The **IA32_APIC_BASE** model-specifc register is for the configuration of the [Advanced Programmable Interrupt Controller.](https://wiki.osdev.org/APIC) This addition provides support for interacting with this MSR, since it is frequently used in modern OS development.

More information can be found in the [Intel® 64 and IA-32 Architectures Software Developer’s Manual Volume 3 (3A, 3B, 3C, & 3D): System Programming Guide](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html) in section **11.4.4 Local APIC Status and Location**