### PR TITLE
feat: make page types `repr(transparent)` and range types `repr(Rust)`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -9,6 +9,7 @@
   - `OffsetPageTable`'s `PageTableFrameMapping` implementation is now public as `PhysOffset`.
 - [make range types `!Copy`](https://github.com/rust-osdev/x86_64/pull/581)
   - To migrate, use `.clone()` if necessary.
+- [make page types `repr(transparent)` and range types `repr(Rust)`](https://github.com/rust-osdev/x86_64/pull/584)
 
 # 0.15.4 – 2025-11-24
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -28,6 +28,10 @@ const ADDRESS_SPACE_SIZE: u64 = 0x1_0000_0000_0000;
 /// On `x86_64`, only the 48 lower bits of a virtual address can be used. The top 16 bits need
 /// to be copies of bit 47, i.e. the most significant bit. Addresses that fulfil this criterion
 /// are called “canonical”. This type guarantees that it always represents a canonical address.
+///
+/// # Representation
+///
+/// This struct has the same representation as a [`u64`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct VirtAddr(u64);
@@ -41,6 +45,10 @@ pub struct VirtAddr(u64);
 ///
 /// On `x86_64`, only the 52 lower bits of a physical address can be used. The top 12 bits need
 /// to be zero. This type guarantees that it always represents a valid physical address.
+///
+/// # Representation
+///
+/// This struct has the same representation as a [`u64`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct PhysAddr(u64);

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -8,6 +8,10 @@ use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A physical memory frame.
+///
+/// # Representation
+///
+/// This struct has the same representation as a [`u64`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct PhysFrame<S: PageSize = Size4KiB> {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -134,7 +134,6 @@ impl<S: PageSize> Sub<PhysFrame<S>> for PhysFrame<S> {
 
 /// An range of physical memory frames, exclusive the upper bound.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[repr(C)]
 pub struct PhysFrameRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
     pub start: PhysFrame<S>,
@@ -192,7 +191,6 @@ impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
 
 /// An range of physical memory frames, inclusive the upper bound.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[repr(C)]
 pub struct PhysFrameRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
     pub start: PhysFrame<S>,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -9,7 +9,7 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A physical memory frame.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(C)]
+#[repr(transparent)]
 pub struct PhysFrame<S: PageSize = Size4KiB> {
     // TODO: Make private when our minimum supported stable Rust version is 1.61
     pub(crate) start_address: PhysAddr,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -326,7 +326,6 @@ impl<S: PageSize> Step for Page<S> {
 
 /// A range of pages with exclusive upper bound.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[repr(C)]
 pub struct PageRange<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
     pub start: Page<S>,
@@ -395,7 +394,6 @@ impl<S: PageSize> fmt::Debug for PageRange<S> {
 
 /// A range of pages with inclusive upper bound.
 #[derive(Clone, PartialEq, Eq, Hash)]
-#[repr(C)]
 pub struct PageRangeInclusive<S: PageSize = Size4KiB> {
     /// The start of the range, inclusive.
     pub start: Page<S>,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -63,7 +63,7 @@ impl Sealed for super::Size1GiB {}
 
 /// A virtual memory page.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(C)]
+#[repr(transparent)]
 pub struct Page<S: PageSize = Size4KiB> {
     start_address: VirtAddr,
     size: PhantomData<S>,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -62,6 +62,10 @@ impl PageSize for Size1GiB {
 impl Sealed for super::Size1GiB {}
 
 /// A virtual memory page.
+///
+/// # Representation
+///
+/// This struct has the same representation as a [`u64`].
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
 pub struct Page<S: PageSize = Size4KiB> {


### PR DESCRIPTION
This PR makes the custom paging range types [`repr(Rust)`](https://doc.rust-lang.org/reference/type-layout.html#the-rust-representation), as discussed in https://github.com/rust-osdev/x86_64/pull/581#pullrequestreview-3670533242. `repr(C)` for these types was introduced in https://github.com/rust-osdev/x86_64/commit/399b3d4d4743559317c9e0a886caabf5b68e02c7.

This PR also makes `Page` and `PhysFrame` `repr(Rust)`, since I did not find any code that does not use these types by value and depends on the representation in any way. I can undo that, though, if that undocumented representation is intentional.