### PR TITLE
Add page attribute table support

### DIFF
--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -64,7 +64,7 @@ impl<'a> RecursivePageTable<'a> {
         {
             return Err(InvalidPageTable::NotRecursive);
         }
-        if Ok(Cr3::read().0) != table[recursive_index].frame() {
+        if Ok(Cr3::read().0) != table[recursive_index].frame(false) {
             return Err(InvalidPageTable::NotActive);
         }
 
@@ -322,7 +322,7 @@ impl Mapper<Size1GiB> for RecursivePageTable<'_> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
 
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -349,7 +349,7 @@ impl Mapper<Size1GiB> for RecursivePageTable<'_> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
 
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -476,14 +476,14 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
     ) -> Result<(PhysFrame<Size2MiB>, PageTableFlags, MapperFlush<Size2MiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        p3_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -509,14 +509,14 @@ impl Mapper<Size2MiB> for RecursivePageTable<'_> {
     fn clear(&mut self, page: Page<Size2MiB>) -> Result<UnmappedFrame<Size2MiB>, UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        p3_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -672,21 +672,21 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
     ) -> Result<(PhysFrame<Size4KiB>, PageTableFlags, MapperFlush<Size4KiB>), UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        p3_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
         let p2_entry = &p2[page.p2_index()];
-        p2_entry.frame().map_err(|err| match err {
+        p2_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -694,9 +694,9 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         let p1 = unsafe { &mut *(p1_ptr(page, self.recursive_index)) };
         let p1_entry = &mut p1[page.p1_index()];
 
-        let frame = p1_entry.frame().map_err(|err| match err {
+        let frame = p1_entry.frame(true).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
-            FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
+            FrameError::HugeFrame => unreachable!(),
         })?;
         let flags = p1_entry.flags();
 
@@ -707,21 +707,21 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
     fn clear(&mut self, page: Page<Size4KiB>) -> Result<UnmappedFrame<Size4KiB>, UnmapError> {
         let p4 = &mut self.p4;
         let p4_entry = &p4[page.p4_index()];
-        p4_entry.frame().map_err(|err| match err {
+        p4_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p3 = unsafe { &mut *(p3_ptr(page, self.recursive_index)) };
         let p3_entry = &p3[page.p3_index()];
-        p3_entry.frame().map_err(|err| match err {
+        p3_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
 
         let p2 = unsafe { &mut *(p2_ptr(page, self.recursive_index)) };
         let p2_entry = &p2[page.p2_index()];
-        p2_entry.frame().map_err(|err| match err {
+        p2_entry.frame(false).map_err(|err| match err {
             FrameError::FrameNotPresent => UnmapError::PageNotMapped,
             FrameError::HugeFrame => UnmapError::ParentEntryHugePage,
         })?;
@@ -729,14 +729,14 @@ impl Mapper<Size4KiB> for RecursivePageTable<'_> {
         let p1 = unsafe { &mut *(p1_ptr(page, self.recursive_index)) };
         let p1_entry = &mut p1[page.p1_index()];
 
-        let frame = match p1_entry.frame() {
+        let frame = match p1_entry.frame(true) {
             Ok(frame) => frame,
             Err(FrameError::FrameNotPresent) => {
                 let cloned = p1_entry.clone();
                 p1_entry.set_unused();
                 return Ok(UnmappedFrame::NotPresent { entry: cloned });
             }
-            Err(FrameError::HugeFrame) => return Err(UnmapError::ParentEntryHugePage),
+            Err(FrameError::HugeFrame) => unreachable!(),
         };
         let flags = p1_entry.flags();
 
@@ -939,9 +939,6 @@ impl Translate for RecursivePageTable<'_> {
         if p1_entry.is_unused() {
             return TranslateResult::NotMapped;
         }
-        if p1_entry.flags().contains(PageTableFlags::HUGE_PAGE) {
-            panic!("level 1 entry has huge page bit set")
-        }
 
         let frame = match PhysFrame::from_start_address(p1_entry.addr()) {
             Ok(frame) => frame,
@@ -1011,7 +1008,7 @@ impl CleanUp for RecursivePageTable<'_> {
                         !(level == PageTableLevel::Four && *i == recursive_index.into())
                     })
                 {
-                    if let Ok(frame) = entry.frame() {
+                    if let Ok(frame) = entry.frame(level == PageTableLevel::One) {
                         let start = VirtAddr::forward_checked_impl(
                             table_addr,
                             (offset_per_entry as usize) * i,

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -64,12 +64,12 @@ impl PageTableEntry {
     ///
     /// - `FrameError::FrameNotPresent` if the entry doesn't have the `PRESENT` flag set.
     /// - `FrameError::HugeFrame` if the entry has the `HUGE_PAGE` flag set (for huge pages the
-    ///   `addr` function must be used)
+    ///   `addr` function must be used) and `is_level_1_entry` is `false`
     #[inline]
-    pub fn frame(&self) -> Result<PhysFrame, FrameError> {
+    pub fn frame(&self, is_level_1_entry: bool) -> Result<PhysFrame, FrameError> {
         if !self.flags().contains(PageTableFlags::PRESENT) {
             Err(FrameError::FrameNotPresent)
-        } else if self.flags().contains(PageTableFlags::HUGE_PAGE) {
+        } else if !is_level_1_entry && self.flags().contains(PageTableFlags::HUGE_PAGE) {
             Err(FrameError::HugeFrame)
         } else {
             Ok(PhysFrame::containing_address(self.addr()))
@@ -86,7 +86,6 @@ impl PageTableEntry {
     /// Map the entry to the specified physical frame with the specified flags.
     #[inline]
     pub fn set_frame(&mut self, frame: PhysFrame, flags: PageTableFlags) {
-        assert!(!flags.contains(PageTableFlags::HUGE_PAGE));
         self.set_addr(frame.start_address(), flags)
     }
 
@@ -128,17 +127,21 @@ bitflags! {
         /// Controls whether accesses from userspace (i.e. ring 3) are permitted.
         const USER_ACCESSIBLE = 1 << 2;
         /// If this bit is set, a “write-through” policy is used for the cache, else a “write-back”
-        /// policy is used.
+        /// policy is used. This referred to as the page-level write-through (PWT) bit.
         const WRITE_THROUGH =   1 << 3;
-        /// Disables caching for the pointed entry is cacheable.
+        /// Disables caching for the pointed entry if it is cacheable. This referred to as the
+        /// page-level cache disable (PCD) bit.
         const NO_CACHE =        1 << 4;
         /// Set by the CPU when the mapped frame or page table is accessed.
         const ACCESSED =        1 << 5;
         /// Set by the CPU on a write to the mapped frame.
         const DIRTY =           1 << 6;
-        /// Specifies that the entry maps a huge frame instead of a page table. Only allowed in
-        /// P2 or P3 tables.
+        /// Specifies that the entry maps a huge frame instead of a page table. This is the same bit
+        /// as `PAT_4KIB_PAGE`.
         const HUGE_PAGE =       1 << 7;
+        /// This is the PAT bit for page table entries that point to 4KiB pages. This is the same
+        /// bit as `HUGE_PAGE`.
+        const PAT_4KIB_PAGE =   1 << 7;
         /// Indicates that the mapping is present in all address spaces, so it isn't flushed from
         /// the TLB on an address space switch.
         const GLOBAL =          1 << 8;
@@ -148,6 +151,8 @@ bitflags! {
         const BIT_10 =          1 << 10;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.
         const BIT_11 =          1 << 11;
+        /// This is the PAT bit for page table entries that point to huge pages.
+        const PAT_HUGE_PAGE =   1 << 12;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.
         const BIT_52 =          1 << 52;
         /// Available to the OS, can be used to store additional data, e.g. custom flags.


### PR DESCRIPTION
This adds support for the page attribute table MSR, and allows level 1 page table entries to have the `HUGE_PAGE` bit set. The `HUGE_PAGE` bit is used as the `PAT` bit to index the table for 4KiB pages.

This commit is based on #529. Following this PR, it was brought up that that PR was a breaking change because some users rely on FrameError::HugeFrame. This PR is still a breaking change, but it tries to make migrating easier for users that use this error variant.

I decided to go with Philipp's suggestion to add a is_level_1_entry parameter. I'll concede that this doesn't feel particularly clean, however callers usually already know the level of the page table entry (at least the was the case for all the callers in this crate) and having this function saves quite a lot of boilerplate (see #529 for how calling code needs to be changed without this function detecting huge pages). I tried looking through some projects on GitHub and it looks like most of them don't have support for huge pages and just panic if they encounter an error from this function. I think this is also another good reason to keep the FrameError::HugeFrame variant around because if a project ever starts to adopt huge pages, it will be very obvious where code is failing opposed to frame() silently returning a frame of the wrong size.

Cc @adavis628
Cc @ChocolateLoverRaj

Closes #538