### PR TITLE
add missing {forward,backward}_overflowing impls

### DIFF
--- a/src/addr.rs
+++ b/src/addr.rs
@@ -485,6 +485,30 @@ impl Step for VirtAddr {
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         Self::backward_checked_u64(start, u64::try_from(count).ok()?)
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 #[cfg(kani)]
@@ -934,6 +958,26 @@ mod tests {
             Step::steps_between(&VirtAddr(0), &VirtAddr(0x1_0000_0000)),
             (usize::MAX, None)
         );
+    }
+
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn virtaddr_step_overflowing() {
+        assert_eq!(
+            Step::forward_overflowing(VirtAddr(0x7fff_ffff_ffff), 1),
+            (VirtAddr(0xffff_8000_0000_0000), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(VirtAddr(0xffff_8000_0000_0000), 1),
+            (VirtAddr(0x7fff_ffff_ffff), false)
+        );
+        assert_eq!(
+            Step::forward_overflowing(VirtAddr(0), 0),
+            (VirtAddr(0), false)
+        );
+
+        assert!(Step::forward_overflowing(VirtAddr(0xffff_ffff_ffff_ffff), 1).1);
+        assert!(Step::backward_overflowing(VirtAddr(0), 1).1);
     }
 
     #[test]

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -322,6 +322,28 @@ impl<S: PageSize> Step for Page<S> {
             size: PhantomData,
         })
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 /// A range of pages with exclusive upper bound.
@@ -913,6 +935,24 @@ mod tests {
             let end = Page::from_start_address(VirtAddr::new(end)).unwrap();
             assert_eq!(Step::steps_between(&start, &end), (lower, upper));
         }
+    }
+
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn page_step_overflowing() {
+        let page = |addr| Page::<Size4KiB>::from_start_address(VirtAddr::new(addr)).unwrap();
+
+        assert_eq!(
+            Step::forward_overflowing(page(0x7fff_ffff_f000), 1),
+            (page(0xffff_8000_0000_0000), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(page(0xffff_8000_0000_0000), 1),
+            (page(0x7fff_ffff_f000), false)
+        );
+
+        assert!(Step::forward_overflowing(page(0xffff_ffff_ffff_f000), 1).1);
+        assert!(Step::backward_overflowing(page(0), 1).1);
     }
 }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -388,6 +388,30 @@ impl Step for PageTableIndex {
         let idx = usize::from(start).checked_sub(count)?;
         Some(Self::new(idx as u16))
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 /// A 12-bit offset into a 4KiB Page.
@@ -483,5 +507,27 @@ impl PageTableLevel {
     /// Returns the alignment for the address space described by an entry in a table of this level.
     pub const fn entry_address_space_alignment(self) -> u64 {
         1u64 << (((self as u8 - 1) * 9) + 12)
+    }
+}
+
+#[cfg(all(test, feature = "step_trait"))]
+mod tests {
+    use super::*;
+    use core::iter::Step;
+
+    #[test]
+    fn page_table_index_step_overflowing() {
+        assert_eq!(
+            Step::forward_overflowing(PageTableIndex::new(0), 511),
+            (PageTableIndex::new(511), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(PageTableIndex::new(511), 511),
+            (PageTableIndex::new(0), false)
+        );
+
+        // Overflow the 0..512 range: only the flag is specified.
+        assert!(Step::forward_overflowing(PageTableIndex::new(511), 1).1);
+        assert!(Step::backward_overflowing(PageTableIndex::new(0), 1).1);
     }
 }


### PR DESCRIPTION
Cause: rust-lang/rust#155114

One problem: [Kani bundles `nightly-2025-11-21`](https://github.com/model-checking/kani/releases/tag/kani-0.67.0) (their `main` bundles `nightly-2025-12-31` as of 2026-07-09 (yesterday at the time of writing) as per model-checking/kani#4624), meaning I can't add Kani proofs. Once they bundle `nightly-2026-07-10` or later, you can do this: https://github.com/rust-osdev/x86_64/compare/4bc97dadf4481e6d8ce858c0ca6413e351322c12..9bf986f2282f691ccc856087bf7a86cd41316c03 (without disabling Kani of course).

Fixes #594