### PR TITLE
don't pass -Crelocation-model=static to host targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,9 +89,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 15
 
-    env:
-      RUSTFLAGS: -Crelocation-model=static -Dwarnings
-
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v4
@@ -137,9 +134,11 @@ jobs:
         run: qemu-system-x86_64 --version
 
       - name: "Run Test Framework"
-        run: cargo test
+        run: cargo test --target x86_64-unknown-none
         shell: bash
         working-directory: "testing"
+        env:
+          RUSTFLAGS: -Crelocation-model=static -Dwarnings
 
   check_formatting:
     name: "Check Formatting"


### PR DESCRIPTION
The bootloader integration tests recently started failing on Linux and Windows because of this. I think Rust probably ought to support this, but there's also no good reason for us to do this.