### PR TITLE
feat: add forwarding `impl PageTableFrameMapping for &P`

### DIFF
--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -881,3 +881,10 @@ pub unsafe trait PageTableFrameMapping {
     /// Translate the given physical frame to a virtual page table pointer.
     fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable;
 }
+
+unsafe impl<P: PageTableFrameMapping + ?Sized> PageTableFrameMapping for &P {
+    #[inline]
+    fn frame_to_pointer(&self, frame: PhysFrame) -> *mut PageTable {
+        (**self).frame_to_pointer(frame)
+    }
+}


### PR DESCRIPTION
Since all methods of `PageTableFrameMapping` take `self` by reference, we can implement `PageTableFrameMapping` for all `&P` where `P: PageTableMapping`.

This is useful whenever we need a `P: PageTableMapping` by value, but we only have a `&P`, for example from `MappedPageTable::page_table_frame_mapping(&self) -> &P`.