### PR TITLE
don't enable abi_x86_interrupt if not needed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,13 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
+#![cfg_attr(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        feature = "abi_x86_interrupt"
+    ),
+    feature(abi_x86_interrupt)
+)]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -1,4 +1,3 @@
-#![feature(abi_x86_interrupt)]
 #![no_std]
 #![no_main]
 


### PR DESCRIPTION
rustc will warn about unused features:
https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#unused-features