### PR TITLE
Revert #529 on master

### DIFF
--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -64,7 +64,7 @@ impl PageTableEntry {
     ///
     /// - `FrameError::FrameNotPresent` if the entry doesn't have the `PRESENT` flag set.
     /// - `FrameError::HugeFrame` if the entry has the `HUGE_PAGE` flag set (for huge pages the
-    ///    `addr` function must be used)
+    ///   `addr` function must be used)
     #[inline]
     pub fn frame(&self) -> Result<PhysFrame, FrameError> {
         if !self.flags().contains(PageTableFlags::PRESENT) {


### PR DESCRIPTION
This PR reverts #529 due to the concerns about breaking behavior listed in #538. We'll reintroduce the PR on the next branch. Once this PR has been merged, we'll merge master into next, then cherry-pick #529 onto the next branch, and potentially implement some of the improvements mentioned in #538.

@ChocolateLoverRaj I apologize for the delay, this has been sitting on top of my to-do list for way too long 😅

Cc @adavis628