### PR TITLE
use default python again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,8 @@ jobs:
       - name: "Checkout Repository"
         uses: actions/checkout@v4
 
-      # TODO: Remove when Python 3.11 is the default on the Gihtub Actions image
-      - name: "Install Python 3.11"
-        run: sudo apt-get -y install python3.11
-
       - name: "Run release script"
-        run: "python3.11 scripts/ci-release.py"
+        run: "python scripts/ci-release.py"
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Currently, ubuntu-latest is ubuntu-24.04. ubuntu-24.04 ships with python 3.12 which is newer than python 3.11 (the version we previously manually installed).

On another happy note, cargo-semver-checks seems to have updated to a newer nightly and that fixed one of our CI jobs. Right now, none of the CI jobs should be broken anymore, all of them should pass :)