### PR TITLE
feat: Added the "from_pfn" in PhysFrame

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,6 +11,8 @@ use core::sync::atomic::Ordering;
 #[cfg(feature = "memory_encryption")]
 use crate::structures::mem_encrypt::ENC_BIT_MASK;
 use crate::structures::paging::page_table::PageTableLevel;
+#[cfg(doc)]
+use crate::structures::paging::PhysFrame;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 
 use bit_field::BitField;
@@ -522,7 +524,8 @@ impl kani::Arbitrary for VirtAddr {
 ///
 /// This means that bits 52 to 64 were not all null.
 ///
-/// Contains the invalid address.
+/// Contains the invalid address in common situation, or the PFN number
+/// if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
 pub struct PhysAddrNotValid(pub u64);
 
 impl core::fmt::Debug for PhysAddrNotValid {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,8 +11,6 @@ use core::sync::atomic::Ordering;
 #[cfg(feature = "memory_encryption")]
 use crate::structures::mem_encrypt::ENC_BIT_MASK;
 use crate::structures::paging::page_table::PageTableLevel;
-#[cfg(doc)]
-use crate::structures::paging::PhysFrame;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 
 use bit_field::BitField;
@@ -524,8 +522,7 @@ impl kani::Arbitrary for VirtAddr {
 ///
 /// This means that bits 52 to 64 were not all null.
 ///
-/// Contains the invalid address in common situation, or the PFN number
-/// if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+/// Contains the invalid address.
 pub struct PhysAddrNotValid(pub u64);
 
 impl core::fmt::Debug for PhysAddrNotValid {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -539,8 +539,9 @@ impl PhysAddr {
     /// ## Panics
     ///
     /// This function panics if a bit in the range 52 to 64 is set.
-    // If the `memory_encryption` feature has been enabled and an encryption bit has been
-    // configured, this also panics if the encryption bit is manually set in the address.
+    ///
+    /// If the `memory_encryption` feature has been enabled and an encryption bit has been
+    /// configured, this also panics if the encryption bit is manually set in the address.
     #[inline]
     #[const_fn(cfg(not(feature = "memory_encryption")))]
     pub const fn new(addr: u64) -> Self {

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -469,7 +469,7 @@ mod x86_64 {
             ss_syscall: SegmentSelector,
         ) -> Result<(), InvalidStarSegmentSelectors> {
             // Convert to i32 to prevent underflows.
-            let cs_sysret_cmp = i32::from(cs_sysret.0);
+            let cs_sysret_cmp = i32::from(cs_sysret.0) - 16;
             let ss_sysret_cmp = i32::from(ss_sysret.0) - 8;
             let cs_syscall_cmp = i32::from(cs_syscall.0);
             let ss_syscall_cmp = i32::from(ss_syscall.0) - 8;

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -428,9 +428,12 @@ mod x86_64 {
         /// not valid for long mode.
         ///
         /// # Parameters
-        /// - sysret: The CS selector is set to this field + 16. SS.Sel is set to
-        ///   this field + 8. Because SYSRET always returns to CPL 3, the
-        ///   RPL bits 1:0 should be initialized to 11b.
+        ///
+        /// - sysret: For SYSRETQ (64-bit), the CS selector is set to this
+        ///   field + 16. For SYSRET (32-bit), the CS selector is set to this
+        ///   field. SS.Sel is set to this field + 8. Because SYSRETQ/SYSRET
+        ///   always returns to CPL 3, the RPL bits 1:0 should be initialized
+        ///   to 11b.
         /// - syscall: This field is copied directly into CS.Sel. SS.Sel is set to
         ///   this field + 8. Because SYSCALL always switches to CPL 0, the RPL bits
         ///   33:32 should be initialized to 00b.
@@ -459,8 +462,8 @@ mod x86_64 {
         /// not in the correct offset of each other or if the
         /// segment selectors do not have correct privileges.
         ///
-        /// Also, if you want to return from syscall, you
-        /// shall use "sysretq" (64) instead of "sysret" (32).
+        /// Note that `cs_sysret` should contain the segment to be used for
+        /// SYSRETQ (64-bit), not SYSRET (32-bit).
         #[inline]
         pub fn write(
             cs_sysret: SegmentSelector,

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -451,11 +451,16 @@ mod x86_64 {
         }
 
         /// Write the Ring 0 and Ring 3 segment bases.
+        ///
         /// The remaining fields are ignored because they are
         /// not valid for long mode.
+        ///
         /// This function will fail if the segment selectors are
         /// not in the correct offset of each other or if the
         /// segment selectors do not have correct privileges.
+        ///
+        /// Also, if you want to return from syscall, you
+        /// shall use "sysretq" (64) instead of "sysret" (32).
         #[inline]
         pub fn write(
             cs_sysret: SegmentSelector,

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -464,7 +464,7 @@ mod x86_64 {
             ss_syscall: SegmentSelector,
         ) -> Result<(), InvalidStarSegmentSelectors> {
             // Convert to i32 to prevent underflows.
-            let cs_sysret_cmp = i32::from(cs_sysret.0) - 16;
+            let cs_sysret_cmp = i32::from(cs_sysret.0);
             let ss_sysret_cmp = i32::from(ss_sysret.0) - 8;
             let cs_syscall_cmp = i32::from(cs_syscall.0);
             let ss_syscall_cmp = i32::from(ss_syscall.0) - 8;

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -10,11 +10,9 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A passed `u64` was not a valid physical address.
 ///
-/// This means address which PFN refer to is:
-///  - Overflowed the `u64`;
-///  - The address's 52..64 is not empty.
+/// This means that bits 40 to 64 were not all null.
 ///
-/// Contains the invalid PFN number if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+/// Contains the invalid PFN.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct InvalidPfn(pub u64);
@@ -68,11 +66,15 @@ impl<S: PageSize> PhysFrame<S> {
 
     /// Returns the frame by a physical frame number.
     ///
-    /// This function will automatically time the size of the frame to get its
-    /// physical address
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size4KiB}};
     ///
-    /// ## Panics
-    /// Will panic if the after-converted address's 52..64 bits is not empty.
+    /// assert_eq!(PhysFrame::<Size4KiB>::from_pfn(0x123), PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000)));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the resulting address is not valid.
     #[inline]
     pub fn from_pfn(pfn: u64) -> Self {
         match Self::try_from_pfn(pfn) {
@@ -81,10 +83,17 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
-    /// Try to convert a physical frame number to a frame.
+    /// Returns the frame by a physical frame number.
     ///
-    /// ## Error
-    /// Will return error if the after-converted address's 52..64 bits is not empty.
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size4KiB}};
+    ///
+    /// assert_eq!(PhysFrame::<Size4KiB>::try_from_pfn(0x123), Ok(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000))));
+    /// ```
+    ///
+    /// # Error
+    ///
+    /// This function will return an error if the resulting address is not valid.
     #[inline]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
         let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
@@ -95,10 +104,11 @@ impl<S: PageSize> PhysFrame<S> {
         })
     }
 
-    /// Returns the frame by a physical frame number without checking.
+    /// Returns the frame by a physical frame number.
     ///
     /// # Safety
-    /// The PFN must be valid (The after-converted address's 52..64 bits must be empty).
+    ///
+    /// The resulting address must be valid.
     #[inline]
     #[rustversion::attr(since(1.61), const)]
     pub unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
@@ -133,6 +143,20 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the PFN of the current frame.
+    ///
+    /// The PFN is defined to be the address divided by the page size.
+    ///
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size1GiB, Size2MiB, Size4KiB}};
+    ///
+    /// assert_eq!(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000)).pfn(), 0x123);
+    ///
+    /// // Note that this means that the PFN for the same address will be
+    /// // different for different page sizes.
+    /// assert_eq!(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0xC0000);
+    /// assert_eq!(PhysFrame::<Size2MiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0x600);
+    /// assert_eq!(PhysFrame::<Size1GiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0x3);
+    /// ```
     #[inline]
     #[rustversion::attr(since(1.61), const)]
     pub fn pfn(self) -> u64 {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -48,6 +48,9 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
+    /// 
+    /// This function will automatically time the size of the frame to get its 
+    /// physical address
     ///
     /// ## Panics
     /// Will panic if the after-converted address's 52..64 bits is not empty.

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -1,6 +1,7 @@
 //! Abstractions for default-sized and huge physical memory frames.
 
 use super::page::AddressNotAligned;
+use crate::addr::PhysAddrNotValid;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
 use core::convert::TryFrom;
@@ -47,19 +48,39 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
+    ///
+    /// ## Panics
+    /// Will panic if the after-converted address's 52..64 bits is not empty.
     #[inline]
     pub fn from_pfn(pfn: u64) -> Self {
-        // Let's see the size of this frame...
-        // XXX: We have to hard-code it, as it only supports number, not expr.
-        let addr = match S::SIZE {
-            4096 => PhysAddr::new(pfn >> 12),           // Size4KiB
-            2097152 => PhysAddr::new(pfn >> 21),        // Size2MiB
-            1073741824 => PhysAddr::new(pfn >> 30),     // Size1GiB
-            _ => panic!("Invalid frame size: {}", S::SIZE),   // Wth???
-        };
+        match Self::try_from_pfn(pfn) {
+            Ok(frame) => frame,
+            Err(_) => panic!("The PFN \"{}\"is not valid", pfn),
+        }
+    }
 
+    /// Try to convert a physical frame number to a frame.
+    ///
+    /// ## Error
+    /// Will return error if the after-converted address's 52..64 bits is not empty.
+    #[inline]
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
+        let addr = PhysAddr::try_new(pfn * S::SIZE)?;
+        Ok(PhysFrame {
+            start_address: addr,
+            size: PhantomData,
+        })
+    }
+
+    /// Returns the frame by a physical frame number without checking.
+    ///
+    /// # Safety
+    /// The PFN must be valid (The after-converted address's 52..64 bits must be empty).
+    #[inline]
+    #[rustversion::attr(since(1.61), const)]
+    pub unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
         PhysFrame {
-            start_address: addr,    // Already aligned upthere
+            start_address: unsafe { PhysAddr::new_unsafe(pfn * S::SIZE) },
             size: PhantomData,
         }
     }
@@ -86,6 +107,13 @@ impl<S: PageSize> PhysFrame<S> {
     #[rustversion::attr(since(1.61), const)]
     pub fn size(self) -> u64 {
         S::SIZE
+    }
+
+    /// Returns the PFN of the current frame.
+    #[inline]
+    #[rustversion::attr(since(1.61), const)]
+    pub fn pfn(self) -> u64 {
+        self.start_address.as_u64() / S::SIZE
     }
 
     /// Returns a range of frames, exclusive `end`.

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -58,10 +58,14 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will panic if the resulting address is not valid.
     #[inline]
+    #[rustversion::attr(
+        since(1.61),
+        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
+    )]
     pub fn from_pfn(pfn: u64) -> Self {
         match Self::try_from_pfn(pfn) {
             Ok(frame) => frame,
-            Err(_) => panic!("The PFN \"{}\"is not valid", pfn),
+            Err(_) => panic!("PFNs must not have any bits in the range 40 to 64 set"),
         }
     }
 
@@ -77,9 +81,21 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will return an error if the resulting address is not valid.
     #[inline]
+    #[rustversion::attr(
+        since(1.61),
+        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
+    )]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, PfnNotValid> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PfnNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw).map_err(|_| PfnNotValid(pfn))?;
+        let addr_raw = if let Some(addr_raw) = pfn.checked_mul(S::SIZE) {
+            addr_raw
+        } else {
+            return Err(PfnNotValid(pfn));
+        };
+        let addr = if let Ok(addr) = PhysAddr::try_new(addr_raw) {
+            addr
+        } else {
+            return Err(PfnNotValid(pfn));
+        };
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -48,8 +48,8 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
-    /// 
-    /// This function will automatically time the size of the frame to get its 
+    ///
+    /// This function will automatically time the size of the frame to get its
     /// physical address
     ///
     /// ## Panics
@@ -68,7 +68,8 @@ impl<S: PageSize> PhysFrame<S> {
     /// Will return error if the after-converted address's 52..64 bits is not empty.
     #[inline]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
-        let addr = PhysAddr::try_new(pfn * S::SIZE)?;
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PhysAddrNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw)?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -46,6 +46,24 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    /// Returns the frame by a physical frame number.
+    #[inline]
+    pub fn from_pfn(pfn: u64) -> Self {
+        // Let's see the size of this frame...
+        // XXX: We have to hard-code it, as it only supports number, not expr.
+        let addr = match S::SIZE {
+            4096 => PhysAddr::new(pfn >> 12),           // Size4KiB
+            2097152 => PhysAddr::new(pfn >> 21),        // Size2MiB
+            1073741824 => PhysAddr::new(pfn >> 30),     // Size1GiB
+            _ => panic!("Invalid frame size: {}", S::SIZE),   // Wth???
+        };
+
+        PhysFrame {
+            start_address: addr,    // Already aligned upthere
+            size: PhantomData,
+        }
+    }
+
     /// Returns the frame that contains the given physical address.
     #[inline]
     #[rustversion::attr(since(1.61), const)]

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -8,24 +8,6 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-/// A passed `u64` was not a valid physical address.
-///
-/// This means that bits 40 to 64 were not all null.
-///
-/// Contains the invalid PFN.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct InvalidPfn(pub u64);
-
-// Implementation of display
-impl fmt::Display for InvalidPfn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PhysAddrNotValid")
-            .field(&format_args!("{:#x}", self.0))
-            .finish()
-    }
-}
-
 /// A physical memory frame.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
@@ -95,9 +77,9 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will return an error if the resulting address is not valid.
     #[inline]
-    pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw).map_err(|_| InvalidPfn(pfn))?;
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, PfnNotValid> {
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PfnNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw).map_err(|_| PfnNotValid(pfn))?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,
@@ -345,6 +327,24 @@ impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
         f.debug_struct("PhysFrameRange")
             .field("start", &self.start)
             .field("end", &self.end)
+            .finish()
+    }
+}
+
+/// A passed `u64` was not a valid physical address.
+///
+/// This means that bits 40 to 64 were not all null.
+///
+/// Contains the invalid PFN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PfnNotValid(pub u64);
+
+// Implementation of display
+impl fmt::Display for PfnNotValid {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("PhysAddrNotValid")
+            .field(&format_args!("{:#x}", self.0))
             .finish()
     }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -1,13 +1,32 @@
 //! Abstractions for default-sized and huge physical memory frames.
 
 use super::page::AddressNotAligned;
-use crate::addr::PhysAddrNotValid;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+/// A passed `u64` was not a valid physical address.
+///
+/// This means address which PFN refer to is:
+///  - Overflowed the `u64`;
+///  - The address's 52..64 is not empty.
+///
+/// Contains the invalid PFN number if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct InvalidPfn(pub u64);
+
+// Implementation of display
+impl fmt::Display for InvalidPfn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("PhysAddrNotValid")
+            .field(&format_args!("{:#x}", self.0))
+            .finish()
+    }
+}
 
 /// A physical memory frame.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -67,9 +86,9 @@ impl<S: PageSize> PhysFrame<S> {
     /// ## Error
     /// Will return error if the after-converted address's 52..64 bits is not empty.
     #[inline]
-    pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PhysAddrNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw)?;
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw).map_err(|_| InvalidPfn(pfn))?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,


### PR DESCRIPTION
# Preface
Sometimes, I know its PFN number (espeically in frame allocator), but I have to convert it again and again - That's annoying, and may cause performance problem.

So, the `from_pfn` is one way to solve this problem - No need to convert, write that shitty long code!

# Changelog
 - Added a fn called `from_pfn` that was in `PhysFrame`