### PR TITLE
fix docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,12 @@ instructions = []
 memory_encryption = []
 nightly = ["const_fn", "step_trait", "abi_x86_interrupt", "asm_const"]
 abi_x86_interrupt = []
-# deprecated, no longer needed
-const_fn = []
 asm_const = []
 step_trait = []
+doc_cfg = []
+
+# These are deprecated and no longer needed:
+const_fn = []
 doc_auto_cfg = []
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 #![cfg_attr(not(test), no_std)]
 #![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
-#![cfg_attr(feature = "doc_auto_cfg", feature(doc_auto_cfg))]
+#![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]


### PR DESCRIPTION
The doc_auto_cfg nightly feature has been replaced by doc_cfg.

This caused the docs.rs build for the 0.15.3 release fail: https://docs.rs/crate/x86_64/latest/builds/2671359