### PR TITLE
implement `Step` for `PhysAddr` and `PhysFrame`

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1018,139 +1018,143 @@ mod tests {
 mod proofs {
     use super::*;
 
-    // The next two proof harnesses prove the correctness of the `forward`
-    // implementation of VirtAddr.
+    mod virt_addr {
+        use super::*;
 
-    // This harness proves that our implementation can correctly take 0 or 1
-    // step starting from any address.
-    #[kani::proof]
-    fn forward_base_case() {
-        let start = kani::any::<VirtAddr>();
-        let start_raw = start.as_u64();
+        // The next two proof harnesses prove the correctness of the `forward`
+        // implementation of VirtAddr.
 
-        // Adding 0 to any address should always yield the same address.
-        let same = Step::forward(start, 0);
-        assert!(start == same);
+        // This harness proves that our implementation can correctly take 0 or 1
+        // step starting from any address.
+        #[kani::proof]
+        fn forward_base_case() {
+            let start = kani::any::<VirtAddr>();
+            let start_raw = start.as_u64();
 
-        // Manually calculate the expected address after stepping once.
-        let expected = match start_raw {
-            // Adding 1 to addresses in this range don't require gap jumps, so
-            // we can just add 1.
-            0x0000_0000_0000_0000..=0x0000_7fff_ffff_fffe => Some(start_raw + 1),
-            // Adding 1 to this address jumps the gap.
-            0x0000_7fff_ffff_ffff => Some(0xffff_8000_0000_0000),
-            // The range of non-canonical addresses.
-            0x0000_8000_0000_0000..=0xffff_7fff_ffff_ffff => unreachable!(),
-            // Adding 1 to addresses in this range don't require gap jumps, so
-            // we can just add 1.
-            0xffff_8000_0000_0000..=0xffff_ffff_ffff_fffe => Some(start_raw + 1),
-            // Adding 1 to this address causes an overflow.
-            0xffff_ffff_ffff_ffff => None,
-        };
-        if let Some(expected) = expected {
-            // Verify that `expected` is a valid address.
-            assert!(VirtAddr::try_new(expected).is_ok());
+            // Adding 0 to any address should always yield the same address.
+            let same = Step::forward(start, 0);
+            assert!(start == same);
+
+            // Manually calculate the expected address after stepping once.
+            let expected = match start_raw {
+                // Adding 1 to addresses in this range don't require gap jumps, so
+                // we can just add 1.
+                0x0000_0000_0000_0000..=0x0000_7fff_ffff_fffe => Some(start_raw + 1),
+                // Adding 1 to this address jumps the gap.
+                0x0000_7fff_ffff_ffff => Some(0xffff_8000_0000_0000),
+                // The range of non-canonical addresses.
+                0x0000_8000_0000_0000..=0xffff_7fff_ffff_ffff => unreachable!(),
+                // Adding 1 to addresses in this range don't require gap jumps, so
+                // we can just add 1.
+                0xffff_8000_0000_0000..=0xffff_ffff_ffff_fffe => Some(start_raw + 1),
+                // Adding 1 to this address causes an overflow.
+                0xffff_ffff_ffff_ffff => None,
+            };
+            if let Some(expected) = expected {
+                // Verify that `expected` is a valid address.
+                assert!(VirtAddr::try_new(expected).is_ok());
+            }
+            // Verify `forward_checked`.
+            let next = Step::forward_checked(start, 1);
+            assert!(next.map(VirtAddr::as_u64) == expected);
         }
-        // Verify `forward_checked`.
-        let next = Step::forward_checked(start, 1);
-        assert!(next.map(VirtAddr::as_u64) == expected);
-    }
 
-    // This harness proves that the result of taking two small steps is the
-    // same as taking one combined large step.
-    #[kani::proof]
-    fn forward_induction_step() {
-        let start = kani::any::<VirtAddr>();
+        // This harness proves that the result of taking two small steps is the
+        // same as taking one combined large step.
+        #[kani::proof]
+        fn forward_induction_step() {
+            let start = kani::any::<VirtAddr>();
 
-        let count1: usize = kani::any();
-        let count2: usize = kani::any();
-        // If we can take two small steps...
-        let Some(next1) = Step::forward_checked(start, count1) else {
-            return;
-        };
-        let Some(next2) = Step::forward_checked(next1, count2) else {
-            return;
-        };
+            let count1: usize = kani::any();
+            let count2: usize = kani::any();
+            // If we can take two small steps...
+            let Some(next1) = Step::forward_checked(start, count1) else {
+                return;
+            };
+            let Some(next2) = Step::forward_checked(next1, count2) else {
+                return;
+            };
 
-        // ...then we can also take one combined large step.
-        let count_both = count1 + count2;
-        let next_both = Step::forward(start, count_both);
-        assert!(next2 == next_both);
-    }
+            // ...then we can also take one combined large step.
+            let count_both = count1 + count2;
+            let next_both = Step::forward(start, count_both);
+            assert!(next2 == next_both);
+        }
 
-    // The next two proof harnesses prove the correctness of the `backward`
-    // implementation of VirtAddr using the `forward` implementation which
-    // we've already proven to be correct.
-    // They do this by proving the symmetry between those two functions.
+        // The next two proof harnesses prove the correctness of the `backward`
+        // implementation of VirtAddr using the `forward` implementation which
+        // we've already proven to be correct.
+        // They do this by proving the symmetry between those two functions.
 
-    // This harness proves the correctness of the implementation of `backward`
-    // for all inputs for which `forward_checked` succeeds.
-    #[kani::proof]
-    fn forward_implies_backward() {
-        let start = kani::any::<VirtAddr>();
-        let count: usize = kani::any();
+        // This harness proves the correctness of the implementation of `backward`
+        // for all inputs for which `forward_checked` succeeds.
+        #[kani::proof]
+        fn forward_implies_backward() {
+            let start = kani::any::<VirtAddr>();
+            let count: usize = kani::any();
 
-        // If `forward_checked` succeeds...
-        let Some(end) = Step::forward_checked(start, count) else {
-            return;
-        };
+            // If `forward_checked` succeeds...
+            let Some(end) = Step::forward_checked(start, count) else {
+                return;
+            };
 
-        // ...then `backward` succeeds as well.
-        let start2 = Step::backward(end, count);
-        assert!(start == start2);
-    }
+            // ...then `backward` succeeds as well.
+            let start2 = Step::backward(end, count);
+            assert!(start == start2);
+        }
 
-    // This harness proves that for all inputs for which `backward_checked`
-    // succeeds, `forward` succeeds as well.
-    #[kani::proof]
-    fn backward_implies_forward() {
-        let end = kani::any::<VirtAddr>();
-        let count: usize = kani::any();
+        // This harness proves that for all inputs for which `backward_checked`
+        // succeeds, `forward` succeeds as well.
+        #[kani::proof]
+        fn backward_implies_forward() {
+            let end = kani::any::<VirtAddr>();
+            let count: usize = kani::any();
 
-        // If `backward_checked` succeeds...
-        let Some(start) = Step::backward_checked(end, count) else {
-            return;
-        };
+            // If `backward_checked` succeeds...
+            let Some(start) = Step::backward_checked(end, count) else {
+                return;
+            };
 
-        // ...then `forward` succeeds as well.
-        let end2 = Step::forward(start, count);
-        assert!(end == end2);
-    }
+            // ...then `forward` succeeds as well.
+            let end2 = Step::forward(start, count);
+            assert!(end == end2);
+        }
 
-    // The next two proof harnesses prove the correctness of the
-    // `steps_between` implementation of VirtAddr using the `forward`
-    // implementation which we've already proven to be correct.
-    // They do this by proving the symmetry between those two functions.
+        // The next two proof harnesses prove the correctness of the
+        // `steps_between` implementation of VirtAddr using the `forward`
+        // implementation which we've already proven to be correct.
+        // They do this by proving the symmetry between those two functions.
 
-    // This harness proves the correctness of the implementation of
-    // `steps_between` for all inputs for which `forward_checked` succeeds.
-    #[kani::proof]
-    fn forward_implies_steps_between() {
-        let start = kani::any::<VirtAddr>();
-        let count: usize = kani::any();
+        // This harness proves the correctness of the implementation of
+        // `steps_between` for all inputs for which `forward_checked` succeeds.
+        #[kani::proof]
+        fn forward_implies_steps_between() {
+            let start = kani::any::<VirtAddr>();
+            let count: usize = kani::any();
 
-        // If `forward_checked` succeeds...
-        let Some(end) = Step::forward_checked(start, count) else {
-            return;
-        };
+            // If `forward_checked` succeeds...
+            let Some(end) = Step::forward_checked(start, count) else {
+                return;
+            };
 
-        // ...then `steps_between` succeeds as well.
-        assert!(Step::steps_between(&start, &end) == (count, Some(count)));
-    }
+            // ...then `steps_between` succeeds as well.
+            assert!(Step::steps_between(&start, &end) == (count, Some(count)));
+        }
 
-    // This harness proves that for all inputs for which `steps_between`
-    // succeeds, `forward` succeeds as well.
-    #[kani::proof]
-    fn steps_between_implies_forward() {
-        let start = kani::any::<VirtAddr>();
-        let end = kani::any::<VirtAddr>();
+        // This harness proves that for all inputs for which `steps_between`
+        // succeeds, `forward` succeeds as well.
+        #[kani::proof]
+        fn steps_between_implies_forward() {
+            let start = kani::any::<VirtAddr>();
+            let end = kani::any::<VirtAddr>();
 
-        // If `steps_between` succeeds...
-        let Some(count) = Step::steps_between(&start, &end).1 else {
-            return;
-        };
+            // If `steps_between` succeeds...
+            let Some(count) = Step::steps_between(&start, &end).1 else {
+                return;
+            };
 
-        // ...then `forward` succeeds as well.
-        assert!(Step::forward(start, count) == end);
+            // ...then `forward` succeeds as well.
+            assert!(Step::forward(start, count) == end);
+        }
     }
 }

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -717,6 +717,25 @@ impl Sub<PhysAddr> for PhysAddr {
     }
 }
 
+#[cfg(feature = "step_trait")]
+impl Step for PhysAddr {
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        Step::steps_between(&start.as_u64(), &end.as_u64())
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        PhysAddr::try_new(Step::forward_checked(start.as_u64(), count)?).ok()
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        let addr = Step::backward_checked(start.as_u64(), count)?;
+        Some(unsafe {
+            // SAFETY: There is no lower bound for valid addresses.
+            PhysAddr::new_unsafe(addr)
+        })
+    }
+}
+
 #[cfg(kani)]
 impl kani::Arbitrary for PhysAddr {
     fn any() -> Self {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -1157,4 +1157,159 @@ mod proofs {
             assert!(Step::forward(start, count) == end);
         }
     }
+
+    mod phys_addr {
+        use super::*;
+
+        // The next two proof harnesses prove the correctness of the `forward`
+        // implementation of PhysAddr.
+
+        // This harness proves that our implementation can correctly take 0 or 1
+        // step starting from any address.
+        #[kani::proof]
+        fn forward_base_case() {
+            let start_raw: u64 = kani::any();
+            let Ok(start) = PhysAddr::try_new(start_raw) else {
+                return;
+            };
+
+            // Adding 0 to any address should always yield the same address.
+            let same = Step::forward(start, 0);
+            assert!(start == same);
+
+            // Manually calculate the expected address after stepping once.
+            let expected = match start_raw {
+                // Adding 1 to addresses in this range will result in a valid
+                // address.
+                0x0000_0000_0000_0000..=0xf_ffff_ffff_fffe => Some(start_raw + 1),
+                // Adding 1 to this address causes an overflow.
+                0xf_ffff_ffff_ffff => None,
+                // Bigger addresses do not exist.
+                _ => unreachable!(),
+            };
+            if let Some(expected) = expected {
+                // Verify that `expected` is a valid address.
+                assert!(PhysAddr::try_new(expected).is_ok());
+            }
+            // Verify `forward_checked`.
+            let next = Step::forward_checked(start, 1);
+            assert!(next.map(PhysAddr::as_u64) == expected);
+        }
+
+        // This harness proves that the result of taking two small steps is the
+        // same as taking one combined large step.
+        #[kani::proof]
+        fn forward_induction_step() {
+            let start_raw: u64 = kani::any();
+            let Ok(start) = PhysAddr::try_new(start_raw) else {
+                return;
+            };
+
+            let count1: usize = kani::any();
+            let count2: usize = kani::any();
+            // If we can take two small steps...
+            let Some(next1) = Step::forward_checked(start, count1) else {
+                return;
+            };
+            let Some(next2) = Step::forward_checked(next1, count2) else {
+                return;
+            };
+
+            // ...then we can also take one combined large step.
+            let count_both = count1 + count2;
+            let next_both = Step::forward(start, count_both);
+            assert!(next2 == next_both);
+        }
+
+        // The next two proof harnesses prove the correctness of the `backward`
+        // implementation of PhysAddr using the `forward` implementation which
+        // we've already proven to be correct.
+        // They do this by proving the symmetry between those two functions.
+
+        // This harness proves the correctness of the implementation of `backward`
+        // for all inputs for which `forward_checked` succeeds.
+        #[kani::proof]
+        fn forward_implies_backward() {
+            let start_raw: u64 = kani::any();
+            let Ok(start) = PhysAddr::try_new(start_raw) else {
+                return;
+            };
+            let count: usize = kani::any();
+
+            // If `forward_checked` succeeds...
+            let Some(end) = Step::forward_checked(start, count) else {
+                return;
+            };
+
+            // ...then `backward` succeeds as well.
+            let start2 = Step::backward(end, count);
+            assert!(start == start2);
+        }
+
+        // This harness proves that for all inputs for which `backward_checked`
+        // succeeds, `forward` succeeds as well.
+        #[kani::proof]
+        fn backward_implies_forward() {
+            let end_raw: u64 = kani::any();
+            let Ok(end) = PhysAddr::try_new(end_raw) else {
+                return;
+            };
+            let count: usize = kani::any();
+
+            // If `backward_checked` succeeds...
+            let Some(start) = Step::backward_checked(end, count) else {
+                return;
+            };
+
+            // ...then `forward` succeeds as well.
+            let end2 = Step::forward(start, count);
+            assert!(end == end2);
+        }
+
+        // The next two proof harnesses prove the correctness of the
+        // `steps_between` implementation of PhysAddr using the `forward`
+        // implementation which we've already proven to be correct.
+        // They do this by proving the symmetry between those two functions.
+
+        // This harness proves the correctness of the implementation of
+        // `steps_between` for all inputs for which `forward_checked` succeeds.
+        #[kani::proof]
+        fn forward_implies_steps_between() {
+            let start: u64 = kani::any();
+            let Ok(start) = PhysAddr::try_new(start) else {
+                return;
+            };
+            let count: usize = kani::any();
+
+            // If `forward_checked` succeeds...
+            let Some(end) = Step::forward_checked(start, count) else {
+                return;
+            };
+
+            // ...then `steps_between` succeeds as well.
+            assert!(Step::steps_between(&start, &end) == (count, Some(count)));
+        }
+
+        // This harness proves that for all inputs for which `steps_between`
+        // succeeds, `forward` succeeds as well.
+        #[kani::proof]
+        fn steps_between_implies_forward() {
+            let start: u64 = kani::any();
+            let Ok(start) = PhysAddr::try_new(start) else {
+                return;
+            };
+            let end: u64 = kani::any();
+            let Ok(end) = PhysAddr::try_new(end) else {
+                return;
+            };
+
+            // If `steps_between` succeeds...
+            let Some(count) = Step::steps_between(&start, &end).1 else {
+                return;
+            };
+
+            // ...then `forward` succeeds as well.
+            assert!(Step::forward(start, count) == end);
+        }
+    }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -655,4 +655,117 @@ mod proofs {
         range.nth_back(m);
         assert_eq!(range.nth_back(n), range2.nth_back(sum));
     }
+
+    // This harness proves that steps_between will return the same value
+    // returned by PhysAddr's Step implementation scaled by Size4KiB::Size.
+    #[kani::proof]
+    fn steps_between() {
+        let start_raw: u64 = kani::any();
+        let Ok(start) = PhysAddr::try_new(start_raw) else {
+            return;
+        };
+        let Ok(start_frame) = PhysFrame::<Size4KiB>::from_start_address(start) else {
+            return;
+        };
+
+        let start_end: u64 = kani::any();
+        let Ok(end) = PhysAddr::try_new(start_end) else {
+            return;
+        };
+        let Ok(end_frame) = PhysFrame::<Size4KiB>::from_start_address(end) else {
+            return;
+        };
+
+        let (addr_min, addr_max) = PhysAddr::steps_between(&start, &end);
+        let (frame_min, frame_max) = PhysFrame::steps_between(&start_frame, &end_frame);
+        assert_eq!(addr_min / (Size4KiB::SIZE as usize), frame_min);
+        assert_eq!(
+            addr_max.map(|max| max / (Size4KiB::SIZE as usize)),
+            frame_max
+        );
+    }
+
+    // This harness proves that forward_checked will return the same value
+    // returned by PhysAddr's forward_checked implementation if the count has
+    // scaled by Size4KiB::Size.
+    #[kani::proof]
+    fn forward() {
+        let start_raw: u64 = kani::any();
+        let Ok(start) = PhysAddr::try_new(start_raw) else {
+            return;
+        };
+        let Ok(start_frame) = PhysFrame::<Size4KiB>::from_start_address(start) else {
+            return;
+        };
+
+        let count: usize = kani::any();
+        let Some(scaled_count) = count.checked_mul(Size4KiB::SIZE as usize) else {
+            return;
+        };
+
+        let end_addr = PhysAddr::forward_checked(start, scaled_count);
+        let end_frame = PhysFrame::forward_checked(start_frame, count);
+        assert_eq!(end_addr, end_frame.map(PhysFrame::start_address));
+    }
+
+    // This harness proves that forward_checked will always return `None` if
+    // the count cannot be scaled by Size4KiB::SIZE.
+    #[kani::proof]
+    fn forward_limit() {
+        let start_raw: u64 = kani::any();
+        let Ok(start) = PhysAddr::try_new(start_raw) else {
+            return;
+        };
+        let Ok(start_frame) = PhysFrame::<Size4KiB>::from_start_address(start) else {
+            return;
+        };
+
+        let count: usize = kani::any();
+        kani::assume(count.checked_mul(Size4KiB::SIZE as usize).is_none());
+
+        let end_frame = PhysFrame::forward_checked(start_frame, count);
+        assert_eq!(end_frame, None);
+    }
+
+    // This harness proves that backward_checked will return the same value
+    // returned by PhysAddr's backward_checked implementation if the count has
+    // scaled by Size4KiB::Size.
+    #[kani::proof]
+    fn backward() {
+        let start_raw: u64 = kani::any();
+        let Ok(start) = PhysAddr::try_new(start_raw) else {
+            return;
+        };
+        let Ok(start_frame) = PhysFrame::<Size4KiB>::from_start_address(start) else {
+            return;
+        };
+
+        let count: usize = kani::any();
+        let Some(scaled_count) = count.checked_mul(Size4KiB::SIZE as usize) else {
+            return;
+        };
+
+        let end_addr = PhysAddr::backward_checked(start, scaled_count);
+        let end_frame = PhysFrame::backward_checked(start_frame, count);
+        assert_eq!(end_addr, end_frame.map(PhysFrame::start_address));
+    }
+
+    // This harness proves that backward_checked will always return `None` if
+    // the count cannot be scaled by Size4KiB::SIZE.
+    #[kani::proof]
+    fn backward_limit() {
+        let start_raw: u64 = kani::any();
+        let Ok(start) = PhysAddr::try_new(start_raw) else {
+            return;
+        };
+        let Ok(start_frame) = PhysFrame::<Size4KiB>::from_start_address(start) else {
+            return;
+        };
+
+        let count: usize = kani::any();
+        kani::assume(count.checked_mul(Size4KiB::SIZE as usize).is_none());
+
+        let end_frame = PhysFrame::backward_checked(start_frame, count);
+        assert_eq!(end_frame, None);
+    }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -5,6 +5,8 @@ use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
 use core::convert::TryFrom;
 use core::fmt;
+#[cfg(feature = "step_trait")]
+use core::iter::Step;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
@@ -130,6 +132,47 @@ impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
     #[inline]
     fn sub(self, rhs: PhysFrame<S>) -> Self::Output {
         (self.start_address - rhs.start_address) / S::SIZE
+    }
+}
+
+#[cfg(feature = "step_trait")]
+impl<S> Step for PhysFrame<S>
+where
+    S: PageSize,
+{
+    fn steps_between(start: &Self, end: &Self) -> (usize, Option<usize>) {
+        let start = start.start_address().as_u64() / S::SIZE;
+        let end = end.start_address().as_u64() / S::SIZE;
+        Step::steps_between(&start, &end)
+    }
+
+    fn forward_checked(start: Self, count: usize) -> Option<Self> {
+        let count = u64::try_from(count).ok()?;
+        let count = count.checked_mul(S::SIZE)?;
+        let addr = start.start_address.as_u64().checked_add(count)?;
+        let addr = PhysAddr::try_new(addr).ok()?;
+        Some(unsafe {
+            // SAFETY: `start` is a multiple of `S::SIZE` and we added
+            // multiples of `S::SIZE`, so `addr` is still a multiple of
+            // `S::SIZE`.
+            PhysFrame::from_start_address_unchecked(addr)
+        })
+    }
+
+    fn backward_checked(start: Self, count: usize) -> Option<Self> {
+        let count = u64::try_from(count).ok()?;
+        let count = count.checked_mul(S::SIZE)?;
+        let addr = start.start_address.as_u64().checked_sub(count)?;
+        let addr = unsafe {
+            // SAFETY: There is no lower bound for valid addresses.
+            PhysAddr::new_unsafe(addr)
+        };
+        Some(unsafe {
+            // SAFETY: `start` is a multiple of `S::SIZE` and we subtracted
+            // multiples of `S::SIZE`, so `addr` is still a multiple of
+            // `S::SIZE`.
+            PhysFrame::from_start_address_unchecked(addr)
+        })
     }
 }
 


### PR DESCRIPTION
This PR adds `Step` implementations for `PhysAddr` and `PhysFrame`. This PR also adds kani harnesses to prove the correctness of these new implementations and the unsafe code within them.

Closes #212