### PR TITLE
insert NOP after STI

### DIFF
--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -18,7 +18,7 @@ pub fn enable() {
     // Omit `nomem` to imitate a lock release. Otherwise, the compiler
     // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("sti", options(preserves_flags, nostack));
+        asm!("sti", "nop", options(preserves_flags, nostack));
     }
 }
 

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -13,6 +13,10 @@ pub fn are_enabled() -> bool {
 /// Enable interrupts.
 ///
 /// This is a wrapper around the `sti` instruction.
+///
+/// This function executes `sti; nop` to ensure that the interrupt shadow
+/// caused by the `sti` instruction doesn't last beyond this function.
+/// Use [`enable_and_hlt`] to execute `hlt` in `sti`'s interrupt shadow.
 #[inline]
 pub fn enable() {
     // Omit `nomem` to imitate a lock release. Otherwise, the compiler


### PR DESCRIPTION
Insert a NOP instruction after STI to make sure the interrupt shadow doesn't extend past the enable function.

From the AMD64 APM, Volume 3:
> If STI sets the IF flag and IF was initially clear, then interrupts
> are not enabled until after the instruction following STI. Thus, if
> IF is 0, this code will not allow an INTR to happen:
>
> STI
> CLI
>
> In the following sequence, INTR will be allowed to happen only after the NOP.
>
> STI
> NOP
> CLI