### PR TITLE
chore: merge master into next

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,6 +178,13 @@ jobs:
       - name: Check semver
         run: cargo +stable semver-checks check-release --default-features
 
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: crate-ci/typos@v1.42.0
+
   kani:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       # rustup prioritizes environment variables over rust-toolchain.toml files.
       RUSTUP_TOOLCHAIN: ${{ matrix.rust }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
@@ -56,7 +56,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: x86_64-unknown-linux-musl, i686-unknown-linux-musl, thumbv7em-none-eabihf
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Cache binaries
         id: cache-bin
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -159,7 +159,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: clippy
@@ -169,7 +169,7 @@ jobs:
     name: Semver Checks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "semver-checks"
@@ -182,13 +182,13 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: crate-ci/typos@v1.42.0
 
   kani:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "kani"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: "Checkout Repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Run release script"
         run: "python scripts/ci-release.py"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT/Apache-2.0"
 name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
-version = "0.15.4"
+version = "0.15.5"
 edition = "2018"
 rust-version = "1.59" # Needed to support inline asm and default const generics
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,30 @@
 # Unreleased
 
+# 0.15.5 – 2026-07-11
+
+This release is compatible with Rust nightlies starting with `nightly-2026-07-10` (this only applies when the `nightly` feature is used).
+
+## New Features
+
+- [implement DoubleEndedIterator for ranges + implement more iterator methods](https://github.com/rust-osdev/x86_64/pull/589)
+- [feat: Added the "from_pfn" in PhysFrame](https://github.com/rust-osdev/x86_64/pull/593)
+
+## Fixes
+
+- [fix(instructions): allow unused_unsafe for cpuid](https://github.com/rust-osdev/x86_64/pull/575)
+- [fix(mapper): inline internal map_to\_\* functions](https://github.com/rust-osdev/x86_64/pull/578)
+- [docs: fix typos](https://github.com/rust-osdev/x86_64/pull/579)
+- [docs(page): fix typos](https://github.com/rust-osdev/x86_64/pull/582)
+- [don't enable abi_x86_interrupt if not needed](https://github.com/rust-osdev/x86_64/pull/585)
+- [insert NOP after STI](https://github.com/rust-osdev/x86_64/pull/588)
+- [add missing {forward,backward}\_overflowing impls](https://github.com/rust-osdev/x86_64/pull/595)
+
+## Other Improvements
+
+- [Bump actions/cache from 4 to 5](https://github.com/rust-osdev/x86_64/pull/573)
+- [ci: add typos job](https://github.com/rust-osdev/x86_64/pull/580)
+- [Bump actions/checkout from 6 to 7](https://github.com/rust-osdev/x86_64/pull/590)
+
 # 0.15.4 – 2025-11-24
 
 ## New Features

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -84,7 +84,7 @@ impl VirtAddr {
 
     /// Tries to create a new canonical virtual address.
     ///
-    /// This function checks wether the given address is canonical
+    /// This function checks whether the given address is canonical
     /// and returns an error otherwise. An address is canonical
     /// if bits 48 to 64 are a correct sign
     /// extension (i.e. copies of bit 47).

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -717,6 +717,13 @@ impl Sub<PhysAddr> for PhysAddr {
     }
 }
 
+#[cfg(kani)]
+impl kani::Arbitrary for PhysAddr {
+    fn any() -> Self {
+        Self::new_truncate(kani::any())
+    }
+}
+
 /// Align address downwards.
 ///
 /// Returns the greatest `x` with alignment `align` so that `x <= addr`.

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,6 +11,8 @@ use core::sync::atomic::Ordering;
 #[cfg(feature = "memory_encryption")]
 use crate::structures::mem_encrypt::ENC_BIT_MASK;
 use crate::structures::paging::page_table::PageTableLevel;
+#[cfg(doc)]
+use crate::structures::paging::PhysFrame;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 
 use bit_field::BitField;
@@ -522,7 +524,8 @@ impl kani::Arbitrary for VirtAddr {
 ///
 /// This means that bits 52 to 64 were not all null.
 ///
-/// Contains the invalid address.
+/// Contains the invalid address in common situation, or the PFN number
+/// if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
 pub struct PhysAddrNotValid(pub u64);
 
 impl core::fmt::Debug for PhysAddrNotValid {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -11,8 +11,6 @@ use core::sync::atomic::Ordering;
 #[cfg(feature = "memory_encryption")]
 use crate::structures::mem_encrypt::ENC_BIT_MASK;
 use crate::structures::paging::page_table::PageTableLevel;
-#[cfg(doc)]
-use crate::structures::paging::PhysFrame;
 use crate::structures::paging::{PageOffset, PageTableIndex};
 
 use bit_field::BitField;
@@ -524,8 +522,7 @@ impl kani::Arbitrary for VirtAddr {
 ///
 /// This means that bits 52 to 64 were not all null.
 ///
-/// Contains the invalid address in common situation, or the PFN number
-/// if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+/// Contains the invalid address.
 pub struct PhysAddrNotValid(pub u64);
 
 impl core::fmt::Debug for PhysAddrNotValid {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -485,6 +485,30 @@ impl Step for VirtAddr {
     fn backward_checked(start: Self, count: usize) -> Option<Self> {
         Self::backward_checked_u64(start, u64::try_from(count).ok()?)
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 #[cfg(kani)]
@@ -934,6 +958,26 @@ mod tests {
             Step::steps_between(&VirtAddr(0), &VirtAddr(0x1_0000_0000)),
             (usize::MAX, None)
         );
+    }
+
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn virtaddr_step_overflowing() {
+        assert_eq!(
+            Step::forward_overflowing(VirtAddr(0x7fff_ffff_ffff), 1),
+            (VirtAddr(0xffff_8000_0000_0000), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(VirtAddr(0xffff_8000_0000_0000), 1),
+            (VirtAddr(0x7fff_ffff_ffff), false)
+        );
+        assert_eq!(
+            Step::forward_overflowing(VirtAddr(0), 0),
+            (VirtAddr(0), false)
+        );
+
+        assert!(Step::forward_overflowing(VirtAddr(0xffff_ffff_ffff_ffff), 1).1);
+        assert!(Step::backward_overflowing(VirtAddr(0), 1).1);
     }
 
     #[test]

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -539,8 +539,9 @@ impl PhysAddr {
     /// ## Panics
     ///
     /// This function panics if a bit in the range 52 to 64 is set.
-    // If the `memory_encryption` feature has been enabled and an encryption bit has been
-    // configured, this also panics if the encryption bit is manually set in the address.
+    ///
+    /// If the `memory_encryption` feature has been enabled and an encryption bit has been
+    /// configured, this also panics if the encryption bit is manually set in the address.
     #[inline]
     #[const_fn(cfg(not(feature = "memory_encryption")))]
     pub const fn new(addr: u64) -> Self {

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -259,7 +259,6 @@ impl VirtAddr {
     /// An implementation of steps_between that returns u64. Note that this
     /// function always returns the exact bound, so it doesn't need to return a
     /// lower and upper bound like steps_between does.
-    #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_u64(start: &Self, end: &Self) -> Option<u64> {
         let mut steps = end.0.checked_sub(start.0)?;
 

--- a/src/addr.rs
+++ b/src/addr.rs
@@ -488,6 +488,13 @@ impl Step for VirtAddr {
     }
 }
 
+#[cfg(kani)]
+impl kani::Arbitrary for VirtAddr {
+    fn any() -> Self {
+        Self::new_truncate(kani::any())
+    }
+}
+
 /// A passed `u64` was not a valid physical address.
 ///
 /// This means that bits 52 to 64 were not all null.
@@ -993,10 +1000,8 @@ mod proofs {
     // step starting from any address.
     #[kani::proof]
     fn forward_base_case() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
+        let start_raw = start.as_u64();
 
         // Adding 0 to any address should always yield the same address.
         let same = Step::forward(start, 0);
@@ -1030,10 +1035,7 @@ mod proofs {
     // same as taking one combined large step.
     #[kani::proof]
     fn forward_induction_step() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
 
         let count1: usize = kani::any();
         let count2: usize = kani::any();
@@ -1060,10 +1062,7 @@ mod proofs {
     // for all inputs for which `forward_checked` succeeds.
     #[kani::proof]
     fn forward_implies_backward() {
-        let start_raw: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start_raw) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `forward_checked` succeeds...
@@ -1080,10 +1079,7 @@ mod proofs {
     // succeeds, `forward` succeeds as well.
     #[kani::proof]
     fn backward_implies_forward() {
-        let end_raw: u64 = kani::any();
-        let Ok(end) = VirtAddr::try_new(end_raw) else {
-            return;
-        };
+        let end = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `backward_checked` succeeds...
@@ -1105,10 +1101,7 @@ mod proofs {
     // `steps_between` for all inputs for which `forward_checked` succeeds.
     #[kani::proof]
     fn forward_implies_steps_between() {
-        let start: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
         let count: usize = kani::any();
 
         // If `forward_checked` succeeds...
@@ -1124,14 +1117,8 @@ mod proofs {
     // succeeds, `forward` succeeds as well.
     #[kani::proof]
     fn steps_between_implies_forward() {
-        let start: u64 = kani::any();
-        let Ok(start) = VirtAddr::try_new(start) else {
-            return;
-        };
-        let end: u64 = kani::any();
-        let Ok(end) = VirtAddr::try_new(end) else {
-            return;
-        };
+        let start = kani::any::<VirtAddr>();
+        let end = kani::any::<VirtAddr>();
 
         // If `steps_between` succeeds...
         let Some(count) = Step::steps_between(&start, &end).1 else {

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -18,7 +18,7 @@ pub fn enable() {
     // Omit `nomem` to imitate a lock release. Otherwise, the compiler
     // is free to move reads and writes through this asm block.
     unsafe {
-        asm!("sti", options(preserves_flags, nostack));
+        asm!("sti", "nop", options(preserves_flags, nostack));
     }
 }
 

--- a/src/instructions/interrupts.rs
+++ b/src/instructions/interrupts.rs
@@ -13,6 +13,10 @@ pub fn are_enabled() -> bool {
 /// Enable interrupts.
 ///
 /// This is a wrapper around the `sti` instruction.
+///
+/// This function executes `sti; nop` to ensure that the interrupt shadow
+/// caused by the `sti` instruction doesn't last beyond this function.
+/// Use [`enable_and_hlt`] to execute `hlt` in `sti`'s interrupt shadow.
 #[inline]
 pub fn enable() {
     // Omit `nomem` to imitate a lock release. Otherwise, the compiler

--- a/src/instructions/smap.rs
+++ b/src/instructions/smap.rs
@@ -21,7 +21,7 @@ use crate::registers::rflags::{self, RFlags};
 
 /// A helper type that provides SMAP related methods.
 ///
-/// This type can only be instatiated if SMAP is supported by the CPU.
+/// This type can only be instantiated if SMAP is supported by the CPU.
 #[derive(Debug, Clone, Copy)]
 pub struct Smap(());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,13 @@
 //! and access to various system registers.
 
 #![cfg_attr(not(test), no_std)]
-#![cfg_attr(feature = "abi_x86_interrupt", feature(abi_x86_interrupt))]
+#![cfg_attr(
+    all(
+        any(target_arch = "x86", target_arch = "x86_64"),
+        feature = "abi_x86_interrupt"
+    ),
+    feature(abi_x86_interrupt)
+)]
 #![cfg_attr(feature = "step_trait", feature(step_trait))]
 #![cfg_attr(feature = "doc_cfg", feature(doc_cfg))]
 #![warn(missing_docs)]

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -174,7 +174,7 @@ bitflags! {
 }
 
 bitflags! {
-    /// Flags for the Advanced Programmable Interrupt Controler Base Register.
+    /// Flags for the Advanced Programmable Interrupt Controller Base Register.
     #[repr(transparent)]
     #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Clone, Copy)]
     pub struct ApicBaseFlags: u64 {

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -469,7 +469,7 @@ mod x86_64 {
             ss_syscall: SegmentSelector,
         ) -> Result<(), InvalidStarSegmentSelectors> {
             // Convert to i32 to prevent underflows.
-            let cs_sysret_cmp = i32::from(cs_sysret.0);
+            let cs_sysret_cmp = i32::from(cs_sysret.0) - 16;
             let ss_sysret_cmp = i32::from(ss_sysret.0) - 8;
             let cs_syscall_cmp = i32::from(cs_syscall.0);
             let ss_syscall_cmp = i32::from(ss_syscall.0) - 8;

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -428,9 +428,12 @@ mod x86_64 {
         /// not valid for long mode.
         ///
         /// # Parameters
-        /// - sysret: The CS selector is set to this field + 16. SS.Sel is set to
-        ///   this field + 8. Because SYSRET always returns to CPL 3, the
-        ///   RPL bits 1:0 should be initialized to 11b.
+        ///
+        /// - sysret: For SYSRETQ (64-bit), the CS selector is set to this
+        ///   field + 16. For SYSRET (32-bit), the CS selector is set to this
+        ///   field. SS.Sel is set to this field + 8. Because SYSRETQ/SYSRET
+        ///   always returns to CPL 3, the RPL bits 1:0 should be initialized
+        ///   to 11b.
         /// - syscall: This field is copied directly into CS.Sel. SS.Sel is set to
         ///   this field + 8. Because SYSCALL always switches to CPL 0, the RPL bits
         ///   33:32 should be initialized to 00b.
@@ -459,8 +462,8 @@ mod x86_64 {
         /// not in the correct offset of each other or if the
         /// segment selectors do not have correct privileges.
         ///
-        /// Also, if you want to return from syscall, you
-        /// shall use "sysretq" (64) instead of "sysret" (32).
+        /// Note that `cs_sysret` should contain the segment to be used for
+        /// SYSRETQ (64-bit), not SYSRET (32-bit).
         #[inline]
         pub fn write(
             cs_sysret: SegmentSelector,

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -451,11 +451,16 @@ mod x86_64 {
         }
 
         /// Write the Ring 0 and Ring 3 segment bases.
+        ///
         /// The remaining fields are ignored because they are
         /// not valid for long mode.
+        ///
         /// This function will fail if the segment selectors are
         /// not in the correct offset of each other or if the
         /// segment selectors do not have correct privileges.
+        ///
+        /// Also, if you want to return from syscall, you
+        /// shall use "sysretq" (64) instead of "sysret" (32).
         #[inline]
         pub fn write(
             cs_sysret: SegmentSelector,

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -464,7 +464,7 @@ mod x86_64 {
             ss_syscall: SegmentSelector,
         ) -> Result<(), InvalidStarSegmentSelectors> {
             // Convert to i32 to prevent underflows.
-            let cs_sysret_cmp = i32::from(cs_sysret.0) - 16;
+            let cs_sysret_cmp = i32::from(cs_sysret.0);
             let ss_sysret_cmp = i32::from(ss_sysret.0) - 8;
             let cs_syscall_cmp = i32::from(cs_syscall.0);
             let ss_syscall_cmp = i32::from(ss_syscall.0) - 8;

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -145,7 +145,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     ///
     /// This method allows for creation of a GDT with malformed or invalid
     /// entries. However, it is safe because loading a GDT with invalid
-    /// entires doesn't do anything until those entries are used. For example,
+    /// entries doesn't do anything until those entries are used. For example,
     /// [`CS::set_reg`] and [`load_tss`](crate::instructions::tables::load_tss)
     /// are both unsafe for this reason.
     ///

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -892,7 +892,7 @@ macro_rules! impl_handler_func_type {
             #[inline]
             fn to_virt_addr(self) -> VirtAddr {
                 // Casting a function pointer to u64 is fine, if the pointer
-                // width doesn't exeed 64 bits.
+                // width doesn't exceed 64 bits.
                 #[cfg_attr(
                     any(target_pointer_width = "32", target_pointer_width = "64"),
                     allow(clippy::fn_to_numeric_cast)
@@ -1198,7 +1198,7 @@ bitflags! {
         /// access.
         const SHADOW_STACK = 1 << 6;
 
-        /// If this flag is set, it indicates that the page fault occured during HLAT paging
+        /// If this flag is set, it indicates that the page fault occurred during HLAT paging
         /// (Intel-only).
         const HLAT = 1 << 7;
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -10,11 +10,9 @@ use core::ops::{Add, AddAssign, Sub, SubAssign};
 
 /// A passed `u64` was not a valid physical address.
 ///
-/// This means address which PFN refer to is:
-///  - Overflowed the `u64`;
-///  - The address's 52..64 is not empty.
+/// This means that bits 40 to 64 were not all null.
 ///
-/// Contains the invalid PFN number if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+/// Contains the invalid PFN.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(transparent)]
 pub struct InvalidPfn(pub u64);
@@ -68,11 +66,15 @@ impl<S: PageSize> PhysFrame<S> {
 
     /// Returns the frame by a physical frame number.
     ///
-    /// This function will automatically time the size of the frame to get its
-    /// physical address
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size4KiB}};
     ///
-    /// ## Panics
-    /// Will panic if the after-converted address's 52..64 bits is not empty.
+    /// assert_eq!(PhysFrame::<Size4KiB>::from_pfn(0x123), PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000)));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the resulting address is not valid.
     #[inline]
     pub fn from_pfn(pfn: u64) -> Self {
         match Self::try_from_pfn(pfn) {
@@ -81,10 +83,17 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
-    /// Try to convert a physical frame number to a frame.
+    /// Returns the frame by a physical frame number.
     ///
-    /// ## Error
-    /// Will return error if the after-converted address's 52..64 bits is not empty.
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size4KiB}};
+    ///
+    /// assert_eq!(PhysFrame::<Size4KiB>::try_from_pfn(0x123), Ok(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000))));
+    /// ```
+    ///
+    /// # Error
+    ///
+    /// This function will return an error if the resulting address is not valid.
     #[inline]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
         let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
@@ -95,10 +104,11 @@ impl<S: PageSize> PhysFrame<S> {
         })
     }
 
-    /// Returns the frame by a physical frame number without checking.
+    /// Returns the frame by a physical frame number.
     ///
     /// # Safety
-    /// The PFN must be valid (The after-converted address's 52..64 bits must be empty).
+    ///
+    /// The resulting address must be valid.
     #[inline]
     #[rustversion::attr(since(1.61), const)]
     pub unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
@@ -133,6 +143,20 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the PFN of the current frame.
+    ///
+    /// The PFN is defined to be the address divided by the page size.
+    ///
+    /// ```
+    /// use x86_64::{PhysAddr, structures::paging::{PhysFrame, Size1GiB, Size2MiB, Size4KiB}};
+    ///
+    /// assert_eq!(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0x123000)).pfn(), 0x123);
+    ///
+    /// // Note that this means that the PFN for the same address will be
+    /// // different for different page sizes.
+    /// assert_eq!(PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0xC0000);
+    /// assert_eq!(PhysFrame::<Size2MiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0x600);
+    /// assert_eq!(PhysFrame::<Size1GiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0x3);
+    /// ```
     #[inline]
     #[rustversion::attr(since(1.61), const)]
     pub fn pfn(self) -> u64 {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -48,6 +48,9 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
+    /// 
+    /// This function will automatically time the size of the frame to get its 
+    /// physical address
     ///
     /// ## Panics
     /// Will panic if the after-converted address's 52..64 bits is not empty.

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -222,6 +222,29 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
             None
         }
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` to `self.end` (it might overflow). Handle
+        // this by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1)?;
+            return self.next_back();
+        }
+
+        self.end -= n;
+        self.next_back()
+    }
 }
 
 impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
@@ -321,6 +344,29 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` to `self.end` (it might overflow). Handle
+        // this by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1)?;
+            return self.next_back();
+        }
+
+        self.end -= n;
+        self.next_back()
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -1,6 +1,7 @@
 //! Abstractions for default-sized and huge physical memory frames.
 
 use super::page::AddressNotAligned;
+use crate::addr::PhysAddrNotValid;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
 use core::convert::TryFrom;
@@ -47,19 +48,39 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
+    ///
+    /// ## Panics
+    /// Will panic if the after-converted address's 52..64 bits is not empty.
     #[inline]
     pub fn from_pfn(pfn: u64) -> Self {
-        // Let's see the size of this frame...
-        // XXX: We have to hard-code it, as it only supports number, not expr.
-        let addr = match S::SIZE {
-            4096 => PhysAddr::new(pfn >> 12),           // Size4KiB
-            2097152 => PhysAddr::new(pfn >> 21),        // Size2MiB
-            1073741824 => PhysAddr::new(pfn >> 30),     // Size1GiB
-            _ => panic!("Invalid frame size: {}", S::SIZE),   // Wth???
-        };
+        match Self::try_from_pfn(pfn) {
+            Ok(frame) => frame,
+            Err(_) => panic!("The PFN \"{}\"is not valid", pfn),
+        }
+    }
 
+    /// Try to convert a physical frame number to a frame.
+    ///
+    /// ## Error
+    /// Will return error if the after-converted address's 52..64 bits is not empty.
+    #[inline]
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
+        let addr = PhysAddr::try_new(pfn * S::SIZE)?;
+        Ok(PhysFrame {
+            start_address: addr,
+            size: PhantomData,
+        })
+    }
+
+    /// Returns the frame by a physical frame number without checking.
+    ///
+    /// # Safety
+    /// The PFN must be valid (The after-converted address's 52..64 bits must be empty).
+    #[inline]
+    #[rustversion::attr(since(1.61), const)]
+    pub unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
         PhysFrame {
-            start_address: addr,    // Already aligned upthere
+            start_address: unsafe { PhysAddr::new_unsafe(pfn * S::SIZE) },
             size: PhantomData,
         }
     }
@@ -86,6 +107,13 @@ impl<S: PageSize> PhysFrame<S> {
     #[rustversion::attr(since(1.61), const)]
     pub fn size(self) -> u64 {
         S::SIZE
+    }
+
+    /// Returns the PFN of the current frame.
+    #[inline]
+    #[rustversion::attr(since(1.61), const)]
+    pub fn pfn(self) -> u64 {
+        self.start_address.as_u64() / S::SIZE
     }
 
     /// Returns a range of frames, exclusive `end`.

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -58,10 +58,14 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will panic if the resulting address is not valid.
     #[inline]
+    #[rustversion::attr(
+        since(1.61),
+        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
+    )]
     pub fn from_pfn(pfn: u64) -> Self {
         match Self::try_from_pfn(pfn) {
             Ok(frame) => frame,
-            Err(_) => panic!("The PFN \"{}\"is not valid", pfn),
+            Err(_) => panic!("PFNs must not have any bits in the range 40 to 64 set"),
         }
     }
 
@@ -77,9 +81,21 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will return an error if the resulting address is not valid.
     #[inline]
+    #[rustversion::attr(
+        since(1.61),
+        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
+    )]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, PfnNotValid> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PfnNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw).map_err(|_| PfnNotValid(pfn))?;
+        let addr_raw = if let Some(addr_raw) = pfn.checked_mul(S::SIZE) {
+            addr_raw
+        } else {
+            return Err(PfnNotValid(pfn));
+        };
+        let addr = if let Ok(addr) = PhysAddr::try_new(addr_raw) {
+            addr
+        } else {
+            return Err(PfnNotValid(pfn));
+        };
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -297,7 +297,16 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
             let frame = self.start;
-            self.start += 1;
+
+            // If the end of the inclusive range is the maximum page possible for size S,
+            // incrementing start until it is greater than the end will cause an integer overflow.
+            // So instead, in that case we decrement end rather than incrementing start.
+            let max_frame_addr = PhysAddr::new_truncate(u64::MAX) - (S::SIZE - 1);
+            if self.start.start_address() < max_frame_addr {
+                self.start += 1;
+            } else {
+                self.end -= 1;
+            }
             Some(frame)
         } else {
             None
@@ -339,8 +348,17 @@ impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         if self.start <= self.end {
-            self.end -= 1;
-            Some(self.end)
+            let frame = self.end;
+
+            // If the start of the inclusive range is 0, decrementing end until
+            // it is smaller than the start will cause an integer underflow.
+            // So instead, in that case we increment start rather than decrementing end.
+            if self.end.start_address().as_u64() != 0 {
+                self.end -= 1;
+            } else {
+                self.start += 1;
+            }
+            Some(frame)
         } else {
             None
         }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -48,8 +48,8 @@ impl<S: PageSize> PhysFrame<S> {
     }
 
     /// Returns the frame by a physical frame number.
-    /// 
-    /// This function will automatically time the size of the frame to get its 
+    ///
+    /// This function will automatically time the size of the frame to get its
     /// physical address
     ///
     /// ## Panics
@@ -68,7 +68,8 @@ impl<S: PageSize> PhysFrame<S> {
     /// Will return error if the after-converted address's 52..64 bits is not empty.
     #[inline]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
-        let addr = PhysAddr::try_new(pfn * S::SIZE)?;
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PhysAddrNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw)?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -3,6 +3,7 @@
 use super::page::AddressNotAligned;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
+use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
@@ -179,6 +180,13 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
+    }
 }
 
 impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
@@ -248,6 +256,13 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
     }
 }
 

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -181,6 +181,29 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
         }
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start` (it might overflow). Handle this
+        // by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        self.start += n;
+        self.next()
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         usize::try_from(len)
@@ -256,6 +279,29 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start` (it might overflow). Handle this
+        // by doing two steps, `self.len()-1` and `1`. This should return
+        // `None`.
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        self.start += n;
+        self.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -397,6 +397,13 @@ impl<S: PageSize> fmt::Debug for PhysFrameRangeInclusive<S> {
     }
 }
 
+#[cfg(kani)]
+impl<S: PageSize> kani::Arbitrary for PhysFrame<S> {
+    fn any() -> Self {
+        Self::containing_address(kani::any())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -411,5 +418,198 @@ mod tests {
 
         let range_inclusive = PhysFrameRangeInclusive { start, end };
         assert_eq!(range_inclusive.len(), 51);
+    }
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn phys_frame_range_next() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+
+        // Test that calling `next` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| start);
+        assert_eq!(range.next(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x2000).then(|| start + 1);
+        assert_eq!(range.next(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_inclusive_next() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+
+        // Test that calling `next` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some().then(|| start);
+        assert_eq!(range.next(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| start + 1);
+        assert_eq!(range.next(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_next_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+
+        // Test that calling `next_back` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| end - 1);
+        assert_eq!(range.next_back(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x2000).then(|| end - 2);
+        assert_eq!(range.next_back(), expected_result);
+    }
+
+    #[kani::proof]
+    fn phys_frame_range_inclusive_next_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+
+        // Test that calling `next_back` twice works.
+        let difference = end
+            .start_address()
+            .as_u64()
+            .checked_sub(start.start_address().as_u64());
+        let expected_result = difference.is_some().then(|| end);
+        assert_eq!(range.next_back(), expected_result);
+        let expected_result = difference.is_some_and(|d| d >= 0x1000).then(|| end - 1);
+        assert_eq!(range.next_back(), expected_result);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that nth(0) behaves like next().
+        assert_eq!(range.next(), range2.nth(0));
+        assert_eq!(range.next(), range2.nth(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth(m);
+        assert_eq!(range.nth(n), range2.nth(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that nth(0) behaves like next().
+        assert_eq!(range.next(), range2.nth(0));
+        assert_eq!(range.next(), range2.nth(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth(m);
+        assert_eq!(range.nth(n), range2.nth(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_back_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that nth_back(0) behaves like next_back().
+        assert_eq!(range.next_back(), range2.nth_back(0));
+        assert_eq!(range.next_back(), range2.nth_back(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_nth_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range(start, end);
+        let mut range2 = PhysFrame::range(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth_back(m);
+        assert_eq!(range.nth_back(n), range2.nth_back(sum));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_back_0() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that nth_back(0) behaves like next_back().
+        assert_eq!(range.next_back(), range2.nth_back(0));
+        assert_eq!(range.next_back(), range2.nth_back(0));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn phys_frame_range_inclusive_nth_back() {
+        let start = kani::any::<PhysFrame>();
+        let end = kani::any::<PhysFrame>();
+        let m = kani::any::<usize>();
+        let n = kani::any::<usize>();
+        let sum = m.saturating_add(n).saturating_add(1);
+        let mut range = PhysFrame::range_inclusive(start, end);
+        let mut range2 = PhysFrame::range_inclusive(start, end);
+
+        // Test that doing steps of size m and n is equivalent to a single step
+        // of size m+n+1.
+        range.nth_back(m);
+        assert_eq!(range.nth_back(n), range2.nth_back(sum));
     }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -181,6 +181,18 @@ impl<S: PageSize> Iterator for PhysFrameRange<S> {
     }
 }
 
+impl<S: PageSize> DoubleEndedIterator for PhysFrameRange<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(self.end)
+        } else {
+            None
+        }
+    }
+}
+
 impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("PhysFrameRange")
@@ -233,6 +245,18 @@ impl<S: PageSize> Iterator for PhysFrameRangeInclusive<S> {
             let frame = self.start;
             self.start += 1;
             Some(frame)
+        } else {
+            None
+        }
+    }
+}
+
+impl<S: PageSize> DoubleEndedIterator for PhysFrameRangeInclusive<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start <= self.end {
+            self.end -= 1;
+            Some(self.end)
         } else {
             None
         }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -46,6 +46,24 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    /// Returns the frame by a physical frame number.
+    #[inline]
+    pub fn from_pfn(pfn: u64) -> Self {
+        // Let's see the size of this frame...
+        // XXX: We have to hard-code it, as it only supports number, not expr.
+        let addr = match S::SIZE {
+            4096 => PhysAddr::new(pfn >> 12),           // Size4KiB
+            2097152 => PhysAddr::new(pfn >> 21),        // Size2MiB
+            1073741824 => PhysAddr::new(pfn >> 30),     // Size1GiB
+            _ => panic!("Invalid frame size: {}", S::SIZE),   // Wth???
+        };
+
+        PhysFrame {
+            start_address: addr,    // Already aligned upthere
+            size: PhantomData,
+        }
+    }
+
     /// Returns the frame that contains the given physical address.
     #[inline]
     #[rustversion::attr(since(1.61), const)]

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -8,24 +8,6 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
 
-/// A passed `u64` was not a valid physical address.
-///
-/// This means that bits 40 to 64 were not all null.
-///
-/// Contains the invalid PFN.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[repr(transparent)]
-pub struct InvalidPfn(pub u64);
-
-// Implementation of display
-impl fmt::Display for InvalidPfn {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_tuple("PhysAddrNotValid")
-            .field(&format_args!("{:#x}", self.0))
-            .finish()
-    }
-}
-
 /// A physical memory frame.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(C)]
@@ -95,9 +77,9 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will return an error if the resulting address is not valid.
     #[inline]
-    pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw).map_err(|_| InvalidPfn(pfn))?;
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, PfnNotValid> {
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PfnNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw).map_err(|_| PfnNotValid(pfn))?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,
@@ -345,6 +327,24 @@ impl<S: PageSize> fmt::Debug for PhysFrameRange<S> {
         f.debug_struct("PhysFrameRange")
             .field("start", &self.start)
             .field("end", &self.end)
+            .finish()
+    }
+}
+
+/// A passed `u64` was not a valid physical address.
+///
+/// This means that bits 40 to 64 were not all null.
+///
+/// Contains the invalid PFN.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct PfnNotValid(pub u64);
+
+// Implementation of display
+impl fmt::Display for PfnNotValid {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("PhysAddrNotValid")
+            .field(&format_args!("{:#x}", self.0))
             .finish()
     }
 }

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -1,13 +1,32 @@
 //! Abstractions for default-sized and huge physical memory frames.
 
 use super::page::AddressNotAligned;
-use crate::addr::PhysAddrNotValid;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;
 use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+/// A passed `u64` was not a valid physical address.
+///
+/// This means address which PFN refer to is:
+///  - Overflowed the `u64`;
+///  - The address's 52..64 is not empty.
+///
+/// Contains the invalid PFN number if use [`PhysFrame::try_from_pfn`] / [`PhysFrame::from_pfn`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct InvalidPfn(pub u64);
+
+// Implementation of display
+impl fmt::Display for InvalidPfn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("PhysAddrNotValid")
+            .field(&format_args!("{:#x}", self.0))
+            .finish()
+    }
+}
 
 /// A physical memory frame.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -67,9 +86,9 @@ impl<S: PageSize> PhysFrame<S> {
     /// ## Error
     /// Will return error if the after-converted address's 52..64 bits is not empty.
     #[inline]
-    pub fn try_from_pfn(pfn: u64) -> Result<Self, PhysAddrNotValid> {
-        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(PhysAddrNotValid(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
-        let addr = PhysAddr::try_new(addr_raw)?;
+    pub fn try_from_pfn(pfn: u64) -> Result<Self, InvalidPfn> {
+        let addr_raw = pfn.checked_mul(S::SIZE).ok_or(InvalidPfn(pfn))?; // XXX: The phys addr that the PFN ref is invalid.
+        let addr = PhysAddr::try_new(addr_raw).map_err(|_| InvalidPfn(pfn))?;
         Ok(PhysFrame {
             start_address: addr,
             size: PhantomData,

--- a/src/structures/paging/mapper/mapped_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table.rs
@@ -49,10 +49,11 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
     pub fn page_table_frame_mapping(&self) -> &P {
         &self.page_table_walker.page_table_frame_mapping
     }
+}
 
-    /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
-    /// https://github.com/rust-lang/rfcs/pull/2585.
-    fn map_to_1gib<A>(
+impl<P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'_, P> {
+    #[inline]
+    unsafe fn map_to_with_table_flags<A>(
         &mut self,
         page: Page<Size1GiB>,
         frame: PhysFrame<Size1GiB>,
@@ -76,94 +77,6 @@ impl<'a, P: PageTableFrameMapping> MappedPageTable<'a, P> {
         p3[page.p3_index()].set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
 
         Ok(MapperFlush::new(page))
-    }
-
-    /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
-    /// https://github.com/rust-lang/rfcs/pull/2585.
-    fn map_to_2mib<A>(
-        &mut self,
-        page: Page<Size2MiB>,
-        frame: PhysFrame<Size2MiB>,
-        flags: PageTableFlags,
-        parent_table_flags: PageTableFlags,
-        allocator: &mut A,
-    ) -> Result<MapperFlush<Size2MiB>, MapToError<Size2MiB>>
-    where
-        A: FrameAllocator<Size4KiB> + ?Sized,
-    {
-        let p4 = &mut self.level_4_table;
-        let p3 = self.page_table_walker.create_next_table(
-            &mut p4[page.p4_index()],
-            parent_table_flags,
-            allocator,
-        )?;
-        let p2 = self.page_table_walker.create_next_table(
-            &mut p3[page.p3_index()],
-            parent_table_flags,
-            allocator,
-        )?;
-
-        if !p2[page.p2_index()].is_unused() {
-            return Err(MapToError::PageAlreadyMapped(frame));
-        }
-        p2[page.p2_index()].set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
-
-        Ok(MapperFlush::new(page))
-    }
-
-    /// Helper function for implementing Mapper. Safe to limit the scope of unsafe, see
-    /// https://github.com/rust-lang/rfcs/pull/2585.
-    fn map_to_4kib<A>(
-        &mut self,
-        page: Page<Size4KiB>,
-        frame: PhysFrame<Size4KiB>,
-        flags: PageTableFlags,
-        parent_table_flags: PageTableFlags,
-        allocator: &mut A,
-    ) -> Result<MapperFlush<Size4KiB>, MapToError<Size4KiB>>
-    where
-        A: FrameAllocator<Size4KiB> + ?Sized,
-    {
-        let p4 = &mut self.level_4_table;
-        let p3 = self.page_table_walker.create_next_table(
-            &mut p4[page.p4_index()],
-            parent_table_flags,
-            allocator,
-        )?;
-        let p2 = self.page_table_walker.create_next_table(
-            &mut p3[page.p3_index()],
-            parent_table_flags,
-            allocator,
-        )?;
-        let p1 = self.page_table_walker.create_next_table(
-            &mut p2[page.p2_index()],
-            parent_table_flags,
-            allocator,
-        )?;
-
-        if !p1[page.p1_index()].is_unused() {
-            return Err(MapToError::PageAlreadyMapped(frame));
-        }
-        p1[page.p1_index()].set_frame(frame, flags);
-
-        Ok(MapperFlush::new(page))
-    }
-}
-
-impl<P: PageTableFrameMapping> Mapper<Size1GiB> for MappedPageTable<'_, P> {
-    #[inline]
-    unsafe fn map_to_with_table_flags<A>(
-        &mut self,
-        page: Page<Size1GiB>,
-        frame: PhysFrame<Size1GiB>,
-        flags: PageTableFlags,
-        parent_table_flags: PageTableFlags,
-        allocator: &mut A,
-    ) -> Result<MapperFlush<Size1GiB>, MapToError<Size1GiB>>
-    where
-        A: FrameAllocator<Size4KiB> + ?Sized,
-    {
-        self.map_to_1gib(page, frame, flags, parent_table_flags, allocator)
     }
 
     fn unmap(
@@ -271,7 +184,24 @@ impl<P: PageTableFrameMapping> Mapper<Size2MiB> for MappedPageTable<'_, P> {
     where
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
-        self.map_to_2mib(page, frame, flags, parent_table_flags, allocator)
+        let p4 = &mut self.level_4_table;
+        let p3 = self.page_table_walker.create_next_table(
+            &mut p4[page.p4_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p2 = self.page_table_walker.create_next_table(
+            &mut p3[page.p3_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+
+        if !p2[page.p2_index()].is_unused() {
+            return Err(MapToError::PageAlreadyMapped(frame));
+        }
+        p2[page.p2_index()].set_addr(frame.start_address(), flags | PageTableFlags::HUGE_PAGE);
+
+        Ok(MapperFlush::new(page))
     }
 
     fn unmap(
@@ -399,7 +329,29 @@ impl<P: PageTableFrameMapping> Mapper<Size4KiB> for MappedPageTable<'_, P> {
     where
         A: FrameAllocator<Size4KiB> + ?Sized,
     {
-        self.map_to_4kib(page, frame, flags, parent_table_flags, allocator)
+        let p4 = &mut self.level_4_table;
+        let p3 = self.page_table_walker.create_next_table(
+            &mut p4[page.p4_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p2 = self.page_table_walker.create_next_table(
+            &mut p3[page.p3_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+        let p1 = self.page_table_walker.create_next_table(
+            &mut p2[page.p2_index()],
+            parent_table_flags,
+            allocator,
+        )?;
+
+        if !p1[page.p1_index()].is_unused() {
+            return Err(MapToError::PageAlreadyMapped(frame));
+        }
+        p1[page.p1_index()].set_frame(frame, flags);
+
+        Ok(MapperFlush::new(page))
     }
 
     fn unmap(

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -19,7 +19,7 @@ mod offset_page_table;
 #[cfg(all(feature = "instructions", target_arch = "x86_64"))]
 mod recursive_page_table;
 
-/// An empty convencience trait that requires the `Mapper` trait for all page sizes.
+/// An empty convenience trait that requires the `Mapper` trait for all page sizes.
 pub trait MapperAllSizes: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB> {}
 
 impl<T> MapperAllSizes for T where T: Mapper<Size4KiB> + Mapper<Size2MiB> + Mapper<Size1GiB> {}
@@ -356,7 +356,7 @@ pub trait Mapper<S: PageSize> {
     ///
     /// ## Safety
     ///
-    /// This is a convencience function that invokes [`Mapper::map_to`] internally, so
+    /// This is a convenience function that invokes [`Mapper::map_to`] internally, so
     /// all safety requirements of it also apply for this function.
     #[inline]
     unsafe fn identity_map<A>(

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -335,7 +335,7 @@ pub struct PageRange<S: PageSize = Size4KiB> {
 }
 
 impl<S: PageSize> PageRange<S> {
-    /// Returns wether this range contains no pages.
+    /// Returns whether this range contains no pages.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.start >= self.end

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -410,7 +410,7 @@ impl<S: PageSize> PageRangeInclusive<S> {
         self.start > self.end
     }
 
-    /// Returns the number of frames in the range.
+    /// Returns the number of pages in the range.
     #[inline]
     pub fn len(&self) -> u64 {
         if !self.is_empty() {
@@ -420,7 +420,7 @@ impl<S: PageSize> PageRangeInclusive<S> {
         }
     }
 
-    /// Returns the size in bytes of all frames within the range.
+    /// Returns the size in bytes of all pages within the range.
     #[inline]
     pub fn size(&self) -> u64 {
         S::SIZE * self.len()

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -424,6 +424,40 @@ impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
             None
         }
     }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` from `self.end`. Handle this by doing two
+        // steps, `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1);
+            return self.next_back();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let first_half_end = Page::<S>::containing_address(VirtAddr::new(0x7fff_ffff_f000));
+        let steps_until_gap = Page::steps_between_u64(&first_half_end, &self.end)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.end -= steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next_back()?;
+            unreachable!("the previous call to `next_back` should have panicked")
+        }
+
+        self.end -= n;
+        self.next_back()
+    }
 }
 
 impl PageRange<Size2MiB> {
@@ -563,6 +597,40 @@ impl<S: PageSize> DoubleEndedIterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just subtract `n` from `self.end`. Handle this by doing two
+        // steps, `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth_back(self.len() as usize - 1);
+            return self.next_back();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let first_half_end = Page::<S>::containing_address(VirtAddr::new(0x7fff_ffff_f000));
+        let steps_until_gap = Page::steps_between_u64(&first_half_end, &self.end)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.end -= steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next_back()?;
+            unreachable!("the previous call to `next_back` should have panicked")
+        }
+
+        self.end -= n;
+        self.next_back()
     }
 }
 
@@ -1051,6 +1119,60 @@ mod proofs {
         page_range_nth_harness(true);
     }
 
+    fn page_range_nth_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_start =
+            offset.and_then(|offset| end.start_address().as_u64().checked_sub(offset));
+        let should_panic = expected_start.is_some_and(|expected_start| {
+            expected_start <= 0xffff_7fff_ffff_f000
+                && end.start_address().as_u64() > 0xffff_7fff_ffff_f000
+        }) || expected_start.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth_back` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.nth_back(n as usize);
+            our_range.nth_back(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        assert_eq!(
+            our_range.nth_back(m as usize),
+            native_range.nth_back(m as usize)
+        );
+        assert_eq!(
+            our_range.nth_back(n as usize),
+            native_range.nth_back(n as usize)
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_nth_back() {
+        page_range_nth_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_nth_back_panic() {
+        page_range_nth_back_harness(true);
+    }
+
     fn page_range_inclusive_nth_harness(should_panic_mode: bool) {
         let start = kani::any::<Page>();
         let end = kani::any::<Page>();
@@ -1096,5 +1218,59 @@ mod proofs {
     #[kani::should_panic]
     fn page_range_inclusive_nth_panic() {
         page_range_inclusive_nth_harness(true);
+    }
+
+    fn page_range_inclusive_nth_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_start =
+            offset.and_then(|offset| end.start_address().as_u64().checked_sub(offset));
+        let should_panic = expected_start.is_some_and(|expected_start| {
+            expected_start <= 0xffff_7fff_ffff_f000
+                && end.start_address().as_u64() > 0xffff_7fff_ffff_f000
+        }) || expected_start.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth_back` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.nth_back(n as usize);
+            our_range.nth_back(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        assert_eq!(
+            our_range.nth_back(m as usize),
+            native_range.nth_back(m as usize)
+        );
+        assert_eq!(
+            our_range.nth_back(n as usize),
+            native_range.nth_back(n as usize)
+        );
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_inclusive_nth_back() {
+        page_range_inclusive_nth_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_inclusive_nth_back_panic() {
+        page_range_inclusive_nth_back_harness(true);
     }
 }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -765,3 +765,160 @@ mod tests {
         }
     }
 }
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    fn page_range_next_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0x7fff_ffff_e000
+            || start.start_address().as_u64() != 0x7fff_ffff_f000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.next();
+            our_range.next();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next(), native_range.next());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next(), native_range.next());
+    }
+
+    #[kani::proof]
+    fn page_range_next() {
+        page_range_next_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_next_panic() {
+        page_range_next_harness(true);
+    }
+
+    fn page_range_next_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0xffff_8000_0000_0000
+            || start.start_address().as_u64() != 0xffff_8000_0000_1000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next_back` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.next_back();
+            our_range.next_back();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+    }
+
+    #[kani::proof]
+    fn page_range_next_back() {
+        page_range_next_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_next_back_panic() {
+        page_range_next_back_harness(true);
+    }
+
+    fn page_range_inclusive_next_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0x7fff_ffff_e000
+            || start.start_address().as_u64() != 0x7fff_ffff_f000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.next();
+            our_range.next();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next(), native_range.next());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next(), native_range.next());
+    }
+
+    #[kani::proof]
+    fn page_range_inclusive_next() {
+        page_range_inclusive_next_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_inclusive_next_panic() {
+        page_range_inclusive_next_harness(true);
+    }
+
+    fn page_range_inclusive_next_back_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page<Size4KiB>>();
+        let end = kani::any::<Page<Size4KiB>>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let should_panic = start.start_address().as_u64() != 0xffff_8000_0000_0000
+            || start.start_address().as_u64() != 0xffff_8000_0000_1000;
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `next_back` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.next_back();
+            our_range.next_back();
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        // The first assert checks that we're returning the correct value.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+        // The second assert checks that we're updating the range state correctly.
+        assert_eq!(our_range.next_back(), native_range.next_back());
+    }
+
+    #[kani::proof]
+    fn page_range_inclusive_next_back() {
+        page_range_inclusive_next_back_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::should_panic]
+    fn page_range_inclusive_next_back_panic() {
+        page_range_inclusive_next_back_harness(true);
+    }
+}

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -460,6 +460,13 @@ impl<S: PageSize> fmt::Debug for PageRangeInclusive<S> {
     }
 }
 
+#[cfg(kani)]
+impl<S: PageSize> kani::Arbitrary for Page<S> {
+    fn any() -> Self {
+        Self::containing_address(kani::any())
+    }
+}
+
 /// The given address was not sufficiently aligned.
 #[derive(Debug)]
 pub struct AddressNotAligned;

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -160,12 +160,15 @@ impl<S: PageSize> Page<S> {
     }
 
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
+    pub(crate) fn steps_between_u64(start: &Self, end: &Self) -> Option<u64> {
+        VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
+            .map(|steps| steps / S::SIZE)
+    }
+
+    // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
-        if let Some(steps) =
-            VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
-        {
-            let steps = steps / S::SIZE;
+        if let Some(steps) = Self::steps_between_u64(start, end) {
             let steps = usize::try_from(steps).ok();
             (steps.unwrap_or(usize::MAX), steps)
         } else {
@@ -369,6 +372,40 @@ impl<S: PageSize> Iterator for PageRange<S> {
         }
     }
 
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start`. Handle this by doing two steps,
+        // `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let second_half_start = Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
+        let steps_until_gap = Page::steps_between_u64(&self.start, &second_half_start)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.start += steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next()?;
+            unreachable!("the previous call to `next` should have panicked")
+        }
+
+        self.start += n;
+        self.next()
+    }
+
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         usize::try_from(len)
@@ -464,6 +501,40 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Convert to `u64`. If the value doesn't fit just use `u64::MAX`.
+        // `self.len()` is guaranteed to be smaller than the real value and
+        // `u64::MAX` anyway, so it doesn't make a difference.
+        let n = u64::try_from(n).unwrap_or(u64::MAX);
+
+        // Handling `n >= self.len()` is a bit more complicated because we
+        // can't just add `n` to `self.start`. Handle this by doing two steps,
+        // `self.len()-1` and `1`. This should return `None` (or panic).
+        if n >= self.len() {
+            self.nth(self.len() as usize - 1)?;
+            return self.next();
+        }
+
+        // Figure out how many steps there are until the address range gap.
+        let second_half_start = Page::<S>::containing_address(VirtAddr::new(0xffff_8000_0000_0000));
+        let steps_until_gap = Page::steps_between_u64(&self.start, &second_half_start)
+            .filter(|steps| *steps <= n && *steps > 0);
+        if let Some(steps_until_gap) = steps_until_gap {
+            // Jump just *before* the address range gap.
+            self.start += steps_until_gap - 1;
+            // Advancing one more time should panic.
+            self.next()?;
+            unreachable!("the previous call to `next` should have panicked")
+        }
+
+        self.start += n;
+        self.next()
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
@@ -931,5 +1002,99 @@ mod proofs {
     #[kani::should_panic]
     fn page_range_inclusive_next_back_panic() {
         page_range_inclusive_next_back_harness(true);
+    }
+
+    fn page_range_nth_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_end =
+            offset.and_then(|offset| start.start_address().as_u64().checked_add(offset));
+        let should_panic = expected_end.is_some_and(|expected_end| {
+            start.start_address().as_u64() <= 0x7fff_ffff_f000 && expected_end > 0x7fff_ffff_f000
+        }) || expected_end.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth` should panic.
+            let mut our_range = Page::range(start, end);
+            our_range.nth(n as usize);
+            our_range.nth(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range(start, end);
+        let mut native_range = start..end;
+        assert_eq!(our_range.nth(m as usize), native_range.nth(m as usize));
+        assert_eq!(our_range.nth(n as usize), native_range.nth(n as usize));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_nth() {
+        page_range_nth_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_nth_panic() {
+        page_range_nth_harness(true);
+    }
+
+    fn page_range_inclusive_nth_harness(should_panic_mode: bool) {
+        let start = kani::any::<Page>();
+        let end = kani::any::<Page>();
+        let m = kani::any::<u64>();
+        let n = kani::any::<u64>();
+
+        // If the code is expected to panic, only run it in `#[should_panic]`
+        // mode.
+        let offset = m
+            .checked_add(n)
+            .and_then(|sum| sum.checked_add(2))
+            .and_then(|sum| sum.checked_mul(Size4KiB::SIZE));
+        let expected_end =
+            offset.and_then(|offset| start.start_address().as_u64().checked_add(offset));
+        let should_panic = expected_end.is_some_and(|expected_end| {
+            start.start_address().as_u64() <= 0x7fff_ffff_f000 && expected_end > 0x7fff_ffff_f000
+        }) || expected_end.is_none();
+        kani::assume(should_panic == should_panic_mode);
+
+        if should_panic {
+            // Calling `nth` should panic.
+            let mut our_range = Page::range_inclusive(start, end);
+            our_range.nth(n as usize);
+            our_range.nth(m as usize);
+            return;
+        }
+
+        // Otherwise the results should match what `Range` returns.
+        let mut our_range = Page::range_inclusive(start, end);
+        let mut native_range = start..=end;
+        assert_eq!(our_range.nth(m as usize), native_range.nth(m as usize));
+        assert_eq!(our_range.nth(n as usize), native_range.nth(n as usize));
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    fn page_range_inclusive_nth() {
+        page_range_inclusive_nth_harness(false);
+    }
+
+    #[kani::proof]
+    #[kani::unwind(1)]
+    #[kani::should_panic]
+    fn page_range_inclusive_nth_panic() {
+        page_range_inclusive_nth_harness(true);
     }
 }

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -373,6 +373,18 @@ impl<S: PageSize> Iterator for PageRange<S> {
     }
 }
 
+impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start < self.end {
+            self.end -= 1;
+            Some(self.end)
+        } else {
+            None
+        }
+    }
+}
+
 impl PageRange<Size2MiB> {
     /// Converts the range of 2MiB pages to a range of 4KiB pages.
     #[inline]
@@ -443,6 +455,27 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
                 self.start += 1;
             } else {
                 self.end -= 1;
+            }
+            Some(page)
+        } else {
+            None
+        }
+    }
+}
+
+impl<S: PageSize> DoubleEndedIterator for PageRangeInclusive<S> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.start <= self.end {
+            let page = self.end;
+
+            // If the start of the inclusive range is 0, decrementing end until
+            // it is smaller than the start will cause an integer underflow.
+            // So instead, in that case we increment start rather than decrementing end.
+            if self.end.start_address().as_u64() != 0 {
+                self.end -= 1;
+            } else {
+                self.start += 1;
             }
             Some(page)
         } else {
@@ -551,6 +584,18 @@ mod tests {
 
     // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
     #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_next_back_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range(start, end).next_back();
+    }
+
+    #[test]
     #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
     fn test_page_range_inclusive_next_not_jumping_gap_panics() {
         let start = 0x7fff_ffff_f000;
@@ -563,6 +608,19 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_inclusive_next_back_not_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next_back();
+    }
+
+    // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
+    #[test]
     #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
     fn test_page_range_inclusive_next_jumping_gap_panics() {
         let start = 0x7fff_ffff_f000;
@@ -573,6 +631,19 @@ mod tests {
         let end = Page::from_start_address(end).unwrap();
         Page::range_inclusive(start, end).next();
         Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
+    #[should_panic = "attempt to subtract resulted in non-canonical virtual address: VirtAddrNotValid(0xffff7ffffffff000)"]
+    fn test_page_range_inclusive_next_back_jumping_gap_panics() {
+        let start = 0xffff_8000_0000_0000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next_back();
+        Page::range_inclusive(start, end).next_back();
     }
 
     #[test]

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -322,6 +322,28 @@ impl<S: PageSize> Step for Page<S> {
             size: PhantomData,
         })
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 /// A range of pages with exclusive upper bound.
@@ -913,6 +935,24 @@ mod tests {
             let end = Page::from_start_address(VirtAddr::new(end)).unwrap();
             assert_eq!(Step::steps_between(&start, &end), (lower, upper));
         }
+    }
+
+    #[test]
+    #[cfg(feature = "step_trait")]
+    fn page_step_overflowing() {
+        let page = |addr| Page::<Size4KiB>::from_start_address(VirtAddr::new(addr)).unwrap();
+
+        assert_eq!(
+            Step::forward_overflowing(page(0x7fff_ffff_f000), 1),
+            (page(0xffff_8000_0000_0000), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(page(0xffff_8000_0000_0000), 1),
+            (page(0x7fff_ffff_f000), false)
+        );
+
+        assert!(Step::forward_overflowing(page(0xffff_ffff_ffff_f000), 1).1);
+        assert!(Step::backward_overflowing(page(0), 1).1);
     }
 }
 

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -538,6 +538,44 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_next_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0xffff_8000_0000_0000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range(start, end).next();
+    }
+
+    // TODO: This probably shouldn't panic, but we can't fix this without a breaking change.
+    #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_inclusive_next_not_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0x7fff_ffff_f000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
+    #[should_panic = "attempt to add resulted in non-canonical virtual address: VirtAddrNotValid(0x800000000000)"]
+    fn test_page_range_inclusive_next_jumping_gap_panics() {
+        let start = 0x7fff_ffff_f000;
+        let end = 0x7fff_ffff_f000;
+        let start = VirtAddr::new(start);
+        let end = VirtAddr::new(end);
+        let start = Page::<Size4KiB>::from_start_address(start).unwrap();
+        let end = Page::from_start_address(end).unwrap();
+        Page::range_inclusive(start, end).next();
+        Page::range_inclusive(start, end).next();
+    }
+
+    #[test]
     pub fn test_page_range_len() {
         let start_addr = VirtAddr::new(0xdead_beaf);
         let start = Page::<Size4KiB>::containing_address(start_addr);

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -4,6 +4,7 @@ use crate::sealed::Sealed;
 use crate::structures::paging::page_table::PageTableLevel;
 use crate::structures::paging::PageTableIndex;
 use crate::VirtAddr;
+use core::convert::TryFrom;
 use core::fmt;
 #[cfg(feature = "step_trait")]
 use core::iter::Step;
@@ -161,8 +162,6 @@ impl<S: PageSize> Page<S> {
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn steps_between_impl(start: &Self, end: &Self) -> (usize, Option<usize>) {
-        use core::convert::TryFrom;
-
         if let Some(steps) =
             VirtAddr::steps_between_u64(&start.start_address(), &end.start_address())
         {
@@ -177,8 +176,6 @@ impl<S: PageSize> Page<S> {
     // FIXME: Move this into the `Step` impl, once `Step` is stabilized.
     #[cfg(any(feature = "instructions", feature = "step_trait"))]
     pub(crate) fn forward_checked_impl(start: Self, count: usize) -> Option<Self> {
-        use core::convert::TryFrom;
-
         let count = u64::try_from(count).ok()?.checked_mul(S::SIZE)?;
         let start_address = VirtAddr::forward_checked_u64(start.start_address, count)?;
         Some(Self {
@@ -371,6 +368,13 @@ impl<S: PageSize> Iterator for PageRange<S> {
             None
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
+    }
 }
 
 impl<S: PageSize> DoubleEndedIterator for PageRange<S> {
@@ -460,6 +464,13 @@ impl<S: PageSize> Iterator for PageRangeInclusive<S> {
         } else {
             None
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        usize::try_from(len)
+            .map(|len| (len, Some(len)))
+            .unwrap_or((usize::MAX, None))
     }
 }
 

--- a/src/structures/paging/page_table.rs
+++ b/src/structures/paging/page_table.rs
@@ -388,6 +388,30 @@ impl Step for PageTableIndex {
         let idx = usize::from(start).checked_sub(count)?;
         Some(Self::new(idx as u16))
     }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn forward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::forward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
+
+    // Kani's bundled toolchain predates these methods being added to `Step`.
+    // Exclude them there so the crate still compiles under `cargo kani`.
+    // This can be removed once Kani upgrades its bundled toolchain to nightly-2026-07-10 or later.
+    #[cfg(not(kani))]
+    #[inline]
+    fn backward_overflowing(start: Self, count: usize) -> (Self, bool) {
+        match Self::backward_checked(start, count) {
+            Some(next) => (next, false),
+            None => (start, true),
+        }
+    }
 }
 
 /// A 12-bit offset into a 4KiB Page.
@@ -483,5 +507,27 @@ impl PageTableLevel {
     /// Returns the alignment for the address space described by an entry in a table of this level.
     pub const fn entry_address_space_alignment(self) -> u64 {
         1u64 << (((self as u8 - 1) * 9) + 12)
+    }
+}
+
+#[cfg(all(test, feature = "step_trait"))]
+mod tests {
+    use super::*;
+    use core::iter::Step;
+
+    #[test]
+    fn page_table_index_step_overflowing() {
+        assert_eq!(
+            Step::forward_overflowing(PageTableIndex::new(0), 511),
+            (PageTableIndex::new(511), false)
+        );
+        assert_eq!(
+            Step::backward_overflowing(PageTableIndex::new(511), 511),
+            (PageTableIndex::new(0), false)
+        );
+
+        // Overflow the 0..512 range: only the flag is specified.
+        assert!(Step::forward_overflowing(PageTableIndex::new(511), 1).1);
+        assert!(Step::backward_overflowing(PageTableIndex::new(0), 1).1);
     }
 }

--- a/testing/tests/double_fault_stack_overflow.rs
+++ b/testing/tests/double_fault_stack_overflow.rs
@@ -21,7 +21,7 @@ pub extern "C" fn _start() -> ! {
     stack_overflow();
 
     serial_println!("[failed]");
-    serial_println!("    No exception occured");
+    serial_println!("    No exception occurred");
     exit_qemu(QemuExitCode::Failed);
 
     loop {}

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -1,4 +1,3 @@
-#![feature(abi_x86_interrupt)]
 #![no_std]
 #![no_main]
 

--- a/testing/tests/port_read_write.rs
+++ b/testing/tests/port_read_write.rs
@@ -16,7 +16,7 @@ const CRT_DATA_PORT: u16 = 0x3D5;
 // bits that won't crash the system when written to
 const OFFSET_REGISTER: u8 = 0x0A;
 
-// A randomly chosen value to test againts
+// A randomly chosen value to test against
 const TEST_VALUE: u8 = 0b10101010;
 
 /// This function is the entry point, since the linker looks for a function

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+AAS = "AAS"
+DAA = "DAA"
+IST = "IST"
+SME = "SME"
+UE = "UE"


### PR DESCRIPTION
This merges master into next and handles the resulting conflicts. 

The main conflict resulted from #574 specifically fc03c8fbbdc6c184b88bdf59c32c85d6da64322f (refactor mapped_page_table.rs into directory). Luckily there was only 1 change I could find to `mapped_page_table.rs` which made it fairly easy to combine with the changes to the new directory in next. 

The other change was to `Changelog.md` where I accepted both current and incoming changes.