### PR TITLE
increase the Minimum Supported Rust Version to 1.98

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         rust:
           - nightly
-          - 1.59
+          - 1.98
     runs-on: ubuntu-latest
     env:
       # rustup prioritizes environment variables over rust-toolchain.toml files.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "x86_64"
 readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
 version = "0.15.5"
-edition = "2018"
+edition = "2024"
 rust-version = "1.98"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
 version = "0.15.5"
 edition = "2018"
-rust-version = "1.59" # Needed to support inline asm and default const generics
+rust-version = "1.98"
 
 [dependencies]
 bit_field = "0.10.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["amd64", "x86", "x86_64", "no_std"]
 categories = ["no-std"]
 license = "MIT/Apache-2.0"
 name = "x86_64"
-readme = "README.md"
 repository = "https://github.com/rust-osdev/x86_64"
 version = "0.15.5"
 edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ rust-version = "1.98"
 bit_field = "0.10.1"
 bitflags = "2.3.2"
 volatile = "0.4.4"
-rustversion = "1.0.5"
 dep_const_fn = { package = "const_fn", version = "0.4.11" }
 
 [features]

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@
 - [make page types `repr(transparent)` and range types `repr(Rust)`](https://github.com/rust-osdev/x86_64/pull/584)
 - [add `MappedPageTable::display`](https://github.com/rust-osdev/x86_64/pull/574)
   - The mappings of a `MappedPageTable` can now be displayed.
+- [Increase the Minimum Supported Rust Version to 1.98](https://github.com/rust-osdev/x86_64/pull/604)
 
 # 0.15.5 – 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Support for x86_64 specific instructions (e.g. TLB flush), registers (e.g. contr
 
 ## Minimum Supported Rust Version (MSRV)
 
-If no nightly features are enabled, Rust 1.59.0 is required.
+If no nightly features are enabled, Rust 1.98.0 is required.
 This can be done by either:
   - `--no-default-features --features instructions`
   - `--no-default-features`

--- a/src/instructions/segmentation.rs
+++ b/src/instructions/segmentation.rs
@@ -1,10 +1,10 @@
 //! Provides functions to read and write segment registers.
 
-pub use crate::registers::segmentation::{Segment, Segment64, CS, DS, ES, FS, GS, SS};
+pub use crate::registers::segmentation::{CS, DS, ES, FS, GS, SS, Segment, Segment64};
 use crate::{
+    VirtAddr,
     registers::model_specific::{FsBase, GsBase, Msr},
     structures::gdt::SegmentSelector,
-    VirtAddr,
 };
 use core::arch::asm;
 

--- a/src/instructions/tables.rs
+++ b/src/instructions/tables.rs
@@ -1,7 +1,7 @@
 //! Functions to load GDT, IDT, and TSS structures.
 
-use crate::structures::gdt::SegmentSelector;
 use crate::VirtAddr;
+use crate::structures::gdt::SegmentSelector;
 use core::arch::asm;
 
 pub use crate::structures::DescriptorTablePointer;

--- a/src/instructions/tlb.rs
+++ b/src/instructions/tlb.rs
@@ -3,12 +3,12 @@
 use bit_field::BitField;
 
 use crate::{
-    instructions::segmentation::{Segment, CS},
-    structures::paging::{
-        page::{NotGiantPageSize, PageRange},
-        Page, PageSize, Size2MiB, Size4KiB,
-    },
     PrivilegeLevel, VirtAddr,
+    instructions::segmentation::{CS, Segment},
+    structures::paging::{
+        Page, PageSize, Size2MiB, Size4KiB,
+        page::{NotGiantPageSize, PageRange},
+    },
 };
 use core::{arch::asm, cmp, convert::TryFrom, fmt};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 #![deny(missing_debug_implementations)]
 #![deny(unsafe_op_in_unsafe_fn)]
 
-pub use crate::addr::{align_down, align_up, PhysAddr, VirtAddr};
+pub use crate::addr::{PhysAddr, VirtAddr, align_down, align_up};
 
 pub mod addr;
 pub mod instructions;

--- a/src/registers/control.rs
+++ b/src/registers/control.rs
@@ -230,8 +230,8 @@ impl PriorityClass {
 mod x86_64 {
     use super::*;
     use crate::{
-        addr::VirtAddrNotValid, instructions::tlb::Pcid, structures::paging::PhysFrame, PhysAddr,
-        VirtAddr,
+        PhysAddr, VirtAddr, addr::VirtAddrNotValid, instructions::tlb::Pcid,
+        structures::paging::PhysFrame,
     };
     use core::arch::asm;
 

--- a/src/registers/model_specific.rs
+++ b/src/registers/model_specific.rs
@@ -250,14 +250,14 @@ impl PatMemoryType {
 #[cfg(all(feature = "instructions", target_arch = "x86_64"))]
 mod x86_64 {
     use super::*;
+    use crate::PhysAddr;
+    use crate::PrivilegeLevel;
     use crate::addr::VirtAddr;
     use crate::registers::rflags::RFlags;
     use crate::structures::gdt::SegmentSelector;
     use crate::structures::paging::Page;
     use crate::structures::paging::PhysFrame;
     use crate::structures::paging::Size4KiB;
-    use crate::PhysAddr;
-    use crate::PrivilegeLevel;
     use bit_field::BitField;
     use core::convert::TryInto;
     use core::fmt;
@@ -265,7 +265,7 @@ mod x86_64 {
     #[cfg(doc)]
     use crate::registers::{
         control::Cr4Flags,
-        segmentation::{Segment, Segment64, CS, SS},
+        segmentation::{CS, SS, Segment, Segment64},
     };
     use core::arch::asm;
 

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -193,8 +193,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     ///
     /// Panics if the GDT doesn't have enough free entries.
     #[inline]
-    #[rustversion::attr(since(1.83), const)]
-    pub fn append(&mut self, entry: Descriptor) -> SegmentSelector {
+    pub const fn append(&mut self, entry: Descriptor) -> SegmentSelector {
         let index = match entry {
             Descriptor::UserSegment(value) => {
                 if self.len > self.table.len().saturating_sub(1) {
@@ -246,8 +245,7 @@ impl<const MAX: usize> GlobalDescriptorTable<MAX> {
     }
 
     #[inline]
-    #[rustversion::attr(since(1.83), const)]
-    fn push(&mut self, value: u64) -> usize {
+    const fn push(&mut self, value: u64) -> usize {
         let index = self.len;
         self.table[index] = Entry::new(value);
         self.len += 1;

--- a/src/structures/gdt.rs
+++ b/src/structures/gdt.rs
@@ -1,14 +1,14 @@
 //! Types for the Global Descriptor Table and segment selectors.
 
+use crate::PrivilegeLevel;
 pub use crate::registers::segmentation::SegmentSelector;
 use crate::structures::tss::{InvalidIoMap, TaskStateSegment};
-use crate::PrivilegeLevel;
 use bit_field::BitField;
 use bitflags::bitflags;
 use core::{cmp, fmt, mem};
 // imports for intra-doc links
 #[cfg(doc)]
-use crate::registers::segmentation::{Segment, CS, SS};
+use crate::registers::segmentation::{CS, SS, Segment};
 
 #[cfg(all(feature = "instructions", target_arch = "x86_64"))]
 use core::sync::atomic::{AtomicU64 as EntryValue, Ordering};

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -449,8 +449,7 @@ pub struct InterruptDescriptorTable {
 impl InterruptDescriptorTable {
     /// Creates a new IDT filled with non-present entries.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn new() -> InterruptDescriptorTable {
+    pub const fn new() -> InterruptDescriptorTable {
         InterruptDescriptorTable {
             divide_error: Entry::missing(),
             debug: Entry::missing(),

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -825,7 +825,7 @@ impl<F> Entry<F> {
     #[cfg(all(feature = "instructions", target_arch = "x86_64"))]
     #[inline]
     pub unsafe fn set_handler_addr(&mut self, addr: VirtAddr) -> &mut EntryOptions {
-        use crate::instructions::segmentation::{Segment, CS};
+        use crate::instructions::segmentation::{CS, Segment};
 
         let addr = addr.as_u64();
         self.pointer_low = addr as u16;

--- a/src/structures/idt.rs
+++ b/src/structures/idt.rs
@@ -293,8 +293,7 @@ pub struct InterruptDescriptorTable {
     /// The virtual (linear) address that caused the `#PF` is stored in the `CR2` register.
     /// The saved instruction pointer points to the instruction that caused the `#PF`.
     ///
-    /// The page-fault error code is described by the
-    /// [`PageFaultErrorCode`](struct.PageFaultErrorCode.html) struct.
+    /// The page-fault error code is described by the [`PageFaultErrorCode`] struct.
     ///
     /// The vector number of the `#PF` exception is 14.
     pub page_fault: Entry<PageFaultHandlerFunc>,

--- a/src/structures/mem_encrypt.rs
+++ b/src/structures/mem_encrypt.rs
@@ -7,8 +7,8 @@
 
 use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
-use crate::structures::paging::page_table::PHYSICAL_ADDRESS_MASK;
 use crate::structures::paging::PageTableFlags;
+use crate::structures::paging::page_table::PHYSICAL_ADDRESS_MASK;
 
 /// Position of the encryption (C/S) bit in the physical address
 pub(crate) static ENC_BIT_MASK: AtomicU64 = AtomicU64::new(0);

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -3,8 +3,8 @@
 use dep_const_fn::const_fn;
 
 use super::page::AddressNotAligned;
-use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
+use crate::structures::paging::page::{PageSize, Size4KiB};
 use core::convert::TryFrom;
 use core::fmt;
 use core::marker::PhantomData;

--- a/src/structures/paging/frame.rs
+++ b/src/structures/paging/frame.rs
@@ -1,5 +1,7 @@
 //! Abstractions for default-sized and huge physical memory frames.
 
+use dep_const_fn::const_fn;
+
 use super::page::AddressNotAligned;
 use crate::structures::paging::page::{PageSize, Size4KiB};
 use crate::PhysAddr;
@@ -26,8 +28,7 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// Returns an error if the address is not correctly aligned (i.e. is not a valid frame start).
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn from_start_address(address: PhysAddr) -> Result<Self, AddressNotAligned> {
+    pub const fn from_start_address(address: PhysAddr) -> Result<Self, AddressNotAligned> {
         if !address.is_aligned_u64(S::SIZE) {
             return Err(AddressNotAligned);
         }
@@ -42,8 +43,7 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// The address must be correctly aligned.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub unsafe fn from_start_address_unchecked(start_address: PhysAddr) -> Self {
+    pub const unsafe fn from_start_address_unchecked(start_address: PhysAddr) -> Self {
         PhysFrame {
             start_address,
             size: PhantomData,
@@ -62,10 +62,7 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will panic if the resulting address is not valid.
     #[inline]
-    #[rustversion::attr(
-        since(1.61),
-        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
-    )]
+    #[const_fn(cfg(not(feature = "memory_encryption")))]
     pub fn from_pfn(pfn: u64) -> Self {
         match Self::try_from_pfn(pfn) {
             Ok(frame) => frame,
@@ -85,10 +82,7 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// This function will return an error if the resulting address is not valid.
     #[inline]
-    #[rustversion::attr(
-        since(1.61),
-        dep_const_fn::const_fn(cfg(not(feature = "memory_encryption")))
-    )]
+    #[const_fn(cfg(not(feature = "memory_encryption")))]
     pub fn try_from_pfn(pfn: u64) -> Result<Self, PfnNotValid> {
         let addr_raw = if let Some(addr_raw) = pfn.checked_mul(S::SIZE) {
             addr_raw
@@ -112,8 +106,7 @@ impl<S: PageSize> PhysFrame<S> {
     ///
     /// The resulting address must be valid.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
+    pub const unsafe fn from_pfn_unchecked(pfn: u64) -> Self {
         PhysFrame {
             start_address: unsafe { PhysAddr::new_unsafe(pfn * S::SIZE) },
             size: PhantomData,
@@ -122,8 +115,7 @@ impl<S: PageSize> PhysFrame<S> {
 
     /// Returns the frame that contains the given physical address.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn containing_address(address: PhysAddr) -> Self {
+    pub const fn containing_address(address: PhysAddr) -> Self {
         PhysFrame {
             start_address: address.align_down_u64(S::SIZE),
             size: PhantomData,
@@ -132,15 +124,13 @@ impl<S: PageSize> PhysFrame<S> {
 
     /// Returns the start address of the frame.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn start_address(self) -> PhysAddr {
+    pub const fn start_address(self) -> PhysAddr {
         self.start_address
     }
 
     /// Returns the size the frame (4KB, 2MB or 1GB).
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn size(self) -> u64 {
+    pub const fn size(self) -> u64 {
         S::SIZE
     }
 
@@ -160,22 +150,22 @@ impl<S: PageSize> PhysFrame<S> {
     /// assert_eq!(PhysFrame::<Size1GiB>::containing_address(PhysAddr::new(0xC000_0000)).pfn(), 0x3);
     /// ```
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn pfn(self) -> u64 {
+    pub const fn pfn(self) -> u64 {
         self.start_address.as_u64() / S::SIZE
     }
 
     /// Returns a range of frames, exclusive `end`.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn range(start: PhysFrame<S>, end: PhysFrame<S>) -> PhysFrameRange<S> {
+    pub const fn range(start: PhysFrame<S>, end: PhysFrame<S>) -> PhysFrameRange<S> {
         PhysFrameRange { start, end }
     }
 
     /// Returns a range of frames, inclusive `end`.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn range_inclusive(start: PhysFrame<S>, end: PhysFrame<S>) -> PhysFrameRangeInclusive<S> {
+    pub const fn range_inclusive(
+        start: PhysFrame<S>,
+        end: PhysFrame<S>,
+    ) -> PhysFrameRangeInclusive<S> {
         PhysFrameRangeInclusive { start, end }
     }
 }

--- a/src/structures/paging/mapper/mapped_page_table/iter.rs
+++ b/src/structures/paging/mapper/mapped_page_table/iter.rs
@@ -141,7 +141,7 @@ impl<P: PageTableFrameMapping> MappedPageTableIter<'_, P> {
 
     /// Increments the current P4 index.
     ///
-    /// This sets the lower indixes to zero.
+    /// This sets the lower indices to zero.
     /// When reaching the end, this returns [`None`] .
     fn increment_p4_index(&mut self) -> Option<()> {
         self.p4_index += 1;
@@ -159,7 +159,7 @@ impl<P: PageTableFrameMapping> MappedPageTableIter<'_, P> {
 
     /// Increments the current P3 index.
     ///
-    /// This sets the lower indixes to zero.
+    /// This sets the lower indices to zero.
     /// When reaching the end, this increments the next-higher index and returns [`None`].
     fn increment_p3_index(&mut self) -> Option<()> {
         self.p3_index += 1;
@@ -176,7 +176,7 @@ impl<P: PageTableFrameMapping> MappedPageTableIter<'_, P> {
 
     /// Increments the current P2 index.
     ///
-    /// This sets the lower indixes to zero.
+    /// This sets the lower indices to zero.
     /// When reaching the end, this increments the next-higher index and returns [`None`].
     fn increment_p2_index(&mut self) -> Option<()> {
         self.p2_index += 1;

--- a/src/structures/paging/mapper/mapped_page_table/offset_page_table.rs
+++ b/src/structures/paging/mapper/mapped_page_table/offset_page_table.rs
@@ -1,6 +1,6 @@
 #![cfg(target_pointer_width = "64")]
 
-use crate::structures::paging::{mapper::*, PageTable};
+use crate::structures::paging::{PageTable, mapper::*};
 
 /// A Mapper implementation that requires that the complete physical memory is mapped at some
 /// offset in the virtual address space.

--- a/src/structures/paging/mapper/mod.rs
+++ b/src/structures/paging/mapper/mod.rs
@@ -9,10 +9,10 @@ pub use self::mapped_page_table::{OffsetPageTable, PhysOffset};
 pub use self::recursive_page_table::{InvalidPageTable, RecursivePageTable};
 
 use crate::structures::paging::{
+    Page, PageSize, PhysFrame, Size1GiB, Size2MiB, Size4KiB,
     frame_alloc::{FrameAllocator, FrameDeallocator},
     page::PageRangeInclusive,
     page_table::{PageTableEntry, PageTableFlags},
-    Page, PageSize, PhysFrame, Size1GiB, Size2MiB, Size4KiB,
 };
 use crate::{PhysAddr, VirtAddr};
 

--- a/src/structures/paging/mapper/recursive_page_table.rs
+++ b/src/structures/paging/mapper/recursive_page_table.rs
@@ -6,9 +6,9 @@ use super::*;
 use crate::registers::control::Cr3;
 use crate::structures::paging::page_table::PageTableLevel;
 use crate::structures::paging::{
+    PageTableIndex,
     page::{AddressNotAligned, NotGiantPageSize},
     page_table::{FrameError, PageTable, PageTableEntry},
-    PageTableIndex,
 };
 
 /// A recursive page table is a last level page table with an entry mapped to the table itself.

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -82,8 +82,7 @@ impl<S: PageSize> Page<S> {
     ///
     /// Returns an error if the address is not correctly aligned (i.e. is not a valid page start).
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn from_start_address(address: VirtAddr) -> Result<Self, AddressNotAligned> {
+    pub const fn from_start_address(address: VirtAddr) -> Result<Self, AddressNotAligned> {
         if !address.is_aligned_u64(S::SIZE) {
             return Err(AddressNotAligned);
         }
@@ -96,8 +95,7 @@ impl<S: PageSize> Page<S> {
     ///
     /// The address must be correctly aligned.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub unsafe fn from_start_address_unchecked(start_address: VirtAddr) -> Self {
+    pub const unsafe fn from_start_address_unchecked(start_address: VirtAddr) -> Self {
         Page {
             start_address,
             size: PhantomData,
@@ -106,8 +104,7 @@ impl<S: PageSize> Page<S> {
 
     /// Returns the page that contains the given virtual address.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn containing_address(address: VirtAddr) -> Self {
+    pub const fn containing_address(address: VirtAddr) -> Self {
         Page {
             start_address: address.align_down_u64(S::SIZE),
             size: PhantomData,
@@ -116,50 +113,43 @@ impl<S: PageSize> Page<S> {
 
     /// Returns the start address of the page.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn start_address(self) -> VirtAddr {
+    pub const fn start_address(self) -> VirtAddr {
         self.start_address
     }
 
     /// Returns the size the page (4KB, 2MB or 1GB).
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn size(self) -> u64 {
+    pub const fn size(self) -> u64 {
         S::SIZE
     }
 
     /// Returns the level 4 page table index of this page.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn p4_index(self) -> PageTableIndex {
+    pub const fn p4_index(self) -> PageTableIndex {
         self.start_address().p4_index()
     }
 
     /// Returns the level 3 page table index of this page.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn p3_index(self) -> PageTableIndex {
+    pub const fn p3_index(self) -> PageTableIndex {
         self.start_address().p3_index()
     }
 
     /// Returns the table index of this page at the specified level.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn page_table_index(self, level: PageTableLevel) -> PageTableIndex {
+    pub const fn page_table_index(self, level: PageTableLevel) -> PageTableIndex {
         self.start_address().page_table_index(level)
     }
 
     /// Returns a range of pages, exclusive `end`.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn range(start: Self, end: Self) -> PageRange<S> {
+    pub const fn range(start: Self, end: Self) -> PageRange<S> {
         PageRange { start, end }
     }
 
     /// Returns a range of pages, inclusive `end`.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn range_inclusive(start: Self, end: Self) -> PageRangeInclusive<S> {
+    pub const fn range_inclusive(start: Self, end: Self) -> PageRangeInclusive<S> {
         PageRangeInclusive { start, end }
     }
 
@@ -195,8 +185,7 @@ impl<S: PageSize> Page<S> {
 impl<S: NotGiantPageSize> Page<S> {
     /// Returns the level 2 page table index of this page.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn p2_index(self) -> PageTableIndex {
+    pub const fn p2_index(self) -> PageTableIndex {
         self.start_address().p2_index()
     }
 }
@@ -204,8 +193,7 @@ impl<S: NotGiantPageSize> Page<S> {
 impl Page<Size1GiB> {
     /// Returns the 1GiB memory page with the specified page table indices.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn from_page_table_indices_1gib(
+    pub const fn from_page_table_indices_1gib(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
     ) -> Self {
@@ -219,8 +207,7 @@ impl Page<Size1GiB> {
 impl Page<Size2MiB> {
     /// Returns the 2MiB memory page with the specified page table indices.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn from_page_table_indices_2mib(
+    pub const fn from_page_table_indices_2mib(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
         p2_index: PageTableIndex,
@@ -236,8 +223,7 @@ impl Page<Size2MiB> {
 impl Page<Size4KiB> {
     /// Returns the 4KiB memory page with the specified page table indices.
     #[inline]
-    #[rustversion::attr(since(1.61), const)]
-    pub fn from_page_table_indices(
+    pub const fn from_page_table_indices(
         p4_index: PageTableIndex,
         p3_index: PageTableIndex,
         p2_index: PageTableIndex,

--- a/src/structures/paging/page.rs
+++ b/src/structures/paging/page.rs
@@ -1,9 +1,9 @@
 //! Abstractions for default-sized and huge virtual memory pages.
 
-use crate::sealed::Sealed;
-use crate::structures::paging::page_table::PageTableLevel;
-use crate::structures::paging::PageTableIndex;
 use crate::VirtAddr;
+use crate::sealed::Sealed;
+use crate::structures::paging::PageTableIndex;
+use crate::structures::paging::page_table::PageTableLevel;
 use core::convert::TryFrom;
 use core::fmt;
 #[cfg(feature = "step_trait")]


### PR DESCRIPTION
This PR increases the MSRV to 1.98 and then cleans up the code a bit to take advantage of the new MSRV.