### PR TITLE
implement DoubleEndedIterator for ranges + implement more iterator methods

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -717,6 +717,13 @@ impl Sub<PhysAddr> for PhysAddr {
     }
 }
 
+#[cfg(kani)]
+impl kani::Arbitrary for PhysAddr {
+    fn any() -> Self {
+        Self::new_truncate(kani::any())
+    }
+}
+
 /// Align address downwards.
 ///
 /// Returns the greatest `x` with alignment `align` so that `x <= addr`.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -259,7 +259,6 @@ impl VirtAddr {
     /// An implementation of steps_between that returns u64. Note that this
     /// function always returns the exact bound, so it doesn't need to return a
     /// lower and upper bound like steps_between does.
-    #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_u64(start: &Self, end: &Self) -> Option<u64> {
         let mut steps = end.0.checked_sub(start.0)?;
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -488,6 +488,13 @@ impl Step for VirtAddr {
     }
 }
 
+#[cfg(kani)]
+impl kani::Arbitrary for VirtAddr {
+    fn any() -> Self {
+        Self::new_truncate(kani::any())
+    }
+}
+
 /// A passed `u64` was not a valid physical address.
 ///
 /// This means that bits 52 to 64 were not all null.
@@ -993,10 +1000,8 @@ mod proofs {
     // step starting from any address.
     #[kani::proof]
     fn forward_base_case() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
+        let start_raw = start.as_u64();
 
         // Adding 0 to any address should always yield the same address.
         let same = Step::forward(start, 0);
@@ -1030,10 +1035,7 @@ mod proofs {
     // same as taking one combined large step.
     #[kani::proof]
     fn forward_induction_step() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
 
         let count1: usize = kani::any();
         let count2: usize = kani::any();
@@ -1060,10 +1062,7 @@ mod proofs {
     // for all inputs for which `forward_checked` succeeds.
     #[kani::proof]
     fn forward_implies_backward() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `forward_checked` succeeds...
@@ -1080,10 +1079,7 @@ mod proofs {
     // succeeds, `forward` succeeds as well.
     #[kani::proof]
     fn backward_implies_forward() {
-        let end_raw: u64 = kani::any();
-        let Ok(end) = VirtAddr::try_new(end_raw) else {
-            return;
-        };
+        let end = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `backward_checked` succeeds...
@@ -1105,10 +1101,7 @@ mod proofs {
     // `steps_between` for all inputs for which `forward_checked` succeeds.
     #[kani::proof]
     fn forward_implies_steps_between() {
-        let start: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `forward_checked` succeeds...
@@ -1124,14 +1117,8 @@ mod proofs {
     // succeeds, `forward` succeeds as well.
     #[kani::proof]
     fn steps_between_implies_forward() {
-        let start: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start) else {
-            return;
-        };
-        let end: u64 = kani::any();
-        let Ok(end) = VirtAddr::try_new(end) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
+        let end = kani::any::<VirtAddr>();
 
         // If `steps_between` succeeds...
         let Some(count) = Step::steps_between(&start, &end).1 else {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -222,6 +222,29 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
             None
         }
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` to `self.end` (it might overflow). Handle
+        // this by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1)?;
+            return self.next_back();
+        }
+
+        self.end -= n;
+        self.next_back()
+    }
 }
 
 impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
@@ -321,6 +344,29 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` to `self.end` (it might overflow). Handle
+        // this by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1)?;
+            return self.next_back();
+        }
+
+        self.end -= n;
+        self.next_back()
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -297,7 +297,16 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
             let frame = self.start;
-            self.start += 1;
+
+            // If the end of the inclusive range is the maximum page possible for size S,
+            // incrementing start until it is greater than the end will cause an integer overflow.
+            // So instead, in that case we decrement end rather than incrementing start.
+            let max_frame_addr = PhysAddr::new_truncate(u64::MAX) - (S::SIZE - 1);
+            if self.start.start_address() < max_frame_addr {
+                self.start += 1;
+            } else {
+                self.end -= 1;
+            }
             Some(frame)
         } else {
             None
@@ -339,8 +348,17 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
-            self.end -= 1;
-            Some(self.end)
+            let frame = self.end;
+
+            // If the start of the inclusive range is 0, decrementing end until
+            // it is smaller than the start will cause an integer underflow.
+            // So instead, in that case we increment start rather than decrementing end.
+            if self.end.start_address().as_u64() != 0 {
+                self.end -= 1;
+            } else {
+                self.start += 1;
+            }
+            Some(frame)
         } else {
             None
         }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -3,6 +3,7 @@
 use super::page::AddressNotAligned;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
+use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -179,6 +180,13 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
+    }
 }
 
 impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
@@ -248,6 +256,13 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -181,6 +181,29 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
         }
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start` (it might overflow). Handle this
+        // by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        self.start += n;
+        self.next()
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         usize::try_from(len)
@@ -256,6 +279,29 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start` (it might overflow). Handle this
+        // by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        self.start += n;
+        self.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -397,6 +397,13 @@ impl<S: PageSize> fmt::Debug for PhysFrameRangeInclusive<S> {
     }
 }
 
+#[cfg(kani)]
+impl<S: PageSize> kani::Arbitrary for PhysFrame<S> {
+    fn any() -> Self {
+        Self::containing_address(kani::any())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -411,5 +418,198 @@ mod tests {
 
         let range_inclusive = PhysFrameRangeInclusive { start, end };
         assert_eq!(range_inclusive.len(), 51);
+    }
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn phys_frame_range_next() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+
+        // Test that calling `next` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| start);
+        assert_eq!(range.next(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x2000).then(|| start + 1);
+        assert_eq!(range.next(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_inclusive_next() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+
+        // Test that calling `next` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some().then(|| start);
+        assert_eq!(range.next(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| start + 1);
+        assert_eq!(range.next(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_next_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+
+        // Test that calling `next_back` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| end - 1);
+        assert_eq!(range.next_back(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x2000).then(|| end - 2);
+        assert_eq!(range.next_back(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_inclusive_next_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+
+        // Test that calling `next_back` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some().then(|| end);
+        assert_eq!(range.next_back(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| end - 1);
+        assert_eq!(range.next_back(), expected_result);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that nth(0) behaves like next().
+        assert_eq!(range.next(), range2.nth(0));
+        assert_eq!(range.next(), range2.nth(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth(m);
+        assert_eq!(range.nth(n), range2.nth(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that nth(0) behaves like next().
+        assert_eq!(range.next(), range2.nth(0));
+        assert_eq!(range.next(), range2.nth(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth(m);
+        assert_eq!(range.nth(n), range2.nth(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_back_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that nth_back(0) behaves like next_back().
+        assert_eq!(range.next_back(), range2.nth_back(0));
+        assert_eq!(range.next_back(), range2.nth_back(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth_back(m);
+        assert_eq!(range.nth_back(n), range2.nth_back(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_back_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that nth_back(0) behaves like next_back().
+        assert_eq!(range.next_back(), range2.nth_back(0));
+        assert_eq!(range.next_back(), range2.nth_back(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth_back(m);
+        assert_eq!(range.nth_back(n), range2.nth_back(sum));
     }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -181,6 +181,18 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
     }
 }
 
+impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(self.end)
+        } else {
+            None
+        }
+    }
+}
+
 impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("PhysFrameRange")
@@ -233,6 +245,18 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
             let frame = self.start;
             self.start += 1;
             Some(frame)
+        } else {
+            None
+        }
+    }
+}
+
+impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start <= self.end {
+            self.end -= 1;
+            Some(self.end)
         } else {
             None
         }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -424,6 +424,40 @@ impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
             None
         }
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` from `self.end`. Handle this by doing two
+        // steps, `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1);
+            return self.next_back();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let first_half_end = Page::<S>::containing_address(VirtAddr::new(0x7fff_ffff_f000));
+        let steps_until_gap = Page::steps_between_u64(&first_half_end, &self.end)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.end -= steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next_back()?;
+            unreachable!("the previous call to `next_back` should have panicked")
+        }
+
+        self.end -= n;
+        self.next_back()
+    }
 }
 
 impl PageRange<Size2MiB> {
@@ -563,6 +597,40 @@ impl<S: PageSize> DoubleEndedIterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` from `self.end`. Handle this by doing two
+        // steps, `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1);
+            return self.next_back();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let first_half_end = Page::<S>::containing_address(VirtAddr::new(0x7fff_ffff_f000));
+        let steps_until_gap = Page::steps_between_u64(&first_half_end, &self.end)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.end -= steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next_back()?;
+            unreachable!("the previous call to `next_back` should have panicked")
+        }
+
+        self.end -= n;
+        self.next_back()
     }
 }
 
@@ -1051,6 +1119,60 @@ mod proofs {
         page_range_nth_harness(true);
     }
 
+    fn page_range_nth_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_start =
+            offset.and_then(|offset| end.start_address().as_u64().checked_sub(offset));
+        let should_panic = expected_start.is_some_and(|expected_start| {
+            expected_start <= 0xffff_7fff_ffff_f000
+                && end.start_address().as_u64() > 0xffff_7fff_ffff_f000
+        }) || expected_start.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth_back` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.nth_back(n as usize);
+            our_range.nth_back(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        assert_eq!(
+            our_range.nth_back(m as usize),
+            native_range.nth_back(m as usize)
+        );
+        assert_eq!(
+            our_range.nth_back(n as usize),
+            native_range.nth_back(n as usize)
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_nth_back() {
+        page_range_nth_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_nth_back_panic() {
+        page_range_nth_back_harness(true);
+    }
+
     fn page_range_inclusive_nth_harness(should_panic_mode: bool) {
         let start = kani::any::<Page>();
         let end = kani::any::<Page>();
@@ -1096,5 +1218,59 @@ mod proofs {
     #[kani::should_panic]
     fn page_range_inclusive_nth_panic() {
         page_range_inclusive_nth_harness(true);
+    }
+
+    fn page_range_inclusive_nth_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_start =
+            offset.and_then(|offset| end.start_address().as_u64().checked_sub(offset));
+        let should_panic = expected_start.is_some_and(|expected_start| {
+            expected_start <= 0xffff_7fff_ffff_f000
+                && end.start_address().as_u64() > 0xffff_7fff_ffff_f000
+        }) || expected_start.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth_back` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.nth_back(n as usize);
+            our_range.nth_back(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        assert_eq!(
+            our_range.nth_back(m as usize),
+            native_range.nth_back(m as usize)
+        );
+        assert_eq!(
+            our_range.nth_back(n as usize),
+            native_range.nth_back(n as usize)
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_inclusive_nth_back() {
+        page_range_inclusive_nth_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_inclusive_nth_back_panic() {
+        page_range_inclusive_nth_back_harness(true);
     }
 }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -765,3 +765,160 @@ mod tests {
         }
     }
 }
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    fn page_range_next_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0x7fff_ffff_e000
+            || start.start_address().as_u64() != 0x7fff_ffff_f000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.next();
+            our_range.next();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next(), native_range.next());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next(), native_range.next());
+    }
+
+    #[kani::proof]
+    fn page_range_next() {
+        page_range_next_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_next_panic() {
+        page_range_next_harness(true);
+    }
+
+    fn page_range_next_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0xffff_8000_0000_0000
+            || start.start_address().as_u64() != 0xffff_8000_0000_1000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next_back` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.next_back();
+            our_range.next_back();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+    }
+
+    #[kani::proof]
+    fn page_range_next_back() {
+        page_range_next_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_next_back_panic() {
+        page_range_next_back_harness(true);
+    }
+
+    fn page_range_inclusive_next_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0x7fff_ffff_e000
+            || start.start_address().as_u64() != 0x7fff_ffff_f000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.next();
+            our_range.next();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next(), native_range.next());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next(), native_range.next());
+    }
+
+    #[kani::proof]
+    fn page_range_inclusive_next() {
+        page_range_inclusive_next_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_inclusive_next_panic() {
+        page_range_inclusive_next_harness(true);
+    }
+
+    fn page_range_inclusive_next_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0xffff_8000_0000_0000
+            || start.start_address().as_u64() != 0xffff_8000_0000_1000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next_back` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.next_back();
+            our_range.next_back();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+    }
+
+    #[kani::proof]
+    fn page_range_inclusive_next_back() {
+        page_range_inclusive_next_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_inclusive_next_back_panic() {
+        page_range_inclusive_next_back_harness(true);
+    }
+}

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -460,6 +460,13 @@ impl<S: PageSize> fmt::Debug for PageRangeInclusive<S> {
     }
 }
 
+#[cfg(kani)]
+impl<S: PageSize> kani::Arbitrary for Page<S> {
+    fn any() -> Self {
+        Self::containing_address(kani::any())
+    }
+}
+
 /// The given address was not sufficiently aligned.
 #[derive(Debug)]
 pub struct AddressNotAligned;

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -160,12 +160,15 @@ impl<S: PageSize> Page<S> {
     }
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
+    pub(crate) fn steps_between_u64(start: &Self, end: &Self) -> Option<u64> {
+        VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
+            .map(|steps| steps / S::SIZE)
+    }
+
+    // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
-        if let Some(steps) =
-            VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
-        {
-            let steps = steps / S::SIZE;
+        if let Some(steps) = Self::steps_between_u64(start, end) {
             let steps = usize::try_from(steps).ok();
             (steps.unwrap_or(usize::MAX), steps)
         } else {
@@ -369,6 +372,40 @@ impl<S: PageSize> Iterator for PageRange<S> {
         }
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start`. Handle this by doing two steps,
+        // `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let second_half_start = Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
+        let steps_until_gap = Page::steps_between_u64(&self.start, &second_half_start)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.start += steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next()?;
+            unreachable!("the previous call to `next` should have panicked")
+        }
+
+        self.start += n;
+        self.next()
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         usize::try_from(len)
@@ -464,6 +501,40 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start`. Handle this by doing two steps,
+        // `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let second_half_start = Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
+        let steps_until_gap = Page::steps_between_u64(&self.start, &second_half_start)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.start += steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next()?;
+            unreachable!("the previous call to `next` should have panicked")
+        }
+
+        self.start += n;
+        self.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -931,5 +1002,99 @@ mod proofs {
     #[kani::should_panic]
     fn page_range_inclusive_next_back_panic() {
         page_range_inclusive_next_back_harness(true);
+    }
+
+    fn page_range_nth_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_end =
+            offset.and_then(|offset| start.start_address().as_u64().checked_add(offset));
+        let should_panic = expected_end.is_some_and(|expected_end| {
+            start.start_address().as_u64() <= 0x7fff_ffff_f000 && expected_end > 0x7fff_ffff_f000
+        }) || expected_end.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.nth(n as usize);
+            our_range.nth(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        assert_eq!(our_range.nth(m as usize), native_range.nth(m as usize));
+        assert_eq!(our_range.nth(n as usize), native_range.nth(n as usize));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_nth() {
+        page_range_nth_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_nth_panic() {
+        page_range_nth_harness(true);
+    }
+
+    fn page_range_inclusive_nth_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_end =
+            offset.and_then(|offset| start.start_address().as_u64().checked_add(offset));
+        let should_panic = expected_end.is_some_and(|expected_end| {
+            start.start_address().as_u64() <= 0x7fff_ffff_f000 && expected_end > 0x7fff_ffff_f000
+        }) || expected_end.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.nth(n as usize);
+            our_range.nth(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        assert_eq!(our_range.nth(m as usize), native_range.nth(m as usize));
+        assert_eq!(our_range.nth(n as usize), native_range.nth(n as usize));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_inclusive_nth() {
+        page_range_inclusive_nth_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_inclusive_nth_panic() {
+        page_range_inclusive_nth_harness(true);
     }
 }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -373,6 +373,18 @@ impl<S: PageSize> Iterator for PageRange<S> {
     }
 }
 
+impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(self.end)
+        } else {
+            None
+        }
+    }
+}
+
 impl PageRange<Size2MiB> {
     /// Converts the range of 2MiB pages to a range of 4KiB pages.
     #[inline]
@@ -443,6 +455,27 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
                 self.start += 1;
             } else {
                 self.end -= 1;
+            }
+            Some(page)
+        } else {
+            None
+        }
+    }
+}
+
+impl<S: PageSize> DoubleEndedIterator for PageRangeInclusive<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start <= self.end {
+            let page = self.end;
+
+            // If the start of the inclusive range is 0, decrementing end until
+            // it is smaller than the start will cause an integer underflow.
+            // So instead, in that case we increment start rather than decrementing end.
+            if self.end.start_address().as_u64() != 0 {
+                self.end -= 1;
+            } else {
+                self.start += 1;
             }
             Some(page)
         } else {
@@ -551,6 +584,18 @@ mod tests {
 
     // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
     #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_next_back_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range(start, end).next_back();
+    }
+
+    #[test]
     #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
     fn test_page_range_inclusive_next_not_jumping_gap_panics() {
         let start = 0x7fff_ffff_f000;
@@ -563,6 +608,19 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_inclusive_next_back_not_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next_back();
+    }
+
+    // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
+    #[test]
     #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
     fn test_page_range_inclusive_next_jumping_gap_panics() {
         let start = 0x7fff_ffff_f000;
@@ -573,6 +631,19 @@ mod tests {
         let end = Page::from_start_address(end).unwrap();
         Page::range_inclusive(start, end).next();
         Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_inclusive_next_back_jumping_gap_panics() {
+        let start = 0xffff_8000_0000_0000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next_back();
+        Page::range_inclusive(start, end).next_back();
     }
 
     #[test]

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -538,6 +538,44 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_next_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range(start, end).next();
+    }
+
+    // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
+    #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_inclusive_next_not_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0x7fff_ffff_f000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_inclusive_next_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0x7fff_ffff_f000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next();
+        Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
     pub fn test_page_range_len() {
         let start_addr = VirtAddr::new(0xdead_beaf);
         let start = Page::<Size4KiB>::containing_address(start_addr);

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -4,6 +4,7 @@ use crate::sealed::Sealed;
 use crate::structures::paging::page_table::PageTableLevel;
 use crate::structures::paging::PageTableIndex;
 use crate::VirtAddr;
+use core::convert::TryFrom;
 use core::fmt;
 #[cfg(feature = "step_trait")]
 use core::iter::Step;
@@ -161,8 +162,6 @@ impl<S: PageSize> Page<S> {
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
-        use core::convert::TryFrom;
-
         if let Some(steps) =
             VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
         {
@@ -177,8 +176,6 @@ impl<S: PageSize> Page<S> {
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn forward_checked_impl(start: Self, count: usize) -> Option<Self> {
-        use core::convert::TryFrom;
-
         let count = u64::try_from(count).ok()?.checked_mul(S::SIZE)?;
         let start_address = VirtAddr::forward_checked_u64(start.start_address, count)?;
         Some(Self {
@@ -371,6 +368,13 @@ impl<S: PageSize> Iterator for PageRange<S> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
+    }
 }
 
 impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
@@ -460,6 +464,13 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
     }
 }
 


### PR DESCRIPTION
This PR implements `DoubleEndedIterator` for `DoubleEndedIterator` for `PageRange`, `PageRangeInclusive`, `PhysFrameRange`, and `PhysFrameRangeInclusive`. This PR also implements `nth`, `nth_back`, and `size_hint` for the range types.

For my use case, I primarily needed an efficient (O(1)) implementation of `PhysFrameRange::nth_back` and since I was already working on that, I figured I might as well add implementations for the other range types as well.

Implementing the panicking behavior for `PageRange`/`PageRangeInclusive` was a bit annoying, so I added kani proofs to make sure the implementations behave correctly for all inputs.